### PR TITLE
Sprint 27: bugfix wave 1 for timeline navigation and paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MVP Telegram auction bot scaffold on `aiogram` + `PostgreSQL` + `Redis` with Docker Compose.
 
-This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 + Sprint 21 + Sprint 22 + Sprint 23 + Sprint 24 + Sprint 25 + Sprint 26**:
+This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 + Sprint 21 + Sprint 22 + Sprint 23 + Sprint 24 + Sprint 25 + Sprint 26 + Sprint 27**:
 
 - Dockerized runtime (`bot`, `db`, `redis`)
 - `Alembic` migrations and initial PostgreSQL schema
@@ -39,6 +39,7 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - CI anti-flaky integration re-run and PR quality checklist template
 - DB-aware timeline page assembly and source filters (`auction`, `bid`, `complaint`, `fraud`, `moderation`)
 - Bug triage foundation: policy, backlog template, and GitHub bug issue form
+- Bugfix wave 1 improvements for timeline navigation context and pagination safety
 
 ## Sprint 0 Checklist
 
@@ -225,6 +226,13 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - [x] Added prioritized bug backlog template for Sprint 27 candidate fixes
 - [x] Added GitHub bug report issue template with required reproduction fields
 
+## Sprint 27 Checklist (Bugfix Wave 1)
+
+- [x] Fixed timeline context retention across timeline/manage navigation (`page`, `limit`, `source`)
+- [x] Fixed timeline page builder to cap fetch volume and return early for out-of-range pages
+- [x] Normalized and deduplicated source filter input; blank source now consistently maps to `all`
+- [x] Added regression tests for navigation context and pagination boundary behavior
+
 ## Quick Start
 
 1. Copy env template:
