### PR TITLE
feat: expand points history UX in bot commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_te
 
 ```text
 /modpoints <tg_user_id>
+/modpoints <tg_user_id> <limit>
 /modpoints <tg_user_id> <amount> <reason>
 ```
 
@@ -371,6 +372,7 @@ Use it as a reply to a message that contains premium/custom emoji.
 /suggest <предложение>
 /guarant <запрос на гаранта>
 /points
+/points <1..20>
 ```
 
 - Include moderation queue destination in env (recommended):

--- a/app/bot/handlers/points.py
+++ b/app/bot/handlers/points.py
@@ -8,10 +8,12 @@ from aiogram.types import Message
 from app.db.enums import PointsEventType
 from app.db.models import PointsLedgerEntry
 from app.db.session import SessionFactory
-from app.services.points_service import get_user_points_balance, list_user_points_entries
+from app.services.points_service import UserPointsSummary, get_user_points_summary, list_user_points_entries
 from app.services.user_service import upsert_user
 
 router = Router(name="points")
+DEFAULT_POINTS_HISTORY_LIMIT = 5
+MAX_POINTS_HISTORY_LIMIT = 20
 
 
 def _event_label(event_type: PointsEventType) -> str:
@@ -20,14 +22,29 @@ def _event_label(event_type: PointsEventType) -> str:
     return "Ручная корректировка"
 
 
-def _render_points_text(*, balance: int, entries: list[PointsLedgerEntry]) -> str:
-    lines = [f"Ваш баланс: {balance} points"]
+def _parse_history_limit(raw: str | None) -> int | None:
+    if raw is None:
+        return DEFAULT_POINTS_HISTORY_LIMIT
+    if not raw.isdigit():
+        return None
+    value = int(raw)
+    if value < 1 or value > MAX_POINTS_HISTORY_LIMIT:
+        return None
+    return value
+
+
+def _render_points_text(*, summary: UserPointsSummary, entries: list[PointsLedgerEntry], shown_limit: int) -> str:
+    lines = [
+        f"Ваш баланс: {summary.balance} points",
+        f"Всего начислено: +{summary.total_earned}",
+        f"Всего списано: -{summary.total_spent}",
+    ]
     if not entries:
         lines.append("Начислений пока нет")
         return "\n".join(lines)
 
     lines.append("")
-    lines.append("Последние операции:")
+    lines.append(f"Последние операции (до {shown_limit}):")
     for entry in entries:
         created_at = entry.created_at.astimezone().strftime("%d.%m %H:%M")
         amount_text = f"+{entry.amount}" if entry.amount > 0 else str(entry.amount)
@@ -40,10 +57,19 @@ async def command_points(message: Message) -> None:
     if message.from_user is None:
         return
 
+    parts = (message.text or "").split()
+    if len(parts) > 2:
+        await message.answer(f"Формат: /points [1..{MAX_POINTS_HISTORY_LIMIT}]")
+        return
+    limit = _parse_history_limit(parts[1] if len(parts) == 2 else None)
+    if limit is None:
+        await message.answer(f"Формат: /points [1..{MAX_POINTS_HISTORY_LIMIT}]")
+        return
+
     async with SessionFactory() as session:
         async with session.begin():
             user = await upsert_user(session, message.from_user, mark_private_started=True)
-            balance = await get_user_points_balance(session, user_id=user.id)
-            entries = await list_user_points_entries(session, user_id=user.id, limit=5)
+            summary = await get_user_points_summary(session, user_id=user.id)
+            entries = await list_user_points_entries(session, user_id=user.id, limit=limit)
 
-    await message.answer(_render_points_text(balance=balance, entries=entries))
+    await message.answer(_render_points_text(summary=summary, entries=entries, shown_limit=limit))

--- a/tests/integration/test_points_command.py
+++ b/tests/integration/test_points_command.py
@@ -17,8 +17,9 @@ class _DummyFromUser:
 
 
 class _DummyMessage:
-    def __init__(self, from_user_id: int) -> None:
+    def __init__(self, from_user_id: int, text: str = "/points") -> None:
         self.from_user = _DummyFromUser(from_user_id)
+        self.text = text
         self.answers: list[str] = []
 
     async def answer(self, text: str, **_kwargs) -> None:
@@ -59,5 +60,56 @@ async def test_points_command_shows_balance_and_history(monkeypatch, integration
     assert message.answers
     reply_text = message.answers[-1]
     assert "Ваш баланс: 25 points" in reply_text
-    assert "Последние операции:" in reply_text
+    assert "Всего начислено: +30" in reply_text
+    assert "Всего списано: -5" in reply_text
+    assert "Последние операции (до 5):" in reply_text
     assert "-5" in reply_text
+
+
+@pytest.mark.asyncio
+async def test_points_command_supports_custom_limit(monkeypatch, integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr("app.bot.handlers.points.SessionFactory", session_factory)
+
+    message = _DummyMessage(from_user_id=93611, text="/points 1")
+
+    async with session_factory() as session:
+        async with session.begin():
+            from app.services.user_service import upsert_user
+
+            user = await upsert_user(session, message.from_user, mark_private_started=True)
+            await grant_points(
+                session,
+                user_id=user.id,
+                amount=10,
+                event_type=PointsEventType.MANUAL_ADJUSTMENT,
+                dedupe_key="manual:711:1",
+                reason="seed",
+            )
+            await grant_points(
+                session,
+                user_id=user.id,
+                amount=20,
+                event_type=PointsEventType.FEEDBACK_APPROVED,
+                dedupe_key="feedback:711:reward",
+                reason="seed",
+            )
+
+    await command_points(message)
+
+    assert message.answers
+    reply_text = message.answers[-1]
+    assert "Последние операции (до 1):" in reply_text
+    assert reply_text.count("\n-") == 1
+
+
+@pytest.mark.asyncio
+async def test_points_command_rejects_invalid_limit(monkeypatch, integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr("app.bot.handlers.points.SessionFactory", session_factory)
+
+    message = _DummyMessage(from_user_id=93621, text="/points 0")
+    await command_points(message)
+
+    assert message.answers
+    assert "Формат: /points [1..20]" in message.answers[-1]

--- a/tests/integration/test_points_service.py
+++ b/tests/integration/test_points_service.py
@@ -8,6 +8,7 @@ from app.db.enums import PointsEventType
 from app.db.models import PointsLedgerEntry, User
 from app.services.points_service import (
     get_user_points_balance,
+    get_user_points_summary,
     grant_points,
     list_user_points_entries,
 )
@@ -96,9 +97,14 @@ async def test_points_balance_and_recent_entries(integration_engine) -> None:
 
     async with session_factory() as session:
         balance = await get_user_points_balance(session, user_id=user.id)
+        summary = await get_user_points_summary(session, user_id=user.id)
         recent = await list_user_points_entries(session, user_id=user.id, limit=2)
 
     assert balance == 25
+    assert summary.balance == 25
+    assert summary.total_earned == 30
+    assert summary.total_spent == 5
+    assert summary.operations_count == 3
     assert len(recent) == 2
     assert recent[0].dedupe_key == "manual:611:bonus"
     assert recent[1].dedupe_key == "manual:611:decay"


### PR DESCRIPTION
## Summary
- extend `/points` with optional history limit (`/points <1..20>`) and richer output that includes balance, total earned, and total spent points
- extend `/modpoints` view mode with optional history limit (`/modpoints <tg_user_id> <limit>`) and the same richer balance snapshot while preserving manual adjustment flow
- add `get_user_points_summary` service aggregate and update integration coverage for custom limits, invalid input handling, and totals rendering

## Validation
- `.venv/bin/python -m ruff check app tests alembic`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@172.20.0.4:5432/auction_test .venv/bin/python -m pytest -q tests/integration` (db unavailable in current compose network -> expected skips)
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@172.20.0.2:5432/auction_test .venv/bin/python -m pytest -q tests/integration`
- integration anti-flaky rerun with the same `172.20.0.2` command