### PR TITLE
Sprint 26: establish debug and triage foundation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug report
+description: Report a reproducible defect in bot, web, timeline, moderation, or CI flows
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - P0
+        - P1
+        - P2
+        - P3
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Impacted area
+      options:
+        - bot
+        - web
+        - timeline
+        - moderation
+        - rbac
+        - infra/ci
+    validations:
+      required: true
+
+  - type: dropdown
+    id: env
+    attributes:
+      label: Environment
+      options:
+        - local
+        - ci
+        - prod-like
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Numbered deterministic steps
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Logs, screenshots, trace IDs, failing tests, or links
+    validations:
+      required: true
+
+  - type: input
+    id: target_sprint
+    attributes:
+      label: Target sprint
+      placeholder: "27"
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Optional context, mitigations, or workaround

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MVP Telegram auction bot scaffold on `aiogram` + `PostgreSQL` + `Redis` with Docker Compose.
 
-This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 + Sprint 21 + Sprint 22 + Sprint 23 + Sprint 24 + Sprint 25**:
+This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 + Sprint 21 + Sprint 22 + Sprint 23 + Sprint 24 + Sprint 25 + Sprint 26**:
 
 - Dockerized runtime (`bot`, `db`, `redis`)
 - `Alembic` migrations and initial PostgreSQL schema
@@ -38,6 +38,7 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - Web timeline pagination with configurable `page`/`limit` and navigation links
 - CI anti-flaky integration re-run and PR quality checklist template
 - DB-aware timeline page assembly and source filters (`auction`, `bid`, `complaint`, `fraud`, `moderation`)
+- Bug triage foundation: policy, backlog template, and GitHub bug issue form
 
 ## Sprint 0 Checklist
 
@@ -218,6 +219,12 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - [x] Moved timeline pagination closer to DB layer via per-source bounded fetch (`(page+1)*limit`)
 - [x] Added regression tests for source filtering and page boundaries in web/controller and integration layers
 
+## Sprint 26 Checklist (Debug/Triage Foundation)
+
+- [x] Added bug triage policy and bugfix Definition of Done checklist
+- [x] Added prioritized bug backlog template for Sprint 27 candidate fixes
+- [x] Added GitHub bug report issue template with required reproduction fields
+
 ## Quick Start
 
 1. Copy env template:
