### PR TITLE
Sprint 24: strengthen PR quality gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## Summary
+
+- 
+
+## Scope
+
+- Type: feature / fix / test / refactor / docs
+- Sprint: Sprint XX
+
+## Validation
+
+- [ ] `python -m ruff check app tests`
+- [ ] `python -m pytest -q tests`
+- [ ] `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_test python -m pytest -q tests/integration`
+- [ ] Integration suite repeated once (anti-flaky)
+
+## Self Review
+
+- [ ] Permissions/scope checks verified for new paths
+- [ ] Idempotency/retry behavior verified for state-changing actions
+- [ ] DB transaction boundaries and side effects reviewed
+- [ ] Timeline/event ordering impact reviewed (if touched)
+
+## Risk & Rollback
+
+- Risk level: low / medium / high
+- Main risk:
+- Rollback plan:
+
+## Manual QA
+
+- Status: done / deferred
+- If done: attach evidence (screenshots + pass/fail matrix)
+- If deferred: when it will be run and by whom
+
+## Reviewer Focus
+
+- 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,7 @@ jobs:
 
       - name: Run DB integration tests
         run: python -m pytest -q tests/integration
+
+      - name: Re-run DB integration tests (anti-flaky)
+        if: github.event_name == 'pull_request'
+        run: python -m pytest -q tests/integration

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MVP Telegram auction bot scaffold on `aiogram` + `PostgreSQL` + `Redis` with Docker Compose.
 
-This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 + Sprint 21 + Sprint 22 + Sprint 23**:
+This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 + Sprint 21 + Sprint 22 + Sprint 23 + Sprint 24**:
 
 - Dockerized runtime (`bot`, `db`, `redis`)
 - `Alembic` migrations and initial PostgreSQL schema
@@ -36,6 +36,7 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - Timeline event sequence guards for callback flows (`create -> moderation action -> resolve`)
 - Stable per-entity timeline ordering on equal timestamps (`created_at` + primary-key tie-breakers)
 - Web timeline pagination with configurable `page`/`limit` and navigation links
+- CI anti-flaky integration re-run and PR quality checklist template
 
 ## Sprint 0 Checklist
 
@@ -204,6 +205,12 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - [x] Added validation for pagination bounds (`page >= 0`, `1 <= limit <= 500`)
 - [x] Added regression tests for page boundaries and event ordering preservation
 
+## Sprint 24 Checklist (Quality Gates)
+
+- [x] Added PR template with validation/self-review/risk/manual-QA checklist
+- [x] Added CI anti-flaky re-run for integration DB suite on pull requests
+- [x] Standardized reviewer focus section in PR metadata
+
 ## Quick Start
 
 1. Copy env template:
@@ -359,7 +366,7 @@ FRAUD_HISTORICAL_START_RATIO_LOW=0.5
 FRAUD_HISTORICAL_START_RATIO_HIGH=2.0
 ```
 
-## Next (Sprint 24)
+## Next (Sprint 25)
 
 - Move timeline pagination closer to DB layer to avoid loading full event history for very large auctions
 - Add filters by source (`auction`, `bid`, `complaint`, `fraud`, `moderation`) in timeline view


### PR DESCRIPTION
## Summary
- add a repository PR template with explicit validation, self-review, risk/rollback, manual QA, and reviewer-focus sections
- add an anti-flaky CI guard by re-running `tests/integration` in the existing `Integration DB (Postgres)` job for pull requests
- update sprint tracking in README to mark Sprint 24 complete and move Next to Sprint 25

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests`
- `docker compose run --rm -v /home/n501/VibeCoding/LiteAuction:/workspace -w /workspace bot sh -lc "pip install -q '.[dev]' && RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test python -m pytest -q tests/integration"`