### PR TITLE
Sprint 25: add timeline source filters and DB-bounded paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MVP Telegram auction bot scaffold on `aiogram` + `PostgreSQL` + `Redis` with Docker Compose.
 
-This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 + Sprint 21 + Sprint 22 + Sprint 23 + Sprint 24**:
+This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 + Sprint 21 + Sprint 22 + Sprint 23 + Sprint 24 + Sprint 25**:
 
 - Dockerized runtime (`bot`, `db`, `redis`)
 - `Alembic` migrations and initial PostgreSQL schema
@@ -37,6 +37,7 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - Stable per-entity timeline ordering on equal timestamps (`created_at` + primary-key tie-breakers)
 - Web timeline pagination with configurable `page`/`limit` and navigation links
 - CI anti-flaky integration re-run and PR quality checklist template
+- DB-aware timeline page assembly and source filters (`auction`, `bid`, `complaint`, `fraud`, `moderation`)
 
 ## Sprint 0 Checklist
 
@@ -211,6 +212,12 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - [x] Added CI anti-flaky re-run for integration DB suite on pull requests
 - [x] Standardized reviewer focus section in PR metadata
 
+## Sprint 25 Checklist (Timeline Source Filters)
+
+- [x] Added source filter support to timeline endpoint (`source=auction,bid,...`)
+- [x] Moved timeline pagination closer to DB layer via per-source bounded fetch (`(page+1)*limit`)
+- [x] Added regression tests for source filtering and page boundaries in web/controller and integration layers
+
 ## Quick Start
 
 1. Copy env template:
@@ -366,8 +373,8 @@ FRAUD_HISTORICAL_START_RATIO_LOW=0.5
 FRAUD_HISTORICAL_START_RATIO_HIGH=2.0
 ```
 
-## Next (Sprint 25)
+## Next (Sprint 26)
 
-- Move timeline pagination closer to DB layer to avoid loading full event history for very large auctions
-- Add filters by source (`auction`, `bid`, `complaint`, `fraud`, `moderation`) in timeline view
+- Add a quick source-filter UI control (checkboxes/chips) instead of query-string-only workflow
+- Add dedicated API endpoint for timeline JSON (for future richer admin UI)
 - Run manual QA using `docs/manual-qa/sprint-19.md` and attach evidence in PR

--- a/tests/integration/test_timeline_pagination_filters.py
+++ b/tests/integration/test_timeline_pagination_filters.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.db.enums import AuctionStatus, ModerationAction
+from app.db.models import Auction, Bid, Complaint, ModerationLog, User
+from app.services.timeline_service import build_auction_timeline_page
+
+
+@pytest.mark.asyncio
+async def test_timeline_page_source_filter_returns_only_requested_source(integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    stamp = datetime(2026, 2, 1, 10, 0, tzinfo=UTC)
+
+    async with session_factory() as session:
+        async with session.begin():
+            seller = User(tg_user_id=91001, username="seller")
+            reporter = User(tg_user_id=91002, username="reporter")
+            actor = User(tg_user_id=91003, username="mod")
+            session.add_all([seller, reporter, actor])
+            await session.flush()
+
+            auction = Auction(
+                seller_user_id=seller.id,
+                description="lot",
+                photo_file_id="photo",
+                start_price=100,
+                buyout_price=None,
+                min_step=10,
+                duration_hours=24,
+                status=AuctionStatus.ACTIVE,
+                created_at=stamp,
+            )
+            session.add(auction)
+            await session.flush()
+
+            session.add(
+                Complaint(
+                    auction_id=auction.id,
+                    reporter_user_id=reporter.id,
+                    reason="reason",
+                    status="RESOLVED",
+                    created_at=stamp + timedelta(minutes=1),
+                    resolved_at=stamp + timedelta(minutes=2),
+                    resolved_by_user_id=actor.id,
+                )
+            )
+            session.add(
+                ModerationLog(
+                    actor_user_id=actor.id,
+                    auction_id=auction.id,
+                    action=ModerationAction.FREEZE_AUCTION,
+                    reason="review",
+                    created_at=stamp + timedelta(minutes=2),
+                )
+            )
+            auction_id = auction.id
+
+    async with session_factory() as session:
+        auction, page_items, total_items = await build_auction_timeline_page(
+            session,
+            auction_id,
+            page=0,
+            limit=50,
+            sources=["moderation"],
+        )
+
+    assert auction is not None
+    assert total_items == 1
+    assert len(page_items) == 1
+    assert page_items[0].source == "moderation"
+    assert page_items[0].title == "Мод-действие: FREEZE_AUCTION"
+
+
+@pytest.mark.asyncio
+async def test_timeline_page_boundary_preserves_bid_order(integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    stamp = datetime(2026, 2, 2, 10, 0, tzinfo=UTC)
+
+    async with session_factory() as session:
+        async with session.begin():
+            seller = User(tg_user_id=91101, username="seller")
+            bidder = User(tg_user_id=91102, username="bidder")
+            session.add_all([seller, bidder])
+            await session.flush()
+
+            auction = Auction(
+                seller_user_id=seller.id,
+                description="lot",
+                photo_file_id="photo",
+                start_price=100,
+                buyout_price=None,
+                min_step=10,
+                duration_hours=24,
+                status=AuctionStatus.ACTIVE,
+                created_at=stamp,
+            )
+            session.add(auction)
+            await session.flush()
+
+            for idx in range(5):
+                session.add(
+                    Bid(
+                        auction_id=auction.id,
+                        user_id=bidder.id,
+                        amount=100 + idx,
+                        created_at=stamp + timedelta(minutes=idx + 1),
+                    )
+                )
+
+            auction_id = auction.id
+
+    async with session_factory() as session:
+        _, first_page, first_total = await build_auction_timeline_page(
+            session,
+            auction_id,
+            page=0,
+            limit=2,
+            sources=["bid"],
+        )
+        _, third_page, third_total = await build_auction_timeline_page(
+            session,
+            auction_id,
+            page=2,
+            limit=2,
+            sources=["bid"],
+        )
+
+    assert first_total == 5
+    assert third_total == 5
+    assert len(first_page) == 2
+    assert len(third_page) == 1
+    assert "amount=$100" in first_page[0].details
+    assert "amount=$101" in first_page[1].details
+    assert "amount=$104" in third_page[0].details


### PR DESCRIPTION
## Summary
- add `source` filtering support to `/timeline/auction/{auction_id}` (`auction`, `bid`, `complaint`, `fraud`, `moderation`)
- move timeline pagination closer to DB access by fetching only bounded per-source rows up to `(page + 1) * limit` for page assembly
- keep timeline ordering rules intact while reducing full-history load pressure for large auctions
- add web and integration regression tests for source filtering and page boundary behavior

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests`
- `docker compose run --rm -v /home/n501/VibeCoding/LiteAuction:/workspace -w /workspace bot sh -lc "pip install -q '.[dev]' && RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test python -m pytest -q tests/integration"`
- repeat integration run (anti-flaky): same command, second pass (`13 passed`)