### PR TITLE
docs: finalize RC-1 product sign-off

### DIFF
--- a/docs/release/rc-1-notes.md
+++ b/docs/release/rc-1-notes.md
@@ -44,7 +44,12 @@ Branch: `main`
 - [x] Code quality gates and anti-flaky rerun are green.
 - [x] Appeals workflow, SLA escalation, and audit trail validated.
 - [x] Manual RC matrix finalized.
-- [ ] Product/owner final communication and rollout window confirmation.
+- [x] Product/owner final communication and rollout window confirmation.
+
+Rollout window confirmation:
+
+- Product/owner communication: confirmed
+- Planned rollout window: 2026-02-13 (post-merge window)
 
 ## Rollback Guidance
 

--- a/docs/release/sprint-30-readiness.md
+++ b/docs/release/sprint-30-readiness.md
@@ -40,5 +40,5 @@ If release verification fails:
 ## Sign-off
 
 - Engineering: [x]
-- Product/Owner: [ ]
+- Product/Owner: [x]
 - Manual QA reviewer: [x]


### PR DESCRIPTION
## Summary
- mark Product/Owner sign-off as completed in Sprint 30 readiness checklist
- close remaining go-live checklist item in RC-1 notes
- add explicit rollout-window confirmation lines to release notes

## Validation
- documentation-only update