### PR TITLE
feat: add one-time appeal SLA escalation

### DIFF
--- a/alembic/versions/0008_add_appeal_sla_fields.py
+++ b/alembic/versions/0008_add_appeal_sla_fields.py
@@ -1,0 +1,65 @@
+"""add appeal sla and escalation fields
+
+Revision ID: 0008_add_appeal_sla_fields
+Revises: 0007_appeal_mod_actions
+Create Date: 2026-02-13 06:30:00
+"""
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0008_add_appeal_sla_fields"
+down_revision: str | None = "0007_appeal_mod_actions"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("appeals", sa.Column("in_review_started_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("appeals", sa.Column("sla_deadline_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("appeals", sa.Column("escalated_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "appeals",
+        sa.Column("escalation_level", sa.SmallInteger(), nullable=False, server_default=sa.text("0")),
+    )
+
+    op.create_index("ix_appeals_sla_deadline_at", "appeals", ["sla_deadline_at"], unique=False)
+    op.create_index("ix_appeals_escalated_at", "appeals", ["escalated_at"], unique=False)
+    op.create_index(
+        "ix_appeals_escalation_scan",
+        "appeals",
+        ["status", "escalated_at", "sla_deadline_at"],
+        unique=False,
+    )
+
+    op.execute(
+        """
+        UPDATE appeals
+        SET
+            in_review_started_at = CASE
+                WHEN status = 'IN_REVIEW' THEN COALESCE(updated_at, created_at)
+                ELSE NULL
+            END,
+            sla_deadline_at = CASE
+                WHEN status = 'OPEN' THEN created_at + INTERVAL '24 hours'
+                WHEN status = 'IN_REVIEW' THEN COALESCE(updated_at, created_at) + INTERVAL '12 hours'
+                ELSE NULL
+            END,
+            escalation_level = 0,
+            escalated_at = NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_appeals_escalation_scan", table_name="appeals")
+    op.drop_index("ix_appeals_escalated_at", table_name="appeals")
+    op.drop_index("ix_appeals_sla_deadline_at", table_name="appeals")
+
+    op.drop_column("appeals", "escalation_level")
+    op.drop_column("appeals", "escalated_at")
+    op.drop_column("appeals", "sla_deadline_at")
+    op.drop_column("appeals", "in_review_started_at")

--- a/app/config.py
+++ b/app/config.py
@@ -61,6 +61,11 @@ class Settings(BaseSettings):
     fraud_historical_spike_score: int = 20
     fraud_historical_start_ratio_low: float = 0.5
     fraud_historical_start_ratio_high: float = 2.0
+    appeal_sla_open_hours: int = 24
+    appeal_sla_in_review_hours: int = 12
+    appeal_escalation_enabled: bool = True
+    appeal_escalation_interval_seconds: int = 60
+    appeal_escalation_batch_size: int = 50
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -229,6 +229,7 @@ class Appeal(Base, TimestampMixin):
         ),
         Index("ix_appeals_status_created_at", "status", "created_at"),
         Index("ix_appeals_source_type_source_id", "source_type", "source_id"),
+        Index("ix_appeals_escalation_scan", "status", "escalated_at", "sla_deadline_at"),
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
@@ -252,6 +253,10 @@ class Appeal(Base, TimestampMixin):
         nullable=True,
     )
     resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    in_review_started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    sla_deadline_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
+    escalated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
+    escalation_level: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
 
 
 class FraudSignal(Base):

--- a/app/services/appeal_escalation_service.py
+++ b/app/services/appeal_escalation_service.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from aiogram import Bot
+from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError
+from sqlalchemy import select
+from sqlalchemy.orm import aliased
+
+from app.config import settings
+from app.db.enums import AppealSourceType
+from app.db.models import Appeal, User
+from app.db.session import SessionFactory
+from app.services.appeal_service import escalate_overdue_appeals
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class EscalatedAppealView:
+    appeal_id: int
+    appeal_ref: str
+    status: str
+    source_type: AppealSourceType
+    source_id: int | None
+    appellant_tg_user_id: int
+    appellant_username: str | None
+    resolver_tg_user_id: int | None
+    resolver_username: str | None
+    sla_deadline_at: datetime | None
+    escalated_at: datetime | None
+
+
+def _format_dt(value: datetime | None) -> str:
+    if value is None:
+        return "-"
+    return value.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def _source_label(source_type: AppealSourceType, source_id: int | None) -> str:
+    if source_type == AppealSourceType.COMPLAINT:
+        return f"Жалоба #{source_id}" if source_id is not None else "Жалоба"
+    if source_type == AppealSourceType.RISK:
+        return f"Фрод-сигнал #{source_id}" if source_id is not None else "Фрод-сигнал"
+    return "Ручная"
+
+
+def _user_label(tg_user_id: int | None, username: str | None) -> str:
+    if tg_user_id is None:
+        return "-"
+    if username:
+        return f"@{username} ({tg_user_id})"
+    return str(tg_user_id)
+
+
+def _render_escalation_text(item: EscalatedAppealView) -> str:
+    return (
+        "Эскалация апелляции\n"
+        f"ID: {item.appeal_id}\n"
+        f"Референс: {item.appeal_ref}\n"
+        f"Статус: {item.status}\n"
+        f"Источник: {_source_label(item.source_type, item.source_id)}\n"
+        f"Апеллянт: {_user_label(item.appellant_tg_user_id, item.appellant_username)}\n"
+        f"Модератор: {_user_label(item.resolver_tg_user_id, item.resolver_username)}\n"
+        f"SLA дедлайн: {_format_dt(item.sla_deadline_at)}\n"
+        f"Эскалирована: {_format_dt(item.escalated_at)}"
+    )
+
+
+async def _notify_moderators(bot: Bot, text: str) -> None:
+    moderation_chat_id = settings.parsed_moderation_chat_id()
+    moderation_thread_id = settings.parsed_moderation_thread_id()
+    if moderation_chat_id is not None:
+        try:
+            kwargs: dict[str, int] = {}
+            if moderation_thread_id is not None:
+                kwargs["message_thread_id"] = moderation_thread_id
+            await bot.send_message(moderation_chat_id, text, **kwargs)
+            return
+        except (TelegramBadRequest, TelegramForbiddenError) as exc:
+            logger.warning("Failed to notify moderation chat about escalated appeal: %s", exc)
+
+    for admin_tg_id in settings.parsed_admin_user_ids():
+        try:
+            await bot.send_message(admin_tg_id, text)
+        except TelegramForbiddenError:
+            continue
+
+
+async def process_overdue_appeal_escalations(bot: Bot) -> int:
+    if not settings.appeal_escalation_enabled:
+        return 0
+
+    batch_size = max(settings.appeal_escalation_batch_size, 1)
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            escalation_result = await escalate_overdue_appeals(session, limit=batch_size)
+            if not escalation_result.escalated:
+                return 0
+
+            resolver_user = aliased(User)
+            rows = (
+                await session.execute(
+                    select(Appeal, User, resolver_user)
+                    .join(User, User.id == Appeal.appellant_user_id)
+                    .outerjoin(resolver_user, resolver_user.id == Appeal.resolver_user_id)
+                    .where(Appeal.id.in_([item.id for item in escalation_result.escalated]))
+                    .order_by(Appeal.sla_deadline_at.asc(), Appeal.id.asc())
+                )
+            ).all()
+
+    escalated_items: list[EscalatedAppealView] = []
+    for appeal, appellant, resolver in rows:
+        escalated_items.append(
+            EscalatedAppealView(
+                appeal_id=appeal.id,
+                appeal_ref=appeal.appeal_ref,
+                status=str(appeal.status),
+                source_type=AppealSourceType(appeal.source_type),
+                source_id=appeal.source_id,
+                appellant_tg_user_id=appellant.tg_user_id,
+                appellant_username=appellant.username,
+                resolver_tg_user_id=resolver.tg_user_id if resolver is not None else None,
+                resolver_username=resolver.username if resolver is not None else None,
+                sla_deadline_at=appeal.sla_deadline_at,
+                escalated_at=appeal.escalated_at,
+            )
+        )
+
+    for item in escalated_items:
+        await _notify_moderators(bot, _render_escalation_text(item))
+
+    return len(escalated_items)

--- a/app/services/appeal_escalation_watcher.py
+++ b/app/services/appeal_escalation_watcher.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from aiogram import Bot
+
+from app.config import settings
+from app.services.appeal_escalation_service import process_overdue_appeal_escalations
+
+logger = logging.getLogger(__name__)
+
+
+async def run_appeal_escalation_watcher(bot: Bot) -> None:
+    interval = max(settings.appeal_escalation_interval_seconds, 1)
+    while True:
+        try:
+            escalated_count = await process_overdue_appeal_escalations(bot)
+            if escalated_count:
+                logger.warning("Appeal escalation watcher escalated %s appeal(s)", escalated_count)
+            await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.exception("Appeal escalation watcher failed: %s", exc)
+            await asyncio.sleep(interval)

--- a/tests/integration/test_appeal_escalation_service.py
+++ b/tests/integration/test_appeal_escalation_service.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.db.enums import AppealSourceType, AppealStatus
+from app.db.models import Appeal, User
+from app.services.appeal_escalation_service import process_overdue_appeal_escalations
+
+
+class _DummyBot:
+    def __init__(self) -> None:
+        self.sent_messages: list[tuple[int, str, dict[str, int]]] = []
+
+    async def send_message(self, chat_id: int, text: str, **kwargs) -> None:
+        self.sent_messages.append((chat_id, text, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_process_overdue_appeal_escalations_marks_and_notifies(monkeypatch, integration_engine) -> None:
+    from app.config import settings
+
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+
+    now = datetime.now(UTC)
+    async with session_factory() as session:
+        async with session.begin():
+            appellant = User(tg_user_id=99701, username="escalate_user")
+            reviewer = User(tg_user_id=99702, username="reviewer_user")
+            session.add_all([appellant, reviewer])
+            await session.flush()
+
+            session.add_all(
+                [
+                    Appeal(
+                        appeal_ref="manual_overdue_notify",
+                        source_type=AppealSourceType.MANUAL,
+                        source_id=None,
+                        appellant_user_id=appellant.id,
+                        status=AppealStatus.IN_REVIEW,
+                        resolver_user_id=reviewer.id,
+                        in_review_started_at=now - timedelta(hours=3),
+                        sla_deadline_at=now - timedelta(minutes=5),
+                    ),
+                    Appeal(
+                        appeal_ref="manual_fresh_notify",
+                        source_type=AppealSourceType.MANUAL,
+                        source_id=None,
+                        appellant_user_id=appellant.id,
+                        status=AppealStatus.OPEN,
+                        sla_deadline_at=now + timedelta(hours=2),
+                    ),
+                ]
+            )
+
+    monkeypatch.setattr("app.services.appeal_escalation_service.SessionFactory", session_factory)
+    monkeypatch.setattr(settings, "appeal_escalation_enabled", True)
+    monkeypatch.setattr(settings, "appeal_escalation_batch_size", 20)
+    monkeypatch.setattr(settings, "moderation_chat_id", "-1007001")
+    monkeypatch.setattr(settings, "moderation_thread_id", "42")
+    monkeypatch.setattr(settings, "admin_user_ids", "99710,99711")
+
+    bot = _DummyBot()
+    escalated_count = await process_overdue_appeal_escalations(bot)
+
+    assert escalated_count == 1
+    assert len(bot.sent_messages) == 1
+
+    sent_chat_id, sent_text, sent_kwargs = bot.sent_messages[0]
+    assert sent_chat_id == -1007001
+    assert sent_kwargs.get("message_thread_id") == 42
+    assert "Эскалация апелляции" in sent_text
+    assert "manual_overdue_notify" in sent_text
+
+    async with session_factory() as session:
+        appeals = (await session.execute(select(Appeal).order_by(Appeal.id.asc()))).scalars().all()
+
+    assert appeals[0].escalated_at is not None
+    assert appeals[0].escalation_level == 1
+    assert appeals[1].escalated_at is None
+    assert appeals[1].escalation_level == 0

--- a/tests/integration/test_appeal_service.py
+++ b/tests/integration/test_appeal_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -8,6 +10,7 @@ from app.db.enums import AppealSourceType, AppealStatus
 from app.db.models import Appeal, User
 from app.services.appeal_service import (
     create_appeal_from_ref,
+    escalate_overdue_appeals,
     mark_appeal_in_review,
     parse_appeal_ref,
     reject_appeal,
@@ -44,6 +47,9 @@ async def test_create_appeal_from_ref_persists_source_data(integration_engine) -
     assert appeal.source_type == AppealSourceType.COMPLAINT
     assert appeal.source_id == 73
     assert appeal.status == AppealStatus.OPEN
+    assert appeal.sla_deadline_at is not None
+    assert appeal.escalated_at is None
+    assert appeal.escalation_level == 0
 
 
 @pytest.mark.asyncio
@@ -149,6 +155,9 @@ async def test_mark_appeal_in_review_allows_followup_finalize(integration_engine
             assert review_result.appeal.resolver_user_id == reviewer.id
             assert review_result.appeal.resolution_note == "Взята в работу"
             assert review_result.appeal.resolved_at is None
+            assert review_result.appeal.in_review_started_at is not None
+            assert review_result.appeal.sla_deadline_at is not None
+            assert review_result.appeal.sla_deadline_at > review_result.appeal.in_review_started_at
 
             resolve_result = await resolve_appeal(
                 session,
@@ -163,3 +172,77 @@ async def test_mark_appeal_in_review_allows_followup_finalize(integration_engine
     assert resolve_result.appeal.resolver_user_id == resolver.id
     assert resolve_result.appeal.resolution_note == "Проверено"
     assert resolve_result.appeal.resolved_at is not None
+    assert resolve_result.appeal.sla_deadline_at is None
+
+
+@pytest.mark.asyncio
+async def test_escalate_overdue_appeals_is_one_time(integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    now = datetime.now(UTC)
+
+    async with session_factory() as session:
+        async with session.begin():
+            user = User(tg_user_id=88501, username="overdue_user")
+            session.add(user)
+            await session.flush()
+
+            overdue_open = Appeal(
+                appeal_ref="manual_overdue_open",
+                source_type=AppealSourceType.MANUAL,
+                source_id=None,
+                appellant_user_id=user.id,
+                status=AppealStatus.OPEN,
+                sla_deadline_at=now - timedelta(minutes=10),
+            )
+            overdue_review = Appeal(
+                appeal_ref="manual_overdue_review",
+                source_type=AppealSourceType.MANUAL,
+                source_id=None,
+                appellant_user_id=user.id,
+                status=AppealStatus.IN_REVIEW,
+                in_review_started_at=now - timedelta(hours=2),
+                sla_deadline_at=now - timedelta(minutes=1),
+            )
+            fresh_open = Appeal(
+                appeal_ref="manual_fresh_open",
+                source_type=AppealSourceType.MANUAL,
+                source_id=None,
+                appellant_user_id=user.id,
+                status=AppealStatus.OPEN,
+                sla_deadline_at=now + timedelta(hours=1),
+            )
+            resolved_due = Appeal(
+                appeal_ref="manual_resolved_due",
+                source_type=AppealSourceType.MANUAL,
+                source_id=None,
+                appellant_user_id=user.id,
+                status=AppealStatus.RESOLVED,
+                sla_deadline_at=now - timedelta(hours=1),
+            )
+            session.add_all([overdue_open, overdue_review, fresh_open, resolved_due])
+            await session.flush()
+
+            first_run = await escalate_overdue_appeals(session, now=now, limit=20)
+            second_run = await escalate_overdue_appeals(session, now=now + timedelta(minutes=1), limit=20)
+
+            refreshed = (
+                await session.execute(
+                    select(Appeal).where(Appeal.appellant_user_id == user.id).order_by(Appeal.id.asc())
+                )
+            ).scalars().all()
+
+    assert {item.appeal_ref for item in first_run.escalated} == {
+        "manual_overdue_open",
+        "manual_overdue_review",
+    }
+    assert second_run.escalated == []
+
+    by_ref = {item.appeal_ref: item for item in refreshed}
+    assert by_ref["manual_overdue_open"].escalation_level == 1
+    assert by_ref["manual_overdue_open"].escalated_at is not None
+    assert by_ref["manual_overdue_review"].escalation_level == 1
+    assert by_ref["manual_overdue_review"].escalated_at is not None
+    assert by_ref["manual_fresh_open"].escalation_level == 0
+    assert by_ref["manual_fresh_open"].escalated_at is None
+    assert by_ref["manual_resolved_due"].escalation_level == 0
+    assert by_ref["manual_resolved_due"].escalated_at is None


### PR DESCRIPTION
## Summary
- add appeal SLA lifecycle fields and migration (`sla_deadline_at`, `in_review_started_at`, `escalated_at`, `escalation_level`) with backfill for existing active appeals
- implement one-time overdue escalation processing and watcher loop with moderation notifications (chat/thread with admin fallback) and configurable SLA/interval settings
- expose overdue state in moderation UI: web `/appeals` overdue filters + SLA/escalation columns and modpanel overdue markers, with integration coverage for idempotency and paging/filter context

## Validation
- `.venv/bin/python -m ruff check app tests alembic`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@172.20.0.4:5432/auction_test .venv/bin/python -m pytest -q tests/integration`
- repeated integration run (anti-flaky)