### PR TITLE
feat: add modpoints history filters and paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_te
 /modpoints <tg_user_id>
 /modpoints <tg_user_id> <limit>
 /modpoints <tg_user_id> <amount> <reason>
+/modpoints_history <tg_user_id> [page] [all|feedback|manual]
 ```
 
 - Open stateful moderation panel:

--- a/tests/integration/test_modpoints_command.py
+++ b/tests/integration/test_modpoints_command.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from app.bot.handlers.moderation import mod_points
+from app.bot.handlers.moderation import mod_points, mod_points_history
 from app.db.enums import ModerationAction, PointsEventType
 from app.db.models import ModerationLog, PointsLedgerEntry, User
 from app.services.points_service import get_user_points_balance
@@ -209,3 +209,105 @@ async def test_modpoints_denied_for_operator_without_scope(monkeypatch, integrat
         balance = await get_user_points_balance(session, user_id=target.id)
 
     assert balance == 0
+
+
+@pytest.mark.asyncio
+async def test_modpoints_history_supports_filter_and_page(monkeypatch, integration_engine) -> None:
+    from app.config import settings
+
+    owner_tg_user_id = 93741
+    target_tg_user_id = 93742
+    monkeypatch.setattr(settings, "admin_user_ids", str(owner_tg_user_id))
+    monkeypatch.setattr(settings, "admin_operator_user_ids", "")
+
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr("app.bot.handlers.moderation.SessionFactory", session_factory)
+
+    async with session_factory() as session:
+        async with session.begin():
+            target_user = User(tg_user_id=target_tg_user_id)
+            session.add(target_user)
+            await session.flush()
+
+            for idx in range(12):
+                session.add(
+                    PointsLedgerEntry(
+                        user_id=target_user.id,
+                        amount=1,
+                        event_type=PointsEventType.MANUAL_ADJUSTMENT,
+                        dedupe_key=f"manual:history:{idx}",
+                        reason=f"manual-{idx}",
+                        payload=None,
+                    )
+                )
+            session.add(
+                PointsLedgerEntry(
+                    user_id=target_user.id,
+                    amount=30,
+                    event_type=PointsEventType.FEEDBACK_APPROVED,
+                    dedupe_key="feedback:history:1",
+                    reason="feedback",
+                    payload=None,
+                )
+            )
+
+    message = _DummyMessage(
+        text=f"/modpoints_history {target_tg_user_id} 2 manual",
+        from_user_id=owner_tg_user_id,
+    )
+    await mod_points_history(message)
+
+    assert message.answers
+    reply = message.answers[-1]
+    assert "фильтр: manual" in reply
+    assert "стр. 2/2" in reply
+    assert "Всего записей: 12" in reply
+
+
+@pytest.mark.asyncio
+async def test_modpoints_history_rejects_invalid_args(monkeypatch, integration_engine) -> None:
+    from app.config import settings
+
+    owner_tg_user_id = 93751
+    target_tg_user_id = 93752
+    monkeypatch.setattr(settings, "admin_user_ids", str(owner_tg_user_id))
+    monkeypatch.setattr(settings, "admin_operator_user_ids", "")
+
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr("app.bot.handlers.moderation.SessionFactory", session_factory)
+
+    async with session_factory() as session:
+        async with session.begin():
+            target_user = User(tg_user_id=target_tg_user_id)
+            session.add(target_user)
+
+    message = _DummyMessage(text=f"/modpoints_history {target_tg_user_id} 0 weird", from_user_id=owner_tg_user_id)
+    await mod_points_history(message)
+
+    assert message.answers
+    assert "Некорректная страница" in message.answers[-1] or "Формат:" in message.answers[-1]
+
+
+@pytest.mark.asyncio
+async def test_modpoints_history_denied_for_operator_without_scope(monkeypatch, integration_engine) -> None:
+    from app.config import settings
+
+    owner_tg_user_id = 93761
+    operator_tg_user_id = 93762
+    target_tg_user_id = 93763
+    monkeypatch.setattr(settings, "admin_user_ids", f"{owner_tg_user_id},{operator_tg_user_id}")
+    monkeypatch.setattr(settings, "admin_operator_user_ids", str(operator_tg_user_id))
+
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr("app.bot.handlers.moderation.SessionFactory", session_factory)
+
+    async with session_factory() as session:
+        async with session.begin():
+            target_user = User(tg_user_id=target_tg_user_id)
+            session.add(target_user)
+
+    message = _DummyMessage(text=f"/modpoints_history {target_tg_user_id}", from_user_id=operator_tg_user_id)
+    await mod_points_history(message)
+
+    assert message.answers
+    assert "Недостаточно прав" in message.answers[-1]


### PR DESCRIPTION
## Summary
- add `/modpoints_history` command for moderators with paging and type filters (`all|feedback|manual`) to inspect reward ledger activity in Telegram
- extend points service with filtered/offset listing and count helpers used to render deterministic history pages
- add integration coverage for filtered paging, invalid args, and scope denial; update README command reference

## Validation
- `.venv/bin/python -m ruff check app tests alembic`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@172.20.0.2:5432/auction_test .venv/bin/python -m pytest -q tests/integration`
- integration anti-flaky rerun with the same command