### PR TITLE
Sprint 30: finalize visual polish and release readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MVP Telegram auction bot scaffold on `aiogram` + `PostgreSQL` + `Redis` with Docker Compose.
 
-This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 + Sprint 21 + Sprint 22 + Sprint 23 + Sprint 24 + Sprint 25 + Sprint 26 + Sprint 27 + Sprint 28 + Sprint 29**:
+This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 + Sprint 4 + Sprint 5 + Sprint 6 + Sprint 7 + Sprint 8 + Sprint 9 + Sprint 10 + Sprint 11 + Sprint 12 + Sprint 13 + Sprint 14 + Sprint 15 + Sprint 16 + Sprint 17 + Sprint 18 + Sprint 19 + Sprint 20 + Sprint 21 + Sprint 22 + Sprint 23 + Sprint 24 + Sprint 25 + Sprint 26 + Sprint 27 + Sprint 28 + Sprint 29 + Sprint 30**:
 
 - Dockerized runtime (`bot`, `db`, `redis`)
 - `Alembic` migrations and initial PostgreSQL schema
@@ -42,6 +42,7 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - Bugfix wave 1 improvements for timeline navigation context and pagination safety
 - Bugfix wave 2 improvements for callback retry safety and denied-scope back navigation
 - Visual foundation refresh for admin web layout, controls, and responsive readability
+- Final visual polish and release-readiness checklist with consolidated QA evidence template
 
 ## Sprint 0 Checklist
 
@@ -248,6 +249,13 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - [x] Added responsive layout handling for mobile viewports in core admin pages
 - [x] Updated timeline source quick-links to chip-style controls for clearer filtering affordance
 
+## Sprint 30 Checklist (Final Polish + Release Readiness)
+
+- [x] Added focus-visible keyboard affordances for interactive controls in admin web
+- [x] Unified visual treatment for empty/error/warning states across key pages
+- [x] Added release-readiness checklist at `docs/release/sprint-30-readiness.md`
+- [x] Kept backend behavior unchanged while polishing UX and recovery paths
+
 ## Quick Start
 
 1. Copy env template:
