### PR TITLE
Post-sprint: harden web return path safety

### DIFF
--- a/docs/quality/bug-backlog.md
+++ b/docs/quality/bug-backlog.md
@@ -1,6 +1,6 @@
 # Bug Backlog
 
-Updated: 2026-02-12
+Updated: 2026-02-13
 
 ## Priority Queue (Sprint 27-28 candidates)
 
@@ -11,6 +11,7 @@ Updated: 2026-02-12
 | BUG-003 | P1 | moderation/timeline | Callback retry paths must not create duplicate timeline side effects | reproducible | assigned | 28 | done |
 | BUG-004 | P2 | web/rbac | Denied scope pages should preserve return navigation context consistently | reproducible | assigned | 28 | done |
 | BUG-005 | P2 | web/ui | Timeline empty-state and filter-label rendering should be consistent for invalid or blank input | reproducible | assigned | 27 | done |
+| BUG-006 | P1 | web/security | Reject protocol-relative return paths in `return_to` and denied-page back links | reproducible | assigned | post-sprint | done |
 
 ## Completed in Sprint 27
 
@@ -22,6 +23,10 @@ Updated: 2026-02-12
 
 - `BUG-003`: added idempotency regression coverage for repeated `modrisk:ban` callbacks (no duplicate logs/blacklist/timeline side effects).
 - `BUG-004`: denied-scope pages now preserve safe return navigation using `return_to`/`Referer` context.
+
+## Completed Post-sprint
+
+- `BUG-006`: protocol-relative paths (for example `//host/path`) are now rejected in `return_to` and denied-page back links.
 
 ## Reproduction Notes
 


### PR DESCRIPTION
## Summary
- harden web return path handling to reject protocol-relative values (for example `//host/path`) in `return_to` and denied-page back-link derivation
- keep internal navigation behavior unchanged for valid local paths
- add regression coverage for unsafe `return_to`, unsafe `Referer` path handling, and safe fallback behavior
- record the fix in bug backlog as `BUG-006`

## Scope
- Type: fix / test / docs
- Sprint: Post-sprint maintenance

## Validation
- [x] `python -m ruff check app tests`
- [x] `python -m pytest -q tests`
- [x] `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_test python -m pytest -q tests/integration`
- [x] Integration suite repeated once (anti-flaky)

## Self Review
- [x] Permissions/scope checks verified for new paths
- [x] Idempotency/retry behavior verified for state-changing actions
- [x] DB transaction boundaries and side effects reviewed
- [x] Timeline/event ordering impact reviewed (if touched)

## Risk & Rollback
- Risk level: low
- Main risk: strict path filtering could reject unusual but valid internal URLs
- Rollback plan: revert commit `4c604ce` to restore previous return-path behavior

## Manual QA
- Status: deferred
- If deferred: when it will be run and by whom
  - Included in consolidated release QA pass using `docs/release/sprint-30-readiness.md`

## Reviewer Focus
- `app/web/main.py`: `_is_safe_local_path`, `_safe_back_to_from_request`, `_safe_return_to`
- `tests/test_web_security.py`: protocol-relative path rejection regressions
- `docs/quality/bug-backlog.md`: `BUG-006` traceability entry