### PR TITLE
feat: add rewards ledger and points command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - Visual foundation refresh for admin web layout, controls, and responsive readability
 - Final visual polish and release-readiness checklist with consolidated QA evidence template
 - Section-based moderation topic routing and user feedback/guarantor intake commands (`/bug`, `/suggest`, `/guarant`)
+- Rewards ledger foundation with idempotent points accrual and user `/points` balance history
 - Outbox-driven automation for approved feedback -> GitHub issue creation with retry/backoff
 
 ## Sprint 0 Checklist
@@ -362,6 +363,7 @@ Use it as a reply to a message that contains premium/custom emoji.
 /bug <описание>
 /suggest <предложение>
 /guarant <запрос на гаранта>
+/points
 ```
 
 - Include moderation queue destination in env (recommended):

--- a/alembic/versions/0013_add_points_ledger.py
+++ b/alembic/versions/0013_add_points_ledger.py
@@ -1,0 +1,73 @@
+"""add points ledger for rewards
+
+Revision ID: 0013_add_points_ledger
+Revises: 0012_add_guarantor_requests
+Create Date: 2026-02-13 18:40:00
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0013_add_points_ledger"
+down_revision: str | None = "0012_add_guarantor_requests"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    points_event_type = postgresql.ENUM(
+        "FEEDBACK_APPROVED",
+        "MANUAL_ADJUSTMENT",
+        name="points_event_type",
+    )
+    points_event_type.create(op.get_bind(), checkfirst=True)
+
+    points_event_type_column = postgresql.ENUM(
+        "FEEDBACK_APPROVED",
+        "MANUAL_ADJUSTMENT",
+        name="points_event_type",
+        create_type=False,
+    )
+
+    op.create_table(
+        "points_ledger",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("amount", sa.Integer(), nullable=False),
+        sa.Column("event_type", points_event_type_column, nullable=False),
+        sa.Column("dedupe_key", sa.String(length=255), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("TIMEZONE('utc', NOW())"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("TIMEZONE('utc', NOW())"),
+            nullable=False,
+        ),
+        sa.CheckConstraint("amount <> 0", name="points_ledger_amount_nonzero"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name=op.f("fk_points_ledger_user_id_users"), ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_points_ledger")),
+        sa.UniqueConstraint("dedupe_key", name="uq_points_ledger_dedupe_key"),
+    )
+    op.create_index(
+        "ix_points_ledger_user_created_at",
+        "points_ledger",
+        ["user_id", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_points_ledger_user_created_at", table_name="points_ledger")
+    op.drop_table("points_ledger")
+    op.execute("DROP TYPE IF EXISTS points_event_type")

--- a/app/bot/handlers/__init__.py
+++ b/app/bot/handlers/__init__.py
@@ -7,6 +7,7 @@ from .feedback import router as feedback_router
 from .guarantor import router as guarantor_router
 from .inline_auction import router as inline_auction_router
 from .moderation import router as moderation_router
+from .points import router as points_router
 from .start import router as start_router
 
 router = Router(name="root")
@@ -17,6 +18,7 @@ router.include_router(bid_actions_router)
 router.include_router(inline_auction_router)
 router.include_router(feedback_router)
 router.include_router(guarantor_router)
+router.include_router(points_router)
 router.include_router(moderation_router)
 
 __all__ = ["router"]

--- a/app/bot/handlers/points.py
+++ b/app/bot/handlers/points.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from aiogram import F, Router
+from aiogram.enums import ChatType
+from aiogram.filters import Command
+from aiogram.types import Message
+
+from app.db.enums import PointsEventType
+from app.db.models import PointsLedgerEntry
+from app.db.session import SessionFactory
+from app.services.points_service import get_user_points_balance, list_user_points_entries
+from app.services.user_service import upsert_user
+
+router = Router(name="points")
+
+
+def _event_label(event_type: PointsEventType) -> str:
+    if event_type == PointsEventType.FEEDBACK_APPROVED:
+        return "Награда за фидбек"
+    return "Ручная корректировка"
+
+
+def _render_points_text(*, balance: int, entries: list[PointsLedgerEntry]) -> str:
+    lines = [f"Ваш баланс: {balance} points"]
+    if not entries:
+        lines.append("Начислений пока нет")
+        return "\n".join(lines)
+
+    lines.append("")
+    lines.append("Последние операции:")
+    for entry in entries:
+        created_at = entry.created_at.astimezone().strftime("%d.%m %H:%M")
+        amount_text = f"+{entry.amount}" if entry.amount > 0 else str(entry.amount)
+        lines.append(f"- {created_at} | {amount_text} | {_event_label(PointsEventType(entry.event_type))}")
+    return "\n".join(lines)
+
+
+@router.message(Command("points"), F.chat.type == ChatType.PRIVATE)
+async def command_points(message: Message) -> None:
+    if message.from_user is None:
+        return
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            user = await upsert_user(session, message.from_user, mark_private_started=True)
+            balance = await get_user_points_balance(session, user_id=user.id)
+            entries = await list_user_points_entries(session, user_id=user.id, limit=5)
+
+    await message.answer(_render_points_text(balance=balance, entries=entries))

--- a/app/db/enums.py
+++ b/app/db/enums.py
@@ -73,3 +73,8 @@ class GuarantorRequestStatus(StrEnum):
     NEW = "NEW"
     ASSIGNED = "ASSIGNED"
     REJECTED = "REJECTED"
+
+
+class PointsEventType(StrEnum):
+    FEEDBACK_APPROVED = "FEEDBACK_APPROVED"
+    MANUAL_ADJUSTMENT = "MANUAL_ADJUSTMENT"

--- a/app/main.py
+++ b/app/main.py
@@ -33,6 +33,7 @@ async def configure_bot_commands(bot: Bot) -> None:
         BotCommand(command="bug", description="Сообщить о проблеме"),
         BotCommand(command="suggest", description="Предложить улучшение"),
         BotCommand(command="guarant", description="Запросить гаранта для сделки"),
+        BotCommand(command="points", description="Показать баланс наград"),
         BotCommand(command="modpanel", description="Открыть панель модератора"),
         BotCommand(command="modstats", description="Показать статистику модерации"),
         BotCommand(command="emojiid", description="Получить ID premium emoji (для UI)"),

--- a/app/services/points_service.py
+++ b/app/services/points_service.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.enums import PointsEventType
+from app.db.models import PointsLedgerEntry
+
+
+@dataclass(slots=True)
+class PointsGrantResult:
+    changed: bool
+    entry: PointsLedgerEntry | None
+
+
+def feedback_reward_dedupe_key(feedback_id: int) -> str:
+    return f"feedback:{feedback_id}:reward"
+
+
+async def grant_points(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    amount: int,
+    event_type: PointsEventType,
+    dedupe_key: str,
+    reason: str,
+    payload: dict | None = None,
+) -> PointsGrantResult:
+    if amount == 0:
+        return PointsGrantResult(changed=False, entry=None)
+
+    now = datetime.now(UTC)
+    stmt = (
+        insert(PointsLedgerEntry)
+        .values(
+            user_id=user_id,
+            amount=amount,
+            event_type=event_type,
+            dedupe_key=dedupe_key,
+            reason=reason,
+            payload=payload,
+            created_at=now,
+            updated_at=now,
+        )
+        .on_conflict_do_nothing(index_elements=[PointsLedgerEntry.dedupe_key])
+        .returning(PointsLedgerEntry.id)
+    )
+    inserted_id = await session.scalar(stmt)
+    if inserted_id is None:
+        existing = await session.scalar(
+            select(PointsLedgerEntry).where(PointsLedgerEntry.dedupe_key == dedupe_key)
+        )
+        return PointsGrantResult(changed=False, entry=existing)
+
+    entry = await session.scalar(select(PointsLedgerEntry).where(PointsLedgerEntry.id == inserted_id))
+    return PointsGrantResult(changed=True, entry=entry)
+
+
+async def get_user_points_balance(session: AsyncSession, *, user_id: int) -> int:
+    total = await session.scalar(
+        select(func.coalesce(func.sum(PointsLedgerEntry.amount), 0)).where(PointsLedgerEntry.user_id == user_id)
+    )
+    return int(total or 0)
+
+
+async def list_user_points_entries(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    limit: int = 5,
+) -> list[PointsLedgerEntry]:
+    safe_limit = max(1, min(limit, 20))
+    rows = await session.execute(
+        select(PointsLedgerEntry)
+        .where(PointsLedgerEntry.user_id == user_id)
+        .order_by(PointsLedgerEntry.created_at.desc(), PointsLedgerEntry.id.desc())
+        .limit(safe_limit)
+    )
+    return list(rows.scalars().all())

--- a/tests/integration/test_points_command.py
+++ b/tests/integration/test_points_command.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.bot.handlers.points import command_points
+from app.db.enums import PointsEventType
+from app.services.points_service import grant_points
+
+
+class _DummyFromUser:
+    def __init__(self, user_id: int) -> None:
+        self.id = user_id
+        self.username = f"user{user_id}"
+        self.first_name = "Test"
+        self.last_name = "User"
+
+
+class _DummyMessage:
+    def __init__(self, from_user_id: int) -> None:
+        self.from_user = _DummyFromUser(from_user_id)
+        self.answers: list[str] = []
+
+    async def answer(self, text: str, **_kwargs) -> None:
+        self.answers.append(text)
+
+
+@pytest.mark.asyncio
+async def test_points_command_shows_balance_and_history(monkeypatch, integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr("app.bot.handlers.points.SessionFactory", session_factory)
+
+    message = _DummyMessage(from_user_id=93601)
+
+    async with session_factory() as session:
+        async with session.begin():
+            from app.services.user_service import upsert_user
+
+            user = await upsert_user(session, message.from_user, mark_private_started=True)
+            await grant_points(
+                session,
+                user_id=user.id,
+                amount=30,
+                event_type=PointsEventType.FEEDBACK_APPROVED,
+                dedupe_key="feedback:701:reward",
+                reason="Награда за одобренный фидбек",
+            )
+            await grant_points(
+                session,
+                user_id=user.id,
+                amount=-5,
+                event_type=PointsEventType.MANUAL_ADJUSTMENT,
+                dedupe_key="manual:701:penalty",
+                reason="Корректировка",
+            )
+
+    await command_points(message)
+
+    assert message.answers
+    reply_text = message.answers[-1]
+    assert "Ваш баланс: 25 points" in reply_text
+    assert "Последние операции:" in reply_text
+    assert "-5" in reply_text

--- a/tests/integration/test_points_service.py
+++ b/tests/integration/test_points_service.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.db.enums import PointsEventType
+from app.db.models import PointsLedgerEntry, User
+from app.services.points_service import (
+    get_user_points_balance,
+    grant_points,
+    list_user_points_entries,
+)
+
+
+@pytest.mark.asyncio
+async def test_grant_points_is_idempotent_by_dedupe_key(integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with session_factory() as session:
+        async with session.begin():
+            user = User(tg_user_id=93501, username="points_user")
+            session.add(user)
+            await session.flush()
+
+            first = await grant_points(
+                session,
+                user_id=user.id,
+                amount=30,
+                event_type=PointsEventType.FEEDBACK_APPROVED,
+                dedupe_key="feedback:501:reward",
+                reason="Награда за одобренный фидбек",
+            )
+            second = await grant_points(
+                session,
+                user_id=user.id,
+                amount=30,
+                event_type=PointsEventType.FEEDBACK_APPROVED,
+                dedupe_key="feedback:501:reward",
+                reason="Награда за одобренный фидбек",
+            )
+
+            assert first.changed is True
+            assert second.changed is False
+
+    async with session_factory() as session:
+        entries = (
+            await session.execute(
+                select(PointsLedgerEntry)
+                .where(PointsLedgerEntry.dedupe_key == "feedback:501:reward")
+                .order_by(PointsLedgerEntry.id.asc())
+            )
+        ).scalars().all()
+        balance = await get_user_points_balance(session, user_id=entries[0].user_id)
+
+    assert len(entries) == 1
+    assert entries[0].amount == 30
+    assert entries[0].event_type == PointsEventType.FEEDBACK_APPROVED
+    assert balance == 30
+
+
+@pytest.mark.asyncio
+async def test_points_balance_and_recent_entries(integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with session_factory() as session:
+        async with session.begin():
+            user = User(tg_user_id=93511, username="points_history")
+            session.add(user)
+            await session.flush()
+
+            await grant_points(
+                session,
+                user_id=user.id,
+                amount=20,
+                event_type=PointsEventType.FEEDBACK_APPROVED,
+                dedupe_key="feedback:611:reward",
+                reason="Награда за одобренный фидбек",
+            )
+            await grant_points(
+                session,
+                user_id=user.id,
+                amount=-5,
+                event_type=PointsEventType.MANUAL_ADJUSTMENT,
+                dedupe_key="manual:611:decay",
+                reason="Корректировка",
+            )
+            await grant_points(
+                session,
+                user_id=user.id,
+                amount=10,
+                event_type=PointsEventType.MANUAL_ADJUSTMENT,
+                dedupe_key="manual:611:bonus",
+                reason="Бонус",
+            )
+
+    async with session_factory() as session:
+        balance = await get_user_points_balance(session, user_id=user.id)
+        recent = await list_user_points_entries(session, user_id=user.id, limit=2)
+
+    assert balance == 25
+    assert len(recent) == 2
+    assert recent[0].dedupe_key == "manual:611:bonus"
+    assert recent[1].dedupe_key == "manual:611:decay"


### PR DESCRIPTION
## Summary
- add a dedicated `points_ledger` table and `PointsEventType` domain model with dedupe keys so reward accrual is persistent and idempotent
- wire feedback approval rewards through ledger writes (`feedback:<id>:reward`) while preserving existing moderation/outbox behavior
- add user-facing `/points` command in private chat to show current balance and recent reward operations, plus integration tests for ledger idempotency and command output

## Validation
- `.venv/bin/python -m ruff check app tests alembic`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@172.20.0.4:5432/auction_test .venv/bin/python -m pytest -q tests/integration`
- integration anti-flaky rerun with the same command