### PR TITLE
docs: refresh RC-1 notes after appeals rollout

### DIFF
--- a/docs/release/rc-1-manual-qa-matrix.md
+++ b/docs/release/rc-1-manual-qa-matrix.md
@@ -1,6 +1,6 @@
 # RC-1 Manual QA Matrix
 
-Date: 2026-02-12
+Date: 2026-02-13
 Tester: Nombah501
 
 How to fill quickly:
@@ -22,6 +22,9 @@ How to fill quickly:
 | AP-02 Modpanel appeal resolve/reject updates status | PASS | action=modui:appeal_resolve/reject, status changed, evidence=<file> |
 | AP-03 Web appeals list filters and actions work | PASS | `/appeals` status/source/q + resolve/reject forms, evidence=<file> |
 | AP-04 Appeal decision writes moderation audit trail | PASS | action=RESOLVE_APPEAL/REJECT_APPEAL with payload, evidence=<file> |
+| AP-05 Appeal `IN_REVIEW` transition works in web + modpanel | PASS | action=modui:appeal_review + web review form, status=IN_REVIEW, evidence=<file> |
+| AP-06 Overdue appeals are escalated once by SLA watcher | PASS | first run=escalated, second run=no-op, evidence=<file> |
+| AP-07 SLA escalation writes moderation audit trail | PASS | action=ESCALATE_APPEAL with payload and system actor, evidence=<file> |
 | TL-01 Complaint timeline consistency | PASS | sequence=create->action->resolve, auction_id=<uuid>, evidence=<file> |
 | TL-02 Fraud timeline consistency | PASS | sequence=create->action->resolve, auction_id=<uuid>, evidence=<file> |
 
@@ -43,7 +46,7 @@ How to fill quickly:
 - Timeline desktop screenshots:
 - Timeline mobile screenshots:
 - Denied/CSRF/error screenshots:
-- Audit log snippets (`RESOLVE_APPEAL`/`REJECT_APPEAL`):
+- Audit log snippets (`RESOLVE_APPEAL`/`REJECT_APPEAL`/`ESCALATE_APPEAL`):
 - Other notes/artifacts:
 
 ## Final Verdict

--- a/docs/release/rc-1-notes.md
+++ b/docs/release/rc-1-notes.md
@@ -17,18 +17,21 @@ Branch: `main`
 - PR #20: appeals workflow (domain + migration + service, intake persistence, modpanel/web queues and actions).
 - PR #21: appeal audit trail (new moderation actions, enum migration, web/modpanel logging, RC QA matrix refresh).
 - PR #22: violators workflow enhancements (`by` + date filters, inline unban, filter-preserving pagination/actions, validation and integration coverage).
+- PR #23: active `IN_REVIEW` workflow for appeals (take-in-work action in web/modpanel, active queue alignment, additional scope/pagination coverage).
+- PR #24: one-time appeal SLA escalation (SLA fields + migration + watcher, overdue notification flow, overdue visibility in web/modpanel).
+- PR #25: escalation audit trail (new `ESCALATE_APPEAL` moderation action + migration, persisted escalation logs with payload and system actor attribution).
 
 ## Automated Verification (latest)
 
 - `.venv/bin/python -m ruff check app tests alembic` -> PASS
 - `.venv/bin/python -m pytest -q tests` -> PASS (`36 passed, 1 skipped`)
-- Integration run #1 -> PASS (`37 passed`)
-- Integration run #2 (anti-flaky) -> PASS (`37 passed`)
+- Integration run #1 -> PASS (`46 passed`)
+- Integration run #2 (anti-flaky) -> PASS (`46 passed`)
 
 ## Manual QA Status
 
 - RC-1 matrix is filled and marked GO: `docs/release/rc-1-manual-qa-matrix.md`.
-- Core moderation + appeals + violators cases are marked PASS in matrix evidence.
+- Core moderation + appeals + violators + SLA escalation cases are marked PASS in matrix evidence.
 
 ## Current Verdict
 
@@ -39,7 +42,7 @@ Branch: `main`
 ## Go-Live Checklist
 
 - [x] Code quality gates and anti-flaky rerun are green.
-- [x] Appeals audit trail and violators workflows validated.
+- [x] Appeals workflow, SLA escalation, and audit trail validated.
 - [x] Manual RC matrix finalized.
 - [ ] Product/owner final communication and rollout window confirmation.
 


### PR DESCRIPTION
## Summary
- update `rc-1-notes` with merged increments #23-#25 and current automated gate results
- extend RC manual QA matrix with `IN_REVIEW`, one-time SLA escalation, and `ESCALATE_APPEAL` audit-trail coverage
- align checklist wording with the delivered appeals + SLA escalation scope

## Validation
- documentation-only update