### PR TITLE
feat: add rewards widget to user admin page

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - Visual foundation refresh for admin web layout, controls, and responsive readability
 - Final visual polish and release-readiness checklist with consolidated QA evidence template
 - Section-based moderation topic routing and user feedback/guarantor intake commands (`/bug`, `/suggest`, `/guarant`)
-- Rewards ledger foundation with idempotent points accrual, user `/points`, and moderator manual adjustments
+- Rewards ledger foundation with idempotent points accrual, advanced `/points`, moderator `/modpoints` + `/modpoints_history`, and admin user-page rewards widget
 - Outbox-driven automation for approved feedback -> GitHub issue creation with retry/backoff
 
 ## Sprint 0 Checklist

--- a/tests/integration/test_web_manage_user_rewards.py
+++ b/tests/integration/test_web_manage_user_rewards.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from starlette.requests import Request
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.db.enums import PointsEventType
+from app.db.models import PointsLedgerEntry, User
+from app.services.rbac_service import (
+    SCOPE_AUCTION_MANAGE,
+    SCOPE_BID_MANAGE,
+    SCOPE_ROLE_MANAGE,
+    SCOPE_USER_BAN,
+)
+from app.web.auth import AdminAuthContext
+from app.web.main import manage_user
+
+
+def _make_request(path: str, query: str = "") -> Request:
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("utf-8"),
+        "query_string": query.encode("utf-8"),
+        "headers": [],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(scope, receive)
+
+
+def _stub_auth() -> AdminAuthContext:
+    return AdminAuthContext(
+        authorized=True,
+        via="token",
+        role="owner",
+        can_manage=True,
+        scopes=frozenset({SCOPE_AUCTION_MANAGE, SCOPE_BID_MANAGE, SCOPE_USER_BAN, SCOPE_ROLE_MANAGE}),
+        tg_user_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_manage_user_shows_points_widget(monkeypatch, integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with session_factory() as session:
+        async with session.begin():
+            user = User(tg_user_id=93801, username="rewards_user")
+            session.add(user)
+            await session.flush()
+
+            session.add(
+                PointsLedgerEntry(
+                    user_id=user.id,
+                    amount=30,
+                    event_type=PointsEventType.FEEDBACK_APPROVED,
+                    dedupe_key="feedback:web:1",
+                    reason="Награда",
+                    payload=None,
+                    created_at=datetime.now(UTC),
+                )
+            )
+            session.add(
+                PointsLedgerEntry(
+                    user_id=user.id,
+                    amount=-5,
+                    event_type=PointsEventType.MANUAL_ADJUSTMENT,
+                    dedupe_key="manual:web:1",
+                    reason="Корректировка",
+                    payload=None,
+                    created_at=datetime.now(UTC),
+                )
+            )
+            user_id = user.id
+
+    monkeypatch.setattr("app.web.main.SessionFactory", session_factory)
+    monkeypatch.setattr("app.web.main._auth_context_or_unauthorized", lambda _req: (None, _stub_auth()))
+    monkeypatch.setattr("app.web.main._csrf_hidden_input", lambda *_args, **_kwargs: "")
+
+    request = _make_request(f"/manage/user/{user_id}")
+    response = await manage_user(request, user_id=user_id)
+
+    body = bytes(response.body).decode("utf-8")
+    assert response.status_code == 200
+    assert "Rewards / points" in body
+    assert "Points баланс" in body
+    assert "Начислено всего:</b> +30" in body
+    assert "Списано всего:</b> -5" in body
+    assert "Награда за фидбек" in body
+    assert "Ручная корректировка" in body
+
+
+@pytest.mark.asyncio
+async def test_manage_user_points_filter_and_paging(monkeypatch, integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with session_factory() as session:
+        async with session.begin():
+            user = User(tg_user_id=93811, username="rewards_filter")
+            session.add(user)
+            await session.flush()
+
+            for idx in range(11):
+                session.add(
+                    PointsLedgerEntry(
+                        user_id=user.id,
+                        amount=1,
+                        event_type=PointsEventType.MANUAL_ADJUSTMENT,
+                        dedupe_key=f"manual:web:{idx}",
+                        reason=f"manual-{idx}",
+                        payload=None,
+                    )
+                )
+            session.add(
+                PointsLedgerEntry(
+                    user_id=user.id,
+                    amount=20,
+                    event_type=PointsEventType.FEEDBACK_APPROVED,
+                    dedupe_key="feedback:web:2",
+                    reason="feedback",
+                    payload=None,
+                )
+            )
+            user_id = user.id
+
+    monkeypatch.setattr("app.web.main.SessionFactory", session_factory)
+    monkeypatch.setattr("app.web.main._auth_context_or_unauthorized", lambda _req: (None, _stub_auth()))
+    monkeypatch.setattr("app.web.main._csrf_hidden_input", lambda *_args, **_kwargs: "")
+
+    request = _make_request(f"/manage/user/{user_id}", query="points_page=2&points_filter=manual")
+    response = await manage_user(request, user_id=user_id, points_page=2, points_filter="manual")
+
+    body = bytes(response.body).decode("utf-8")
+    assert response.status_code == 200
+    assert "Фильтр:</b> manual" in body
+    assert "Страница:</b> 2/2" in body
+    assert "Записей:</b>" in body
+    assert "manual-0" in body
+    assert "manual-10" not in body
+    assert "points_page=1&amp;points_filter=manual" in body


### PR DESCRIPTION
## Summary
- add rewards widget to `/manage/user/{id}` showing points balance, totals, and recent ledger operations directly in admin web
- support filterable and paginated points history in web (`points_filter=all|feedback|manual`, `points_page`) while preserving existing manage-user moderation controls
- add integration tests for widget rendering and filtered paging behavior, and document admin rewards visibility in README

## Validation
- `.venv/bin/python -m ruff check app tests alembic`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@172.20.0.2:5432/auction_test .venv/bin/python -m pytest -q tests/integration`
- integration anti-flaky rerun with the same command