@@ -380,8 +388,8 @@ FRAUD_HISTORICAL_START_RATIO_LOW=0.5
 FRAUD_HISTORICAL_START_RATIO_HIGH=2.0
 ```
 
-## Next (Sprint 27)
+## Next (Sprint 28)
 
-- Start Bugfix Wave 1 using `docs/quality/bug-backlog.md` priority order
-- Focus on timeline/moderation reproducible P1 fixes and regression coverage
+- Continue Bugfix Wave 2 for remaining prioritized defects in `docs/quality/bug-backlog.md`
+- Focus on moderation retry/idempotency and denied-scope navigation edge cases
 - Run manual QA using `docs/manual-qa/sprint-19.md` and attach evidence in PR

--- a/app/services/timeline_service.py
+++ b/app/services/timeline_service.py
@@ -352,14 +352,17 @@ async def build_auction_timeline_page(
     if total_items == 0:
         return auction, [], 0
 
-    fetch_limit = (page + 1) * limit
+    offset = page * limit
+    if offset >= total_items:
+        return auction, [], total_items
+
+    fetch_limit = min((page + 1) * limit, total_items)
     timeline = await _build_timeline_events(
         session,
         auction,
         included_sources,
         max_per_source=fetch_limit,
     )
-    offset = page * limit
     return auction, timeline[offset : offset + limit], total_items
 
 

--- a/docs/quality/bug-backlog.md
+++ b/docs/quality/bug-backlog.md
@@ -6,11 +6,17 @@ Updated: 2026-02-12
 
 | ID | Priority | Area | Title | Repro status | Owner | Target sprint | Status |
 |---|---|---|---|---|---|---|---|
-| BUG-001 | P1 | timeline/web | Timeline source filter should keep state across all navigation entry points | reproducible | unassigned | 27 | triaged |
-| BUG-002 | P1 | timeline/service | Timeline page assembly should not over-fetch rows under high page numbers | reproducible | unassigned | 27 | triaged |
+| BUG-001 | P1 | timeline/web | Timeline source filter should keep state across all navigation entry points | reproducible | assigned | 27 | done |
+| BUG-002 | P1 | timeline/service | Timeline page assembly should not over-fetch rows under high page numbers | reproducible | assigned | 27 | done |
 | BUG-003 | P1 | moderation/timeline | Callback retry paths must not create duplicate timeline side effects | reproducible | unassigned | 27 | triaged |
 | BUG-004 | P2 | web/rbac | Denied scope pages should preserve return navigation context consistently | reproducible | unassigned | 27 | triaged |
-| BUG-005 | P2 | web/ui | Timeline empty-state and filter-label rendering should be consistent for invalid or blank input | reproducible | unassigned | 27 | triaged |
+| BUG-005 | P2 | web/ui | Timeline empty-state and filter-label rendering should be consistent for invalid or blank input | reproducible | assigned | 27 | done |
+
+## Completed in Sprint 27
+
+- `BUG-001`: timeline-to-manage-to-timeline navigation now preserves page/limit/source context.
+- `BUG-002`: timeline page builder now returns early when page offset is outside total range and caps per-source fetch by total items.
+- `BUG-005`: source filter input is normalized/deduplicated; blank filter is treated as `all` consistently.
 
 ## Reproduction Notes
 

--- a/tests/integration/test_timeline_pagination_filters.py
+++ b/tests/integration/test_timeline_pagination_filters.py
@@ -136,3 +136,54 @@ async def test_timeline_page_boundary_preserves_bid_order(integration_engine) ->
     assert "amount=$100" in first_page[0].details
     assert "amount=$101" in first_page[1].details
     assert "amount=$104" in third_page[0].details
+
+
+@pytest.mark.asyncio
+async def test_timeline_page_beyond_total_returns_empty_page(integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    stamp = datetime(2026, 2, 3, 10, 0, tzinfo=UTC)
+
+    async with session_factory() as session:
+        async with session.begin():
+            seller = User(tg_user_id=91201, username="seller")
+            bidder = User(tg_user_id=91202, username="bidder")
+            session.add_all([seller, bidder])
+            await session.flush()
+
+            auction = Auction(
+                seller_user_id=seller.id,
+                description="lot",
+                photo_file_id="photo",
+                start_price=100,
+                buyout_price=None,
+                min_step=10,
+                duration_hours=24,
+                status=AuctionStatus.ACTIVE,
+                created_at=stamp,
+            )
+            session.add(auction)
+            await session.flush()
+
+            for idx in range(3):
+                session.add(
+                    Bid(
+                        auction_id=auction.id,
+                        user_id=bidder.id,
+                        amount=200 + idx,
+                        created_at=stamp + timedelta(minutes=idx + 1),
+                    )
+                )
+
+            auction_id = auction.id
+
+    async with session_factory() as session:
+        _, page_items, total_items = await build_auction_timeline_page(
+            session,
+            auction_id,
+            page=3,
+            limit=2,
+            sources=["bid"],
+        )
+
+    assert total_items == 3
+    assert page_items == []

--- a/tests/test_web_manage_navigation.py
+++ b/tests/test_web_manage_navigation.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from starlette.requests import Request
+
+from app.db.enums import AuctionStatus
+from app.services.rbac_service import SCOPE_AUCTION_MANAGE, SCOPE_BID_MANAGE
+from app.web.auth import AdminAuthContext
+from app.web.main import manage_auction
+
+
+class _DummySession:
+    def __init__(self, auction) -> None:
+        self._auction = auction
+
+    async def scalar(self, _query):
+        return self._auction
+
+
+class _DummySessionFactoryCtx:
+    def __init__(self, auction) -> None:
+        self._auction = auction
+
+    async def __aenter__(self):
+        return _DummySession(self._auction)
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class _DummySessionFactory:
+    def __init__(self, auction) -> None:
+        self._auction = auction
+
+    def __call__(self) -> _DummySessionFactoryCtx:
+        return _DummySessionFactoryCtx(self._auction)
+
+
+def _make_request(path: str, query: str = "") -> Request:
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("utf-8"),
+        "query_string": query.encode("utf-8"),
+        "headers": [],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(scope, receive)
+
+
+def _stub_auth() -> AdminAuthContext:
+    return AdminAuthContext(
+        authorized=True,
+        via="token",
+        role="owner",
+        can_manage=True,
+        scopes=frozenset({SCOPE_AUCTION_MANAGE, SCOPE_BID_MANAGE}),
+        tg_user_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_manage_auction_preserves_timeline_context_in_link(monkeypatch) -> None:
+    auction_id = uuid.uuid4()
+    request = _make_request(
+        f"/manage/auction/{auction_id}",
+        query="timeline_page=2&timeline_limit=25&timeline_source=moderation,complaint",
+    )
+
+    auction = SimpleNamespace(id=auction_id, status=AuctionStatus.ACTIVE, seller_user_id=7)
+
+    monkeypatch.setattr("app.web.main._auth_context_or_unauthorized", lambda _req: (None, _stub_auth()))
+    monkeypatch.setattr("app.web.main.SessionFactory", _DummySessionFactory(auction))
+
+    async def fake_recent_bids(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr("app.web.main.list_recent_bids", fake_recent_bids)
+    monkeypatch.setattr("app.web.main._csrf_hidden_input", lambda *_args, **_kwargs: "")
+
+    response = await manage_auction(request, str(auction_id))
+
+    assert response.status_code == 200
+    body = bytes(response.body).decode("utf-8")
+    assert (
+        f"/timeline/auction/{auction_id}?page=2&amp;limit=25&amp;source=moderation%2Ccomplaint"
+        in body
+    )


### PR DESCRIPTION
## Summary
- preserve timeline context (`page`, `limit`, `source`) when navigating timeline -> manage -> timeline
- normalize and deduplicate source query input; treat blank source input as `all`
- harden timeline page builder to avoid unnecessary fetch work for out-of-range pages and cap fetch to total count
- update bug backlog statuses for completed Wave 1 items and add regression tests for navigation and boundary behavior

## Scope
- Type: fix / test / docs
- Sprint: Sprint 27

## Validation
- [x] `python -m ruff check app tests`
- [x] `python -m pytest -q tests`
- [x] `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_test python -m pytest -q tests/integration`
- [x] Integration suite repeated once (anti-flaky)

## Self Review
- [x] Permissions/scope checks verified for new paths
- [x] Idempotency/retry behavior verified for state-changing actions
- [x] DB transaction boundaries and side effects reviewed
- [x] Timeline/event ordering impact reviewed (if touched)

## Risk & Rollback
- Risk level: low
- Main risk: timeline query param handling could break deep links if malformed values are not normalized consistently
- Rollback plan: revert commit `f1436de` and keep Sprint 26 behavior

## Manual QA
- Status: deferred
- If deferred: when it will be run and by whom
  - Planned after Wave 2 stabilization before release cut

## Reviewer Focus
- `app/web/main.py`: source normalization and timeline/manage context carry-over
- `app/services/timeline_service.py`: out-of-range early return + fetch cap by total
- `tests/test_web_manage_navigation.py` and `tests/integration/test_timeline_pagination_filters.py`: navigation and paging boundary regressions