### PR TITLE
Sprint 23: add pagination for auction timeline view

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MVP Telegram auction bot scaffold on `aiogram` + `PostgreSQL` + `Redis` with Docker Compose.
 
-This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 + Sprint 21 + Sprint 22**:
+This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 + Sprint 21 + Sprint 22 + Sprint 23**:
 
 - Dockerized runtime (`bot`, `db`, `redis`)
 - `Alembic` migrations and initial PostgreSQL schema
@@ -35,6 +35,7 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - Queue message edit and timeline consistency regression coverage for moderation callbacks
 - Timeline event sequence guards for callback flows (`create -> moderation action -> resolve`)
 - Stable per-entity timeline ordering on equal timestamps (`created_at` + primary-key tie-breakers)
+- Web timeline pagination with configurable `page`/`limit` and navigation links
 
 ## Sprint 0 Checklist
 
@@ -196,6 +197,13 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - [x] Removed fragile string-based final tie-breakers from timeline sorting
 - [x] Added regressions for multiple complaints/signals with identical timestamps to enforce numeric id ordering
 
+## Sprint 23 Checklist (Timeline Pagination)
+
+- [x] Added `page` and `limit` query parameters to auction timeline admin endpoint
+- [x] Added timeline page navigation links and visible page coverage counters
+- [x] Added validation for pagination bounds (`page >= 0`, `1 <= limit <= 500`)
+- [x] Added regression tests for page boundaries and event ordering preservation
+
 ## Quick Start
 
 1. Copy env template:
