### PR TITLE
feat: add appeal escalation audit trail

### DIFF
--- a/alembic/versions/0009_add_escalate_appeal_action.py
+++ b/alembic/versions/0009_add_escalate_appeal_action.py
@@ -1,0 +1,25 @@
+"""add escalate appeal moderation action
+
+Revision ID: 0009_add_escalate_appeal_action
+Revises: 0008_add_appeal_sla_fields
+Create Date: 2026-02-13 06:55:00
+"""
+
+from typing import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0009_add_escalate_appeal_action"
+down_revision: str | None = "0008_add_appeal_sla_fields"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE moderation_action ADD VALUE IF NOT EXISTS 'ESCALATE_APPEAL'")
+
+
+def downgrade() -> None:
+    # PostgreSQL enum value removal is intentionally unsupported in downgrade path.
+    pass

--- a/app/config.py
+++ b/app/config.py
@@ -66,6 +66,7 @@ class Settings(BaseSettings):
     appeal_escalation_enabled: bool = True
     appeal_escalation_interval_seconds: int = 60
     appeal_escalation_batch_size: int = 50
+    appeal_escalation_actor_tg_user_id: int = -1
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 

--- a/app/db/enums.py
+++ b/app/db/enums.py
@@ -29,6 +29,7 @@ class ModerationAction(StrEnum):
     UNBAN_USER = "UNBAN_USER"
     RESOLVE_APPEAL = "RESOLVE_APPEAL"
     REJECT_APPEAL = "REJECT_APPEAL"
+    ESCALATE_APPEAL = "ESCALATE_APPEAL"
 
 
 class AppealSourceType(StrEnum):

--- a/tests/integration/test_appeal_escalation_service.py
+++ b/tests/integration/test_appeal_escalation_service.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from typing import cast
 
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from app.db.enums import AppealSourceType, AppealStatus
-from app.db.models import Appeal, User
+from app.db.enums import AppealSourceType, AppealStatus, ModerationAction
+from app.db.models import Appeal, ModerationLog, User
+from aiogram import Bot
 from app.services.appeal_escalation_service import process_overdue_appeal_escalations
 
 
@@ -59,14 +61,17 @@ async def test_process_overdue_appeal_escalations_marks_and_notifies(monkeypatch
     monkeypatch.setattr("app.services.appeal_escalation_service.SessionFactory", session_factory)
     monkeypatch.setattr(settings, "appeal_escalation_enabled", True)
     monkeypatch.setattr(settings, "appeal_escalation_batch_size", 20)
+    monkeypatch.setattr(settings, "appeal_escalation_actor_tg_user_id", -99700)
     monkeypatch.setattr(settings, "moderation_chat_id", "-1007001")
     monkeypatch.setattr(settings, "moderation_thread_id", "42")
     monkeypatch.setattr(settings, "admin_user_ids", "99710,99711")
 
     bot = _DummyBot()
-    escalated_count = await process_overdue_appeal_escalations(bot)
+    escalated_count = await process_overdue_appeal_escalations(cast(Bot, bot))
+    second_run_count = await process_overdue_appeal_escalations(cast(Bot, bot))
 
     assert escalated_count == 1
+    assert second_run_count == 0
     assert len(bot.sent_messages) == 1
 
     sent_chat_id, sent_text, sent_kwargs = bot.sent_messages[0]
@@ -77,8 +82,23 @@ async def test_process_overdue_appeal_escalations_marks_and_notifies(monkeypatch
 
     async with session_factory() as session:
         appeals = (await session.execute(select(Appeal).order_by(Appeal.id.asc()))).scalars().all()
+        logs = (
+            await session.execute(
+                select(ModerationLog)
+                .where(ModerationLog.action == ModerationAction.ESCALATE_APPEAL)
+                .order_by(ModerationLog.id.asc())
+            )
+        ).scalars().all()
+        actor = await session.scalar(select(User).where(User.tg_user_id == -99700))
 
     assert appeals[0].escalated_at is not None
     assert appeals[0].escalation_level == 1
     assert appeals[1].escalated_at is None
     assert appeals[1].escalation_level == 0
+    assert actor is not None
+    assert len(logs) == 1
+    assert logs[0].actor_user_id == actor.id
+    assert logs[0].target_user_id == appeals[0].appellant_user_id
+    assert logs[0].payload is not None
+    assert logs[0].payload.get("appeal_id") == appeals[0].id
+    assert logs[0].payload.get("escalation_level") == 1


### PR DESCRIPTION
## Summary
- add dedicated moderation action `ESCALATE_APPEAL` (enum + migration) for SLA-based one-time appeal escalations
- log escalation events from the escalation processor with deterministic system actor attribution and payload fields for appeal/source/SLA context
- extend escalation integration coverage to assert one-time behavior and persisted moderation audit records

## Validation
- `.venv/bin/python -m ruff check app tests alembic`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@172.20.0.4:5432/auction_test .venv/bin/python -m pytest -q tests/integration`
- repeated integration run (anti-flaky)