### PR TITLE
Sprint 20: guard callback timeline event sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MVP Telegram auction bot scaffold on `aiogram` + `PostgreSQL` + `Redis` with Docker Compose.
 
-This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18**:
+This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19**:
 
 - Dockerized runtime (`bot`, `db`, `redis`)
 - `Alembic` migrations and initial PostgreSQL schema
@@ -32,6 +32,7 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - Role-management workflow tests (web + bot) and permission-downgrade edge-case coverage
 - DB-backed RBAC integration tests and dedicated CI Postgres job
 - End-to-end callback integration tests for complaint/risk moderation flows
+- Queue message edit and timeline consistency regression coverage for moderation callbacks
 
 ## Sprint 0 Checklist
 
@@ -167,6 +168,13 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - [x] Shared integration test fixtures moved to `tests/integration/conftest.py`
 - [x] E2E tests for `modrep` callback flow (`freeze` + scope-denied path)
 - [x] E2E tests for `modrisk` callback flow (`ban` -> DB updates + refresh + notify)
+
+## Sprint 19 Checklist (Queue + Timeline Consistency)
+
+- [x] Scenario checks for complaint/fraud queue message edit behavior after callback actions
+- [x] Timeline consistency checks for complaint/fraud lifecycle after moderation callbacks
+- [x] Regression guard for repeated callback clicks (idempotent behavior)
+- [x] `BAN_USER` callback logs linked to auction timeline (`auction_id` in moderation log)
 
 ## Quick Start
 
@@ -323,7 +331,7 @@ FRAUD_HISTORICAL_START_RATIO_LOW=0.5
 FRAUD_HISTORICAL_START_RATIO_HIGH=2.0
 ```
 
-## Next (Sprint 19)
+## Next (Sprint 20)
 
-- Add scenario tests for complaint/risk queue message edits and moderation timeline consistency
+- Add stricter sequence assertions for timeline events in callback scenarios (create -> moderation action -> resolve)
 - Run manual QA using `docs/manual-qa/sprint-19.md` and attach evidence in PR

--- a/docs/manual-qa/sprint-19.md
+++ b/docs/manual-qa/sprint-19.md
@@ -48,7 +48,7 @@ Expected:
 - Complaint becomes non-open (`RESOLVED`).
 - Auction status becomes `FROZEN` and auction post is refreshed.
 - Original queue message is edited (same message id), action buttons are replaced by panel navigation.
-- Timeline contains complaint creation + complaint resolution + moderation action entries in chronological order.
+- Timeline contains complaint creation + moderation action + complaint resolution entries in chronological order.
 
 ### MQ-02 ban_top denied for operator without user ban scope
 
@@ -81,7 +81,7 @@ Expected:
 - Auction post is refreshed.
 - Target user receives Telegram notification about ban.
 - Queue message is edited to resolved state and action buttons are replaced.
-- Timeline contains signal creation + signal resolution + moderation action in correct order.
+- Timeline contains signal creation + moderation action + signal resolution in correct order.
 
 ### MQ-04 Idempotency on repeated callback click
 


### PR DESCRIPTION
## Summary
- add sequence assertions to moderation callback integration tests so timeline order is explicitly validated for complaint freeze, fraud ban, and repeated-click idempotency scenarios
- keep queue/timeline manual QA expectations consistent with real callback ordering (`create -> moderation action -> resolve`)
- update README sprint status to mark Sprint 19 complete and move Next target to Sprint 20

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests`
- `docker compose run --rm -v /home/n501/VibeCoding/LiteAuction:/workspace -w /workspace bot sh -lc "pip install -q '.[dev]' && RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test python -m pytest -q tests/integration"`