### PR TITLE
Post-sprint: add RC baseline notes and QA handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,4 +415,5 @@ FRAUD_HISTORICAL_START_RATIO_HIGH=2.0
 
 - Continue point improvements from bug triage backlog in small scoped PRs
 - Run consolidated manual QA using `docs/manual-qa/sprint-19.md` + `docs/release/sprint-30-readiness.md`
+- Use `docs/release/rc-1-notes.md` as release-candidate baseline notes
 - Prepare release candidate notes and known limitations

--- a/docs/release/rc-1-notes.md
+++ b/docs/release/rc-1-notes.md
@@ -1,0 +1,47 @@
+# Release Candidate 1 Notes
+
+Date: 2026-02-12
+Branch: `post-sprint-rc-readiness`
+
+## Scope Included
+
+- Sprint 26: debug/triage foundation.
+- Sprint 27-28: bugfix waves for timeline navigation, paging, retry idempotency, denied-scope back links.
+- Sprint 29-30: visual foundation and final polish for admin web UX.
+- Post-sprint: safe return-path hardening (`BUG-006`).
+
+## Automated Verification (completed)
+
+- `python -m ruff check app tests` -> PASS
+- `python -m pytest -q tests` -> PASS (`29 passed, 1 skipped`)
+- Integration run #1 -> PASS (`15 passed`)
+- Integration run #2 (anti-flaky) -> PASS (`15 passed`)
+
+## Manual QA Status (pending)
+
+Consolidated manual QA is pending and must be completed before final release sign-off.
+
+Use:
+
+- `docs/manual-qa/sprint-19.md`
+- `docs/release/sprint-30-readiness.md`
+
+Required evidence:
+
+- moderation queue before/after screenshots,
+- timeline screenshots (desktop + mobile),
+- denied/CSRF/action-error page screenshots,
+- pass/fail matrix for MQ/TL and visual checklist items.
+
+## Known Limitations
+
+- No unresolved P0/P1 from current bug backlog.
+- Manual QA evidence not yet attached in this branch.
+
+## Rollback Guidance
+
+If RC validation fails:
+
+1. Revert the latest failing post-sprint commit(s).
+2. Re-run automated quality gates.
+3. Keep Sprint 27-28 functional fixes unless directly implicated.


### PR DESCRIPTION
## Summary
- add `docs/release/rc-1-notes.md` with consolidated release-candidate baseline (scope, automated verification, pending manual QA evidence, rollback guidance)
- link RC notes from README post-sprint next steps for a single source of release readiness context

## Scope
- Type: docs
- Sprint: Post-sprint maintenance

## Validation
- [x] `python -m ruff check app tests`
- [x] `python -m pytest -q tests`
- [x] `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_test python -m pytest -q tests/integration`
- [x] Integration suite repeated once (anti-flaky)

## Risk & Rollback
- Risk level: low
- Main risk: stale release notes if not updated after additional fixes
- Rollback plan: revert commit `fc4a911`

## Manual QA
- Status: pending
- Will be executed using:
  - `docs/manual-qa/sprint-19.md`
  - `docs/release/sprint-30-readiness.md`