### PR TITLE
Sprint 22: stabilize per-entity timeline ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MVP Telegram auction bot scaffold on `aiogram` + `PostgreSQL` + `Redis` with Docker Compose.
 
-This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20**:
+This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 + Sprint 21 + Sprint 22**:
 
 - Dockerized runtime (`bot`, `db`, `redis`)
 - `Alembic` migrations and initial PostgreSQL schema
@@ -34,6 +34,7 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - End-to-end callback integration tests for complaint/risk moderation flows
 - Queue message edit and timeline consistency regression coverage for moderation callbacks
 - Timeline event sequence guards for callback flows (`create -> moderation action -> resolve`)
+- Stable per-entity timeline ordering on equal timestamps (`created_at` + primary-key tie-breakers)
 
 ## Sprint 0 Checklist
 
@@ -183,6 +184,17 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - [x] Sequence checks for complaint freeze and fraud ban callback paths
 - [x] Sequence checks for repeated callback idempotency path
 - [x] Manual QA expected order synced with callback event ordering
+
+## Sprint 21 Checklist (Same-Timestamp Ordering)
+
+- [x] Deterministic tie-break rules for timeline events sharing the same timestamp
+- [x] Integration regressions for complaint/fraud ordering with same `happened_at`
+
+## Sprint 22 Checklist (Per-Entity Stable Order)
+
+- [x] Added primary-key tie-breakers to timeline source queries (`created_at`, then `id`)
+- [x] Removed fragile string-based final tie-breakers from timeline sorting
+- [x] Added regressions for multiple complaints/signals with identical timestamps to enforce numeric id ordering
 
 ## Quick Start
 
