### PR TITLE
Post-sprint: record conditional RC verdict status

### DIFF
--- a/docs/release/rc-1-notes.md
+++ b/docs/release/rc-1-notes.md
@@ -2,7 +2,7 @@
 
 Date: 2026-02-12
 Last automated re-check: 2026-02-12
-Branch: `post-sprint-rc-readiness`
+Branch: `post-sprint-rc-verification`
 
 ## Scope Included
 
@@ -40,6 +40,12 @@ Required evidence:
 - timeline screenshots (desktop + mobile),
 - denied/CSRF/action-error page screenshots,
 - pass/fail matrix for MQ/TL and visual checklist items.
+
+## Current Verdict
+
+- Automated quality gates: PASS
+- Manual QA evidence: PENDING
+- RC status: CONDITIONAL GO (final GO after manual QA matrix is filled)
 
 ## Known Limitations
 

--- a/docs/release/sprint-30-readiness.md
+++ b/docs/release/sprint-30-readiness.md
@@ -39,6 +39,6 @@ If release verification fails:
 
 ## Sign-off
 
-- Engineering: [ ]
+- Engineering: [x]
 - Product/Owner: [ ]
 - Manual QA reviewer: [ ]


### PR DESCRIPTION
## Summary
- update RC notes with current verification branch context and explicit conditional verdict
- mark engineering sign-off complete in Sprint 30 release-readiness checklist
- keep RC status explicitly blocked on manual QA evidence completion

## Scope
- Type: docs
- Sprint: Post-sprint maintenance

## Validation
- [x] `python -m ruff check app tests`
- [x] `python -m pytest -q tests`
- [x] `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_test python -m pytest -q tests/integration`
- [x] Integration suite repeated once (anti-flaky)

## Manual QA
- Status: pending interactive execution
- Matrix to fill: `docs/release/rc-1-manual-qa-matrix.md`