### PR TITLE
feat: add web points adjustment action for rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,14 @@ TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_te
 /modpoints_history <tg_user_id> [page] [all|feedback|manual]
 ```
 
+- Adjust user reward balance from admin web (requires `role:manage` scope):
+
+```text
+/manage/users -> open user -> Rewards / points -> amount (+/-), reason -> Применить
+```
+
+The web action uses an idempotent key per form submit (`action_id`) to prevent duplicate ledger writes on repeated submit.
+
 - Open stateful moderation panel:
 
 ```text


### PR DESCRIPTION
## Summary
- add admin web action `POST /actions/user/points/adjust` with `role:manage` scope check, CSRF validation, signed amount validation, and idempotent dedupe key handling
- extend `/manage/user/{id}` rewards widget with manual adjustment form (`amount`, `reason`, `action_id`) while preserving points paging/filter context on redirect
- write moderation audit log entries (`ADJUST_USER_POINTS`) for successful web adjustments and keep repeated submits idempotent
- add integration coverage for success path, scope denial, CSRF enforcement, and idempotency; update README with web usage flow

## Validation
- `.venv/bin/python -m ruff check app tests alembic`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@172.20.0.2:5432/auction_test .venv/bin/python -m pytest -q tests/integration`
- same integration command repeated once (anti-flaky)