### PR TITLE
Sprint 28: bugfix wave 2 for retries and denied navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MVP Telegram auction bot scaffold on `aiogram` + `PostgreSQL` + `Redis` with Docker Compose.
 
-This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 + Sprint 21 + Sprint 22 + Sprint 23 + Sprint 24 + Sprint 25 + Sprint 26 + Sprint 27**:
+This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 + Sprint 21 + Sprint 22 + Sprint 23 + Sprint 24 + Sprint 25 + Sprint 26 + Sprint 27 + Sprint 28**:
 
 - Dockerized runtime (`bot`, `db`, `redis`)
 - `Alembic` migrations and initial PostgreSQL schema
@@ -40,6 +40,7 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - DB-aware timeline page assembly and source filters (`auction`, `bid`, `complaint`, `fraud`, `moderation`)
 - Bug triage foundation: policy, backlog template, and GitHub bug issue form
 - Bugfix wave 1 improvements for timeline navigation context and pagination safety
+- Bugfix wave 2 improvements for callback retry safety and denied-scope back navigation
 
 ## Sprint 0 Checklist
 
@@ -233,6 +234,12 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - [x] Normalized and deduplicated source filter input; blank source now consistently maps to `all`
 - [x] Added regression tests for navigation context and pagination boundary behavior
 
+## Sprint 28 Checklist (Bugfix Wave 2)
+
+- [x] Added idempotency regression for repeated `modrisk:ban` callback actions
+- [x] Fixed denied-scope web pages to preserve safe return navigation context
+- [x] Added unit and integration regressions for scope-denied back links and callback retry side effects
+
 ## Quick Start
 
 1. Copy env template:
@@ -388,8 +395,8 @@ FRAUD_HISTORICAL_START_RATIO_LOW=0.5
 FRAUD_HISTORICAL_START_RATIO_HIGH=2.0
 ```
 
-## Next (Sprint 28)
+## Next (Sprint 29)
 
-- Continue Bugfix Wave 2 for remaining prioritized defects in `docs/quality/bug-backlog.md`
-- Focus on moderation retry/idempotency and denied-scope navigation edge cases
+- Start visual foundation pass for admin web (layout consistency, controls readability, state styling)
+- Keep behavior unchanged while improving usability on desktop and mobile
 - Run manual QA using `docs/manual-qa/sprint-19.md` and attach evidence in PR

--- a/docs/quality/bug-backlog.md
+++ b/docs/quality/bug-backlog.md
@@ -2,14 +2,14 @@
 
 Updated: 2026-02-12
 
-## Priority Queue (Sprint 27 candidates)
+## Priority Queue (Sprint 27-28 candidates)
 
 | ID | Priority | Area | Title | Repro status | Owner | Target sprint | Status |
 |---|---|---|---|---|---|---|---|
 | BUG-001 | P1 | timeline/web | Timeline source filter should keep state across all navigation entry points | reproducible | assigned | 27 | done |
 | BUG-002 | P1 | timeline/service | Timeline page assembly should not over-fetch rows under high page numbers | reproducible | assigned | 27 | done |
-| BUG-003 | P1 | moderation/timeline | Callback retry paths must not create duplicate timeline side effects | reproducible | unassigned | 27 | triaged |
-| BUG-004 | P2 | web/rbac | Denied scope pages should preserve return navigation context consistently | reproducible | unassigned | 27 | triaged |
+| BUG-003 | P1 | moderation/timeline | Callback retry paths must not create duplicate timeline side effects | reproducible | assigned | 28 | done |
+| BUG-004 | P2 | web/rbac | Denied scope pages should preserve return navigation context consistently | reproducible | assigned | 28 | done |
 | BUG-005 | P2 | web/ui | Timeline empty-state and filter-label rendering should be consistent for invalid or blank input | reproducible | assigned | 27 | done |
 
 ## Completed in Sprint 27
@@ -17,6 +17,11 @@ Updated: 2026-02-12
 - `BUG-001`: timeline-to-manage-to-timeline navigation now preserves page/limit/source context.
 - `BUG-002`: timeline page builder now returns early when page offset is outside total range and caps per-source fetch by total items.
 - `BUG-005`: source filter input is normalized/deduplicated; blank filter is treated as `all` consistently.
+
+## Completed in Sprint 28
+
+- `BUG-003`: added idempotency regression coverage for repeated `modrisk:ban` callbacks (no duplicate logs/blacklist/timeline side effects).
+- `BUG-004`: denied-scope pages now preserve safe return navigation using `return_to`/`Referer` context.
 
 ## Reproduction Notes
 


### PR DESCRIPTION
## Summary
- preserve safe return navigation context on denied-scope pages using `return_to` and `Referer` fallbacks
- add explicit idempotency regression for repeated `modrisk:ban` callback handling to guarantee no duplicate side effects
- update Wave 2 bug backlog statuses and sprint tracking docs

## Scope
- Type: fix / test / docs
- Sprint: Sprint 28

## Validation
- [x] `python -m ruff check app tests`
- [x] `python -m pytest -q tests`
- [x] `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_test python -m pytest -q tests/integration`
- [x] Integration suite repeated once (anti-flaky)

## Self Review
- [x] Permissions/scope checks verified for new paths
- [x] Idempotency/retry behavior verified for state-changing actions
- [x] DB transaction boundaries and side effects reviewed
- [x] Timeline/event ordering impact reviewed (if touched)

## Risk & Rollback
- Risk level: low
- Main risk: referer-based back link handling could expose unexpected internal paths if not sanitized
- Rollback plan: revert commit `1bf4cf5` to restore previous denied-page/link behavior

## Manual QA
- Status: deferred
- If deferred: when it will be run and by whom
  - Planned as a consolidated pass after visual foundation updates (before release candidate)

## Reviewer Focus
- `app/web/main.py`: `_safe_back_to_from_request` and denied-scope page back-link behavior
- `tests/test_web_security.py`: new denied-scope back-link regressions (`Referer` and `return_to`)
- `tests/integration/test_moderation_callbacks_e2e.py`: repeated `modrisk:ban` idempotency coverage