@@ -351,8 +359,8 @@ FRAUD_HISTORICAL_START_RATIO_LOW=0.5
 FRAUD_HISTORICAL_START_RATIO_HIGH=2.0
 ```
 
-## Next (Sprint 23)
+## Next (Sprint 24)
 
-- Add timeline pagination/limit support in admin view for high-volume auctions
-- Add regression tests for page boundaries while preserving chronological/stable ordering
+- Move timeline pagination closer to DB layer to avoid loading full event history for very large auctions
+- Add filters by source (`auction`, `bid`, `complaint`, `fraud`, `moderation`) in timeline view
 - Run manual QA using `docs/manual-qa/sprint-19.md` and attach evidence in PR

--- a/tests/test_web_timeline_pagination.py
+++ b/tests/test_web_timeline_pagination.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app.db.enums import AuctionStatus
+from app.services.timeline_service import AuctionTimelineItem
+from app.web.auth import AdminAuthContext
+from app.web.main import auction_timeline
+
+
+class _DummySessionFactoryCtx:
+    async def __aenter__(self):
+        return object()
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class _DummySessionFactory:
+    def __call__(self) -> _DummySessionFactoryCtx:
+        return _DummySessionFactoryCtx()
+
+
+def _make_request(path: str) -> Request:
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("utf-8"),
+        "query_string": b"",
+        "headers": [],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(scope, receive)
+
+
+def _stub_auth() -> AdminAuthContext:
+    return AdminAuthContext(
+        authorized=True,
+        via="token",
+        role="owner",
+        can_manage=True,
+        scopes=frozenset(),
+        tg_user_id=None,
+    )
+
+
+def _timeline_items() -> list[AuctionTimelineItem]:
+    base = datetime(2026, 1, 1, 10, 0, tzinfo=UTC)
+    return [
+        AuctionTimelineItem(
+            happened_at=base + timedelta(minutes=idx),
+            source="test",
+            title=f"Event-{idx + 1}",
+            details=f"details-{idx + 1}",
+        )
+        for idx in range(5)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_timeline_first_page_uses_limit_and_next_link(monkeypatch) -> None:
+    request = _make_request("/timeline/auction/test")
+    auction_id = uuid.uuid4()
+
+    monkeypatch.setattr("app.web.main._auth_context_or_unauthorized", lambda _req: (None, _stub_auth()))
+    monkeypatch.setattr("app.web.main.SessionFactory", _DummySessionFactory())
+
+    async def fake_build(_session, _auction_id):
+        auction = SimpleNamespace(id=auction_id, status=AuctionStatus.ACTIVE, seller_user_id=123)
+        return auction, _timeline_items()
+
+    monkeypatch.setattr("app.web.main.build_auction_timeline", fake_build)
+
+    response = await auction_timeline(request, str(auction_id), page=0, limit=2)
+
+    assert response.status_code == 200
+    body = response.body.decode("utf-8")
+    assert "Event-1" in body
+    assert "Event-2" in body
+    assert "Event-3" not in body
+    assert "page=1&amp;limit=2" in body
+    assert "← Назад" not in body
+    assert "Показано:</b> 1-2 из 5" in body
+
+
+@pytest.mark.asyncio
+async def test_timeline_middle_page_keeps_order_and_both_links(monkeypatch) -> None:
+    request = _make_request("/timeline/auction/test")
+    auction_id = uuid.uuid4()
+
+    monkeypatch.setattr("app.web.main._auth_context_or_unauthorized", lambda _req: (None, _stub_auth()))
+    monkeypatch.setattr("app.web.main.SessionFactory", _DummySessionFactory())
+
+    async def fake_build(_session, _auction_id):
+        auction = SimpleNamespace(id=auction_id, status=AuctionStatus.ACTIVE, seller_user_id=123)
+        return auction, _timeline_items()
+
+    monkeypatch.setattr("app.web.main.build_auction_timeline", fake_build)
+
+    response = await auction_timeline(request, str(auction_id), page=1, limit=2)
+
+    assert response.status_code == 200
+    body = response.body.decode("utf-8")
+    assert "Event-2" not in body
+    assert "Event-3" in body
+    assert "Event-4" in body
+    assert "Event-5" not in body
+    assert body.index("Event-3") < body.index("Event-4")
+    assert "page=0&amp;limit=2" in body
+    assert "page=2&amp;limit=2" in body
+    assert "Показано:</b> 3-4 из 5" in body
+
+
+@pytest.mark.asyncio
+async def test_timeline_last_page_has_no_next_link(monkeypatch) -> None:
+    request = _make_request("/timeline/auction/test")
+    auction_id = uuid.uuid4()
+
+    monkeypatch.setattr("app.web.main._auth_context_or_unauthorized", lambda _req: (None, _stub_auth()))
+    monkeypatch.setattr("app.web.main.SessionFactory", _DummySessionFactory())
+
+    async def fake_build(_session, _auction_id):
+        auction = SimpleNamespace(id=auction_id, status=AuctionStatus.ACTIVE, seller_user_id=123)
+        return auction, _timeline_items()
+
+    monkeypatch.setattr("app.web.main.build_auction_timeline", fake_build)
+
+    response = await auction_timeline(request, str(auction_id), page=2, limit=2)
+
+    assert response.status_code == 200
+    body = response.body.decode("utf-8")
+    assert "Event-5" in body
+    assert "Event-4" not in body
+    assert "page=1&amp;limit=2" in body
+    assert "Вперед →" not in body
+    assert "Показано:</b> 5-5 из 5" in body
+
+
+@pytest.mark.asyncio
+async def test_timeline_rejects_invalid_pagination_values(monkeypatch) -> None:
+    request = _make_request("/timeline/auction/test")
+
+    monkeypatch.setattr("app.web.main._auth_context_or_unauthorized", lambda _req: (None, _stub_auth()))
+    monkeypatch.setattr("app.web.main.SessionFactory", _DummySessionFactory())
+
+    with pytest.raises(HTTPException):
+        await auction_timeline(request, str(uuid.uuid4()), page=-1, limit=100)
+
+    with pytest.raises(HTTPException):
+        await auction_timeline(request, str(uuid.uuid4()), page=0, limit=0)
+
+    with pytest.raises(HTTPException):
+        await auction_timeline(request, str(uuid.uuid4()), page=0, limit=501)


### PR DESCRIPTION
## Summary
- add `page` and `limit` query parameters to `/timeline/auction/{auction_id}` for high-volume timelines
- validate pagination bounds (`page >= 0`, `1 <= limit <= 500`) and show page coverage counters
- add prev/next navigation links while preserving chronological timeline order within each page
- add regression tests for first/middle/last page behavior and invalid pagination inputs

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests`
- `docker compose run --rm -v /home/n501/VibeCoding/LiteAuction:/workspace -w /workspace bot sh -lc "pip install -q '.[dev]' && RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test python -m pytest -q tests/integration"`