@@ -339,8 +351,8 @@ FRAUD_HISTORICAL_START_RATIO_LOW=0.5
 FRAUD_HISTORICAL_START_RATIO_HIGH=2.0
 ```
 
-## Next (Sprint 21)
+## Next (Sprint 23)
 
-- Add deterministic timeline tie-breaking when events share the same timestamp
-- Add regression tests for same-timestamp ordering in complaint and fraud flows
+- Add timeline pagination/limit support in admin view for high-volume auctions
+- Add regression tests for page boundaries while preserving chronological/stable ordering
 - Run manual QA using `docs/manual-qa/sprint-19.md` and attach evidence in PR

--- a/app/services/timeline_service.py
+++ b/app/services/timeline_service.py
@@ -52,21 +52,31 @@ async def build_auction_timeline(
         return None, []
 
     bids = (
-        await session.execute(select(Bid).where(Bid.auction_id == auction_id).order_by(Bid.created_at.asc()))
+        await session.execute(
+            select(Bid)
+            .where(Bid.auction_id == auction_id)
+            .order_by(Bid.created_at.asc(), Bid.id.asc())
+        )
     ).scalars().all()
     complaints = (
         await session.execute(
-            select(Complaint).where(Complaint.auction_id == auction_id).order_by(Complaint.created_at.asc())
+            select(Complaint)
+            .where(Complaint.auction_id == auction_id)
+            .order_by(Complaint.created_at.asc(), Complaint.id.asc())
         )
     ).scalars().all()
     signals = (
         await session.execute(
-            select(FraudSignal).where(FraudSignal.auction_id == auction_id).order_by(FraudSignal.created_at.asc())
+            select(FraudSignal)
+            .where(FraudSignal.auction_id == auction_id)
+            .order_by(FraudSignal.created_at.asc(), FraudSignal.id.asc())
         )
     ).scalars().all()
     mod_logs = (
         await session.execute(
-            select(ModerationLog).where(ModerationLog.auction_id == auction_id).order_by(ModerationLog.created_at.asc())
+            select(ModerationLog)
+            .where(ModerationLog.auction_id == auction_id)
+            .order_by(ModerationLog.created_at.asc(), ModerationLog.id.asc())
         )
     ).scalars().all()
 
@@ -206,9 +216,6 @@ async def build_auction_timeline(
         key=lambda item: (
             item.happened_at,
             _timeline_order_rank(item),
-            item.source,
-            item.title,
-            item.details,
         )
     )
     return auction, timeline

--- a/tests/integration/test_timeline_stable_ordering.py
+++ b/tests/integration/test_timeline_stable_ordering.py
@@ -10,6 +10,13 @@ from app.db.models import Auction, Complaint, FraudSignal, ModerationLog, User
 from app.services.timeline_service import build_auction_timeline
 
 
+def _extract_numeric_id(details: str, key: str) -> int:
+    prefix = f"{key}="
+    head = details.split(",", 1)[0]
+    assert head.startswith(prefix)
+    return int(head[len(prefix) :])
+
+
 @pytest.mark.asyncio
 async def test_timeline_orders_moderation_before_complaint_resolution_on_same_timestamp(
     integration_engine,
@@ -127,3 +134,103 @@ async def test_timeline_orders_moderation_before_fraud_resolution_on_same_timest
 
     titles = [item.title for item in timeline]
     assert titles.index("Мод-действие: BAN_USER") < titles.index("Фрод-сигнал обработан")
+
+
+@pytest.mark.asyncio
+async def test_timeline_orders_complaints_by_id_when_timestamps_match(integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    stamp = datetime(2026, 1, 3, 12, 0, tzinfo=UTC)
+
+    async with session_factory() as session:
+        async with session.begin():
+            seller = User(tg_user_id=80301, username="seller")
+            reporter = User(tg_user_id=80302, username="reporter")
+            session.add_all([seller, reporter])
+            await session.flush()
+
+            auction = Auction(
+                seller_user_id=seller.id,
+                description="lot",
+                photo_file_id="photo",
+                start_price=10,
+                buyout_price=None,
+                min_step=1,
+                duration_hours=24,
+                status=AuctionStatus.ACTIVE,
+            )
+            session.add(auction)
+            await session.flush()
+
+            for idx in range(11):
+                session.add(
+                    Complaint(
+                        auction_id=auction.id,
+                        reporter_user_id=reporter.id,
+                        reason=f"r{idx}",
+                        status="OPEN",
+                        created_at=stamp,
+                    )
+                )
+            auction_id = auction.id
+
+    async with session_factory() as session:
+        _, timeline = await build_auction_timeline(session, auction_id)
+
+    complaint_ids = [
+        _extract_numeric_id(item.details, "complaint")
+        for item in timeline
+        if item.title == "Жалоба создана"
+    ]
+    assert len(complaint_ids) == 11
+    assert complaint_ids == sorted(complaint_ids)
+
+
+@pytest.mark.asyncio
+async def test_timeline_orders_signals_by_id_when_timestamps_match(integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    stamp = datetime(2026, 1, 4, 12, 0, tzinfo=UTC)
+
+    async with session_factory() as session:
+        async with session.begin():
+            seller = User(tg_user_id=80401, username="seller")
+            suspect = User(tg_user_id=80402, username="suspect")
+            session.add_all([seller, suspect])
+            await session.flush()
+
+            auction = Auction(
+                seller_user_id=seller.id,
+                description="lot",
+                photo_file_id="photo",
+                start_price=10,
+                buyout_price=None,
+                min_step=1,
+                duration_hours=24,
+                status=AuctionStatus.ACTIVE,
+            )
+            session.add(auction)
+            await session.flush()
+
+            for idx in range(11):
+                session.add(
+                    FraudSignal(
+                        auction_id=auction.id,
+                        user_id=suspect.id,
+                        bid_id=None,
+                        score=70 + idx,
+                        reasons={"rules": [{"code": "TEST", "detail": str(idx), "score": 70 + idx}]},
+                        status="OPEN",
+                        created_at=stamp,
+                    )
+                )
+            auction_id = auction.id
+
+    async with session_factory() as session:
+        _, timeline = await build_auction_timeline(session, auction_id)
+
+    signal_ids = [
+        _extract_numeric_id(item.details, "signal")
+        for item in timeline
+        if item.title == "Фрод-сигнал создан"
+    ]
+    assert len(signal_ids) == 11
+    assert signal_ids == sorted(signal_ids)


### PR DESCRIPTION
## Summary
- enforce deterministic ordering for same-timestamp timeline entities by adding primary-key tie-breakers in source queries (`created_at`, then `id`)
- remove fragile string-based final timeline sort tie-breakers and rely on explicit rank + stable insertion order
- add integration regressions that create many complaints/signals at identical timestamps and assert numeric ID ordering in timeline output

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests`
- `docker compose run --rm -v /home/n501/VibeCoding/LiteAuction:/workspace -w /workspace bot sh -lc "pip install -q '.[dev]' && RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test python -m pytest -q tests/integration"`