@@ -403,8 +411,8 @@ FRAUD_HISTORICAL_START_RATIO_LOW=0.5
 FRAUD_HISTORICAL_START_RATIO_HIGH=2.0
 ```
 
-## Next (Sprint 30)
+## Next (Post-Sprint)
 
-- Apply final visual polish pass (empty/error states, contrast tuning, focus/keyboard affordances)
-- Prepare release-readiness checklist with consolidated Manual QA evidence
-- Run manual QA using `docs/manual-qa/sprint-19.md` and attach evidence in PR
+- Continue point improvements from bug triage backlog in small scoped PRs
+- Run consolidated manual QA using `docs/manual-qa/sprint-19.md` + `docs/release/sprint-30-readiness.md`
+- Prepare release candidate notes and known limitations

--- a/app/web/main.py
+++ b/app/web/main.py
@@ -163,7 +163,7 @@ def _validate_csrf_token(request: Request, auth: AdminAuthContext, csrf_token: s
 def _csrf_failed_response(request: Request, *, back_to: str) -> HTMLResponse:
     body = (
         "<h1>CSRF check failed</h1>"
-        "<p>Обновите страницу и повторите действие.</p>"
+        "<div class='notice notice-error'><p>Обновите страницу и повторите действие.</p></div>"
         f"<p><a href='{escape(_path_with_auth(request, back_to))}'>Назад</a></p>"
     )
     return HTMLResponse(_render_page("Forbidden", body), status_code=403)
@@ -252,8 +252,16 @@ def _render_page(title: str, body: str) -> str:
         "padding:10px 12px;border-radius:10px;box-shadow:0 4px 12px rgba(15,26,31,0.06);}"
         "a{color:var(--accent);text-decoration:none;font-weight:600;}"
         "a:hover{text-decoration:underline;}"
+        "a:focus-visible,button:focus-visible,input:focus-visible,select:focus-visible,textarea:focus-visible{"
+        "outline:3px solid #ffb454;outline-offset:2px;}"
         ".chip{display:inline-block;padding:4px 9px;border-radius:999px;border:1px solid #b8c9c7;"
         "background:#f3faf8;font-size:12px;font-weight:600;margin-right:6px;margin-bottom:4px;}"
+        ".notice{border:1px solid var(--line);border-radius:10px;padding:10px 12px;margin:10px 0;}"
+        ".notice p{margin:0;}"
+        ".notice-error{background:#fff1f1;border-color:#e4b5b5;color:#822727;}"
+        ".notice-warn{background:#fff8ec;border-color:#e9c28e;color:#7b4a0d;}"
+        ".notice-info{background:#edf7f7;border-color:#b4d7d4;color:#0b4f4a;}"
+        ".empty-state{color:var(--muted);font-style:italic;}"
         ".card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:14px;"
         "box-shadow:0 3px 10px rgba(11,31,36,0.05);}"
         "pre{white-space:pre-wrap;background:var(--soft);padding:8px;border-radius:8px;border:1px solid var(--line);margin:0;}"
@@ -364,7 +372,7 @@ def _require_scope_permission(request: Request, scope: str) -> tuple[Response | 
     back_to = _safe_back_to_from_request(request)
     body = (
         "<h1>Недостаточно прав</h1>"
-        f"<p>Для этого действия нужна роль с правом: <b>{escape(scope_title)}</b>.</p>"
+        f"<div class='notice notice-warn'><p>Для этого действия нужна роль с правом: <b>{escape(scope_title)}</b>.</p></div>"
         f"<p><a href='{escape(_path_with_auth(request, back_to))}'>Назад</a></p>"
         f"<p><a href='{escape(_path_with_auth(request, '/'))}'>На главную</a></p>"
     )
@@ -551,7 +559,7 @@ async def complaints(request: Request, status: str = "OPEN", page: int = 0) -> R
         for item in rows
     )
     if not table_rows:
-        table_rows = "<tr><td colspan='6'>Нет записей</td></tr>"
+        table_rows = "<tr><td colspan='6'><span class='empty-state'>Нет записей</span></td></tr>"
 
     prev_link = (
         f"<a href='{escape(_path_with_auth(request, f'/complaints?status={status}&page={page-1}'))}'>← Назад</a>"
@@ -608,7 +616,7 @@ async def signals(request: Request, status: str = "OPEN", page: int = 0) -> Resp
         for item in rows
     )
     if not table_rows:
-        table_rows = "<tr><td colspan='6'>Нет записей</td></tr>"
+        table_rows = "<tr><td colspan='6'><span class='empty-state'>Нет записей</span></td></tr>"
 
     prev_link = (
         f"<a href='{escape(_path_with_auth(request, f'/signals?status={status}&page={page-1}'))}'>← Назад</a>"
@@ -672,7 +680,7 @@ async def auctions(request: Request, status: str = "ACTIVE", page: int = 0) -> R
         for item in rows
     )
     if not table_rows:
-        table_rows = "<tr><td colspan='7'>Нет записей</td></tr>"
+        table_rows = "<tr><td colspan='7'><span class='empty-state'>Нет записей</span></td></tr>"
 
     prev_link = (
         f"<a href='{escape(_path_with_auth(request, f'/auctions?status={status}&page={page-1}'))}'>← Назад</a>"
@@ -751,7 +759,7 @@ async def auction_timeline(
         for item in page_items
     )
     if not rows:
-        rows = "<tr><td colspan='4'>События отсутствуют на этой странице</td></tr>"
+        rows = "<tr><td colspan='4'><span class='empty-state'>События отсутствуют на этой странице</span></td></tr>"
 
     timeline_base = f"/timeline/auction/{auction.id}"
 
@@ -818,7 +826,7 @@ def _safe_return_to(return_to: str | None, fallback: str) -> str:
 def _action_error_page(request: Request, message: str, *, back_to: str) -> HTMLResponse:
     body = (
         "<h1>Action failed</h1>"
-        f"<p>{escape(message)}</p>"
+        f"<div class='notice notice-error'><p>{escape(message)}</p></div>"
         f"<p><a href='{escape(_path_with_auth(request, back_to))}'>Назад</a></p>"
     )
     return HTMLResponse(_render_page("Action Error", body), status_code=400)
@@ -911,7 +919,7 @@ async def manage_auction(request: Request, auction_id: str) -> Response:
 
     bids_table = (
         "<table><thead><tr><th>Bid ID</th><th>Amount</th><th>TG UID</th><th>Username</th><th>Created</th><th>Removed</th><th>Action</th></tr></thead>"
-        f"<tbody>{''.join(bid_rows) if bid_rows else '<tr><td colspan=7>Нет ставок</td></tr>'}</tbody></table>"
+        f"<tbody>{''.join(bid_rows) if bid_rows else '<tr><td colspan=7><span class=\"empty-state\">Нет ставок</span></td></tr>'}</tbody></table>"
     )
 
     body = (
@@ -1068,7 +1076,7 @@ async def manage_user(request: Request, user_id: int) -> Response:
         for item in recent_complaints_against
     )
     if not complaints_rows:
-        complaints_rows = "<tr><td colspan='5'>Нет записей</td></tr>"
+        complaints_rows = "<tr><td colspan='5'><span class='empty-state'>Нет записей</span></td></tr>"
 
     signal_rows = "".join(
         "<tr>"
@@ -1081,7 +1089,7 @@ async def manage_user(request: Request, user_id: int) -> Response:
         for item in recent_fraud_signals
     )
     if not signal_rows:
-        signal_rows = "<tr><td colspan='5'>Нет записей</td></tr>"
+        signal_rows = "<tr><td colspan='5'><span class='empty-state'>Нет записей</span></td></tr>"
 
     roles_text = ", ".join(sorted(role.value for role in user_roles)) if user_roles else "-"
     moderator_text = "yes" if has_moderator_access else "no"
@@ -1229,7 +1237,7 @@ async def manage_users(request: Request, page: int = 0, q: str = "") -> Response
         "</form>"
         f"{moderator_grant_form}"
         "<table><thead><tr><th>ID</th><th>TG User ID</th><th>Username</th><th>Moderator</th><th>Banned</th><th>Created</th><th>Manage</th></tr></thead>"
-        f"<tbody>{''.join(rows) if rows else '<tr><td colspan=7>Нет записей</td></tr>'}</tbody></table>"
+        f"<tbody>{''.join(rows) if rows else '<tr><td colspan=7><span class=\"empty-state\">Нет записей</span></td></tr>'}</tbody></table>"
         f"<p>{prev_link} {' | ' if prev_link and next_link else ''} {next_link}</p>"
     )
     return HTMLResponse(_render_page("Manage Users", body))

--- a/docs/release/sprint-30-readiness.md
+++ b/docs/release/sprint-30-readiness.md
@@ -1,0 +1,42 @@
+# Sprint 30 Release Readiness Checklist
+
+## Objective
+
+Finalize release readiness after bugfix waves and visual foundation updates.
+
+## Hard Gates
+
+- [ ] `python -m ruff check app tests`
+- [ ] `python -m pytest -q tests`
+- [ ] `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_test python -m pytest -q tests/integration`
+- [ ] Repeat integration run once (anti-flaky)
+
+## Manual QA Evidence
+
+Use `docs/manual-qa/sprint-19.md` plus this visual sweep:
+
+- [ ] Timeline filters and paging usable on desktop and mobile widths
+- [ ] Empty-state messaging readable and styled consistently
+- [ ] Error/forbidden/CSRF pages show clear recovery path (`Назад`, `На главную`)
+- [ ] Keyboard focus ring visible on links, buttons, and form fields
+- [ ] Table readability is acceptable at narrow viewport widths
+
+Attach evidence to PR:
+
+- Screenshots for timeline (desktop + mobile)
+- Screenshot for denied/CSRF/error pages
+- Short pass/fail matrix for MQ/TL and visual checks
+
+## Rollback Plan
+
+If release verification fails:
+
+1. Revert Sprint 30 visual polish commit.
+2. Re-run CI and integration checks.
+3. Keep functional bugfix waves (S27/S28) intact.
+
+## Sign-off
+
+- Engineering: [ ]
+- Product/Owner: [ ]
+- Manual QA reviewer: [ ]


### PR DESCRIPTION
## Summary
- apply final admin-web polish for focus visibility and clearer empty/error/warn state treatment across key pages
- keep backend behavior unchanged while improving recovery affordances on forbidden/csrf/action-error screens
- add Sprint 30 release-readiness checklist (`docs/release/sprint-30-readiness.md`) with consolidated QA evidence and rollback/sign-off sections
- update README sprint progression through Sprint 30 and move roadmap to post-sprint maintenance mode

## Scope
- Type: style / docs
- Sprint: Sprint 30

## Validation
- [x] `python -m ruff check app tests`
- [x] `python -m pytest -q tests`
- [x] `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_test python -m pytest -q tests/integration`
- [x] Integration suite repeated once (anti-flaky)

## Self Review
- [x] Permissions/scope checks verified for new paths
- [x] Idempotency/retry behavior verified for state-changing actions
- [x] DB transaction boundaries and side effects reviewed
- [x] Timeline/event ordering impact reviewed (if touched)

## Risk & Rollback
- Risk level: low
- Main risk: CSS-only polish could reduce readability in specific client/browser combinations
- Rollback plan: revert commit `6fab5c6` to restore Sprint 29 visual baseline

## Manual QA
- Status: deferred
- If deferred: when it will be run and by whom
  - Planned as consolidated release check using `docs/manual-qa/sprint-19.md` + `docs/release/sprint-30-readiness.md`

## Reviewer Focus
- `app/web/main.py`: `_render_page` polish (focus-visible, notice/empty-state styles) and message wrappers in CSRF/forbidden/error paths
- `docs/release/sprint-30-readiness.md`: release gate and evidence checklist
- `README.md`: Sprint 30 completion and post-sprint roadmap