### PR TITLE
feat: add user risk snapshot indicators in admin

### DIFF
--- a/app/services/risk_eval_service.py
+++ b/app/services/risk_eval_service.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True, frozen=True)
+class UserRiskSnapshot:
+    score: int
+    level: str
+    reasons: tuple[str, ...]
+
+
+def evaluate_user_risk_snapshot(
+    *,
+    complaints_against: int,
+    open_fraud_signals: int,
+    has_active_blacklist: bool,
+    removed_bids: int,
+) -> UserRiskSnapshot:
+    score = 0
+    reasons: list[str] = []
+
+    if has_active_blacklist:
+        score += 60
+        reasons.append("ACTIVE_BLACKLIST")
+
+    if open_fraud_signals > 0:
+        score += 40
+        reasons.append("OPEN_FRAUD_SIGNAL")
+
+    if complaints_against >= 3:
+        score += 30
+        reasons.append("COMPLAINTS_AGAINST_3PLUS")
+    elif complaints_against >= 1:
+        score += 15
+        reasons.append("COMPLAINTS_AGAINST")
+
+    if removed_bids >= 3:
+        score += 15
+        reasons.append("REMOVED_BIDS_3PLUS")
+    elif removed_bids >= 1:
+        score += 8
+        reasons.append("REMOVED_BIDS")
+
+    score = min(score, 100)
+
+    if score >= 70:
+        level = "HIGH"
+    elif score >= 35:
+        level = "MEDIUM"
+    else:
+        level = "LOW"
+
+    return UserRiskSnapshot(score=score, level=level, reasons=tuple(reasons))

--- a/tests/integration/test_web_manage_user_rewards.py
+++ b/tests/integration/test_web_manage_user_rewards.py
@@ -97,6 +97,9 @@ async def test_manage_user_shows_points_widget(monkeypatch, integration_engine) 
     assert response.status_code == 200
     assert "Rewards / points" in body
     assert "Points баланс" in body
+    assert "Риск-уровень:</b> LOW" in body
+    assert "Риск-скор:</b> 0" in body
+    assert "Риск-факторы:</b> -" in body
     assert "Начислено всего:</b> +30" in body
     assert "Списано всего:</b> -5" in body
     assert "Награда за фидбек" in body

--- a/tests/test_risk_eval_service.py
+++ b/tests/test_risk_eval_service.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from app.services.risk_eval_service import evaluate_user_risk_snapshot
+
+
+def test_evaluate_user_risk_snapshot_low() -> None:
+    snapshot = evaluate_user_risk_snapshot(
+        complaints_against=0,
+        open_fraud_signals=0,
+        has_active_blacklist=False,
+        removed_bids=0,
+    )
+
+    assert snapshot.level == "LOW"
+    assert snapshot.score == 0
+    assert snapshot.reasons == ()
+
+
+def test_evaluate_user_risk_snapshot_medium() -> None:
+    snapshot = evaluate_user_risk_snapshot(
+        complaints_against=1,
+        open_fraud_signals=1,
+        has_active_blacklist=False,
+        removed_bids=1,
+    )
+
+    assert snapshot.level == "MEDIUM"
+    assert snapshot.score == 63
+    assert snapshot.reasons == ("OPEN_FRAUD_SIGNAL", "COMPLAINTS_AGAINST", "REMOVED_BIDS")
+
+
+def test_evaluate_user_risk_snapshot_high_and_capped() -> None:
+    snapshot = evaluate_user_risk_snapshot(
+        complaints_against=8,
+        open_fraud_signals=3,
+        has_active_blacklist=True,
+        removed_bids=7,
+    )
+
+    assert snapshot.level == "HIGH"
+    assert snapshot.score == 100
+    assert snapshot.reasons == (
+        "ACTIVE_BLACKLIST",
+        "OPEN_FRAUD_SIGNAL",
+        "COMPLAINTS_AGAINST_3PLUS",
+        "REMOVED_BIDS_3PLUS",
+    )


### PR DESCRIPTION
## Summary
- add `evaluate_user_risk_snapshot` service to calculate deterministic user risk level, score, and reason codes from complaints, open fraud signals, blacklist status, and removed bids
- surface risk level/score/reason labels on `/manage/user/{id}` so moderators can quickly triage risky profiles
- add unit tests for low/medium/high+capped scoring and extend integration coverage for manage user page rendering

## Validation
- `.venv/bin/python -m ruff check app tests alembic`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@172.20.0.2:5432/auction_test .venv/bin/python -m pytest -q tests/integration`
- same integration command repeated once (anti-flaky)