### PR TITLE
Post-sprint: consolidate RC QA artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,4 +416,5 @@ FRAUD_HISTORICAL_START_RATIO_HIGH=2.0
 - Continue point improvements from bug triage backlog in small scoped PRs
 - Run consolidated manual QA using `docs/manual-qa/sprint-19.md` + `docs/release/sprint-30-readiness.md`
 - Use `docs/release/rc-1-notes.md` as release-candidate baseline notes
+- Fill `docs/release/rc-1-manual-qa-matrix.md` during final interactive QA run
 - Prepare release candidate notes and known limitations

--- a/docs/release/rc-1-manual-qa-matrix.md
+++ b/docs/release/rc-1-manual-qa-matrix.md
@@ -1,0 +1,38 @@
+# RC-1 Manual QA Matrix
+
+Date:
+Tester:
+
+## Core Flow Cases
+
+| Case | Result | Notes |
+|---|---|---|
+| MQ-01 Complaint freeze updates queue and timeline | PASS/FAIL | |
+| MQ-02 ban_top denied without `user:ban` scope | PASS/FAIL | |
+| MQ-03 Fraud signal ban updates queue and timeline | PASS/FAIL | |
+| MQ-04 Repeated callback click is idempotent | PASS/FAIL | |
+| TL-01 Complaint timeline consistency | PASS/FAIL | |
+| TL-02 Fraud timeline consistency | PASS/FAIL | |
+
+## Visual/Release Cases
+
+| Case | Result | Notes |
+|---|---|---|
+| Timeline paging and filters usable on desktop | PASS/FAIL | |
+| Timeline paging and filters usable on mobile width | PASS/FAIL | |
+| Empty-state messaging readability | PASS/FAIL | |
+| Error/forbidden/CSRF recovery links clarity | PASS/FAIL | |
+| Keyboard focus ring visibility | PASS/FAIL | |
+| Table readability on narrow viewport | PASS/FAIL | |
+
+## Evidence
+
+- Queue before/after screenshots:
+- Timeline desktop screenshots:
+- Timeline mobile screenshots:
+- Denied/CSRF/error screenshots:
+
+## Final Verdict
+
+- Release candidate readiness: GO / NO-GO
+- Blocking issues (if any):

--- a/docs/release/rc-1-notes.md
+++ b/docs/release/rc-1-notes.md
@@ -1,6 +1,7 @@
 # Release Candidate 1 Notes
 
 Date: 2026-02-12
+Last automated re-check: 2026-02-12
 Branch: `post-sprint-rc-readiness`
 
 ## Scope Included
@@ -11,6 +12,13 @@ Branch: `post-sprint-rc-readiness`
 - Post-sprint: safe return-path hardening (`BUG-006`).
 
 ## Automated Verification (completed)
+
+- `python -m ruff check app tests` -> PASS
+- `python -m pytest -q tests` -> PASS (`29 passed, 1 skipped`)
+- Integration run #1 -> PASS (`15 passed`)
+- Integration run #2 (anti-flaky) -> PASS (`15 passed`)
+
+Latest rerun snapshot (post-sprint):
 
 - `python -m ruff check app tests` -> PASS
 - `python -m pytest -q tests` -> PASS (`29 passed, 1 skipped`)

--- a/docs/release/sprint-30-readiness.md
+++ b/docs/release/sprint-30-readiness.md
@@ -6,10 +6,10 @@ Finalize release readiness after bugfix waves and visual foundation updates.
 
 ## Hard Gates
 
-- [ ] `python -m ruff check app tests`
-- [ ] `python -m pytest -q tests`
-- [ ] `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_test python -m pytest -q tests/integration`
-- [ ] Repeat integration run once (anti-flaky)
+- [x] `python -m ruff check app tests`
+- [x] `python -m pytest -q tests`
+- [x] `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_test python -m pytest -q tests/integration`
+- [x] Repeat integration run once (anti-flaky)
 
 ## Manual QA Evidence
 
@@ -26,6 +26,8 @@ Attach evidence to PR:
 - Screenshots for timeline (desktop + mobile)
 - Screenshot for denied/CSRF/error pages
 - Short pass/fail matrix for MQ/TL and visual checks
+
+Manual QA execution status: pending (requires interactive Telegram and admin web walkthrough)
 
 ## Rollback Plan
 


### PR DESCRIPTION
## Summary
- update Sprint 30 release-readiness checklist with completed automated gate status
- extend RC notes with latest automated re-verification snapshot
- add `docs/release/rc-1-manual-qa-matrix.md` for final interactive QA capture and GO/NO-GO verdict
- link RC manual QA matrix from README post-sprint section

## Scope
- Type: docs
- Sprint: Post-sprint maintenance

## Validation
- [x] `python -m ruff check app tests`
- [x] `python -m pytest -q tests`
- [x] `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_test python -m pytest -q tests/integration`
- [x] Integration suite repeated once (anti-flaky)

## Manual QA
- Status: pending interactive execution
- Matrix to fill: `docs/release/rc-1-manual-qa-matrix.md`