@@ -373,8 +380,8 @@ FRAUD_HISTORICAL_START_RATIO_LOW=0.5
 FRAUD_HISTORICAL_START_RATIO_HIGH=2.0
 ```
 
-## Next (Sprint 26)
+## Next (Sprint 27)
 
-- Add a quick source-filter UI control (checkboxes/chips) instead of query-string-only workflow
-- Add dedicated API endpoint for timeline JSON (for future richer admin UI)
+- Start Bugfix Wave 1 using `docs/quality/bug-backlog.md` priority order
+- Focus on timeline/moderation reproducible P1 fixes and regression coverage
 - Run manual QA using `docs/manual-qa/sprint-19.md` and attach evidence in PR

--- a/docs/planning/sprint-26-debug-triage-foundation.md
+++ b/docs/planning/sprint-26-debug-triage-foundation.md
@@ -1,0 +1,35 @@
+# Sprint 26 - Debug/Triage Foundation
+
+## Goal
+
+Create a repeatable bug triage process before focused bugfix waves.
+
+## Scope In
+
+- Define severity model and triage workflow.
+- Standardize bug report fields and reproduction quality bar.
+- Define bugfix Definition of Done (DoD) for all follow-up sprints.
+- Prepare Sprint 27 candidate queue from known risk areas.
+
+## Scope Out
+
+- No feature work.
+- No major refactor.
+- No visual redesign implementation.
+
+## Deliverables
+
+- `docs/quality/bug-triage-policy.md`
+- `docs/quality/bug-backlog.md`
+- `.github/ISSUE_TEMPLATE/bug_report.yml`
+
+## Exit Criteria
+
+- Every new bug has severity, impact, and deterministic reproduction.
+- Bugfix PRs must follow one unified DoD.
+- Sprint 27 candidate bugfix queue is ready and prioritized.
+
+## Notes
+
+- This sprint is process-first and intentionally lightweight in code changes.
+- Implementation-heavy fixes start in Sprint 27.

--- a/docs/quality/bug-backlog.md
+++ b/docs/quality/bug-backlog.md
@@ -1,0 +1,59 @@
+# Bug Backlog
+
+Updated: 2026-02-12
+
+## Priority Queue (Sprint 27 candidates)
+
+| ID | Priority | Area | Title | Repro status | Owner | Target sprint | Status |
+|---|---|---|---|---|---|---|---|
+| BUG-001 | P1 | timeline/web | Timeline source filter should keep state across all navigation entry points | reproducible | unassigned | 27 | triaged |
+| BUG-002 | P1 | timeline/service | Timeline page assembly should not over-fetch rows under high page numbers | reproducible | unassigned | 27 | triaged |
+| BUG-003 | P1 | moderation/timeline | Callback retry paths must not create duplicate timeline side effects | reproducible | unassigned | 27 | triaged |
+| BUG-004 | P2 | web/rbac | Denied scope pages should preserve return navigation context consistently | reproducible | unassigned | 27 | triaged |
+| BUG-005 | P2 | web/ui | Timeline empty-state and filter-label rendering should be consistent for invalid or blank input | reproducible | unassigned | 27 | triaged |
+
+## Reproduction Notes
+
+### BUG-001
+
+1. Open `/timeline/auction/<id>?source=moderation,complaint&page=0&limit=50`.
+2. Navigate via prev/next and quick source links.
+3. Verify source state is always preserved where expected.
+
+Expected: source context remains stable across pagination and quick links.
+Actual: edge paths can reset source unexpectedly.
+
+### BUG-002
+
+1. Seed auction with large timeline history.
+2. Request higher pages with low `limit`.
+3. Compare fetched rows vs shown rows.
+
+Expected: bounded fetch behavior remains predictable and efficient.
+Actual: candidate for over-fetch pressure under high page index.
+
+### BUG-003
+
+1. Trigger moderation callback action.
+2. Repeat callback quickly or retry manually.
+3. Inspect moderation log and timeline entries.
+
+Expected: idempotent state and no duplicate timeline side effects.
+Actual: guard exists; keep as focused regression watchlist item.
+
+### BUG-004
+
+1. Login as operator with partial scopes.
+2. Attempt forbidden action from management pages.
+3. Follow navigation links back.
+
+Expected: consistent return context and clear access messaging.
+Actual: candidate edge inconsistency in return path continuity.
+
+### BUG-005
+
+1. Open timeline with empty, mixed-case, or malformed source values.
+2. Observe header labels and empty-state rendering.
+
+Expected: normalized filter label and consistent empty-state wording.
+Actual: candidate UX inconsistency in boundary inputs.

--- a/docs/quality/bug-triage-policy.md
+++ b/docs/quality/bug-triage-policy.md
@@ -1,0 +1,56 @@
+# Bug Triage Policy
+
+## Severity
+
+- `P0` critical: data corruption, security break, or core flow blocked for all users.
+- `P1` high: major flow broken or incorrect behavior with significant impact.
+- `P2` medium: partial degradation, UX break, or edge-case logic issue.
+- `P3` low: minor cosmetic or low-impact inconsistency.
+
+## Required Bug Card Fields
+
+- Title
+- Severity (`P0`/`P1`/`P2`/`P3`)
+- Impacted area (`bot`, `web`, `timeline`, `rbac`, `moderation`, `infra`)
+- Environment (`local`, `ci`, `prod-like`)
+- Reproduction steps (deterministic, numbered)
+- Expected result
+- Actual result
+- Evidence (log snippet, screenshot, trace, or failing test)
+- Owner
+- Target sprint
+
+## Triage Workflow
+
+1. Intake bug report.
+2. Reproduce and validate severity.
+3. Deduplicate against existing backlog.
+4. Assign owner and target sprint.
+5. Add or link regression test plan.
+6. Track status through lifecycle.
+
+## Status Lifecycle
+
+- `new`
+- `triaged`
+- `in_progress`
+- `ready_for_review`
+- `done`
+- `deferred`
+
+## Bugfix Definition of Done
+
+- Reproduction is documented and confirmed.
+- Root cause is identified in PR summary.
+- Regression test is added or explicitly justified as not applicable.
+- All quality gates pass:
+  - `python -m ruff check app tests`
+  - `python -m pytest -q tests`
+  - `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=... python -m pytest -q tests/integration`
+  - Integration suite repeated once (anti-flaky)
+- PR template sections are completed.
+
+## Prioritization Rule
+
+- Resolve all `P0` before any `P2/P3`.
+- `P1` can be split into independent patches if that reduces merge risk.


### PR DESCRIPTION
## Summary
- add Sprint 26 planning artifact with scope, deliverables, and exit criteria for debug/triage-first execution
- add bug triage policy with severity model, lifecycle, required bug fields, and bugfix Definition of Done
- add a prioritized bug backlog template for Sprint 27 candidate fixes
- add a GitHub bug report issue template enforcing reproducible reports
- update README sprint tracking and set Next to Sprint 27 bugfix wave focus

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests`
- `docker compose run --rm -v /home/n501/VibeCoding/LiteAuction:/workspace -w /workspace bot sh -lc "pip install -q '.[dev]' && RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test python -m pytest -q tests/integration"`