### PR TITLE
feat: gate high-risk auction publishing by guarantor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - Startup and container health checks for DB/Redis
 - FSM lot creation in private chat (`/newauction`)
 - Inline auction publishing via `auc_<id>` and `chosen_inline_result`
+- High-risk publish gate requiring assigned guarantor for risky sellers
 - Live post updates after bids (`top-3`, current price, ending time)
 - Buyout, anti-sniper (`2m -> +3m`, max `3`) and anti-mistake protections
 - Background watcher for expired auctions
@@ -384,6 +385,8 @@ Use it as a reply to a message that contains premium/custom emoji.
 /points <1..20>
 ```
 
+High-risk sellers cannot publish drafts until a guarantor request is assigned by moderation.
+
 - Include moderation queue destination in env (recommended):
 
 ```text
@@ -410,6 +413,8 @@ FEEDBACK_BUG_REWARD_POINTS=30
 FEEDBACK_SUGGESTION_REWARD_POINTS=20
 GUARANTOR_INTAKE_MIN_LENGTH=10
 GUARANTOR_INTAKE_COOLDOWN_SECONDS=180
+PUBLISH_HIGH_RISK_REQUIRES_GUARANTOR=true
+PUBLISH_GUARANTOR_ASSIGNMENT_MAX_AGE_DAYS=30
 GITHUB_AUTOMATION_ENABLED=true
 GITHUB_TOKEN=ghp_xxx
 GITHUB_REPO_OWNER=Nombah501

--- a/app/config.py
+++ b/app/config.py
@@ -81,6 +81,8 @@ class Settings(BaseSettings):
     feedback_suggestion_reward_points: int = 20
     guarantor_intake_min_length: int = 10
     guarantor_intake_cooldown_seconds: int = 180
+    publish_high_risk_requires_guarantor: bool = True
+    publish_guarantor_assignment_max_age_days: int = 30
     github_automation_enabled: bool = False
     github_token: str = ""
     github_repo_owner: str = "Nombah501"

--- a/app/services/publish_gate_service.py
+++ b/app/services/publish_gate_service.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.db.models import Bid, BlacklistEntry, Complaint, FraudSignal
+from app.services.guarantor_service import has_assigned_guarantor_request
+from app.services.risk_eval_service import evaluate_user_risk_snapshot, format_risk_reason_label
+
+
+@dataclass(slots=True, frozen=True)
+class SellerPublishGateResult:
+    allowed: bool
+    risk_level: str
+    risk_score: int
+    risk_reasons: tuple[str, ...]
+    block_message: str | None = None
+
+
+def _build_block_message(*, risk_score: int, risk_reasons: tuple[str, ...]) -> str:
+    factors = ", ".join(format_risk_reason_label(code) for code in risk_reasons) if risk_reasons else "без детализации"
+    return (
+        "Публикация лота временно ограничена: высокий риск-профиль продавца "
+        f"(score={risk_score}). Факторы: {factors}.\n"
+        "Для публикации нужен назначенный гарант. Отправьте /guarant в личном чате с ботом."
+    )
+
+
+async def evaluate_seller_publish_gate(
+    session: AsyncSession,
+    *,
+    seller_user_id: int,
+) -> SellerPublishGateResult:
+    complaints_against = int(
+        await session.scalar(select(func.count(Complaint.id)).where(Complaint.target_user_id == seller_user_id))
+        or 0
+    )
+    open_fraud_signals = int(
+        await session.scalar(
+            select(func.count(FraudSignal.id)).where(
+                FraudSignal.user_id == seller_user_id,
+                FraudSignal.status == "OPEN",
+            )
+        )
+        or 0
+    )
+    has_active_blacklist = (
+        await session.scalar(
+            select(BlacklistEntry.id).where(
+                BlacklistEntry.user_id == seller_user_id,
+                BlacklistEntry.is_active.is_(True),
+            )
+        )
+        is not None
+    )
+    removed_bids = int(
+        await session.scalar(
+            select(func.count(Bid.id)).where(
+                Bid.user_id == seller_user_id,
+                Bid.is_removed.is_(True),
+            )
+        )
+        or 0
+    )
+
+    risk = evaluate_user_risk_snapshot(
+        complaints_against=complaints_against,
+        open_fraud_signals=open_fraud_signals,
+        has_active_blacklist=has_active_blacklist,
+        removed_bids=removed_bids,
+    )
+
+    if not settings.publish_high_risk_requires_guarantor:
+        return SellerPublishGateResult(
+            allowed=True,
+            risk_level=risk.level,
+            risk_score=risk.score,
+            risk_reasons=risk.reasons,
+        )
+
+    if risk.level != "HIGH":
+        return SellerPublishGateResult(
+            allowed=True,
+            risk_level=risk.level,
+            risk_score=risk.score,
+            risk_reasons=risk.reasons,
+        )
+
+    has_assigned = await has_assigned_guarantor_request(
+        session,
+        submitter_user_id=seller_user_id,
+        max_age_days=max(settings.publish_guarantor_assignment_max_age_days, 0),
+    )
+    if has_assigned:
+        return SellerPublishGateResult(
+            allowed=True,
+            risk_level=risk.level,
+            risk_score=risk.score,
+            risk_reasons=risk.reasons,
+        )
+
+    return SellerPublishGateResult(
+        allowed=False,
+        risk_level=risk.level,
+        risk_score=risk.score,
+        risk_reasons=risk.reasons,
+        block_message=_build_block_message(risk_score=risk.score, risk_reasons=risk.reasons),
+    )

--- a/app/services/risk_eval_service.py
+++ b/app/services/risk_eval_service.py
@@ -10,6 +10,18 @@ class UserRiskSnapshot:
     reasons: tuple[str, ...]
 
 
+def format_risk_reason_label(reason_code: str) -> str:
+    labels = {
+        "ACTIVE_BLACKLIST": "Активный бан",
+        "OPEN_FRAUD_SIGNAL": "Есть открытые фрод-сигналы",
+        "COMPLAINTS_AGAINST_3PLUS": "3+ жалобы на пользователя",
+        "COMPLAINTS_AGAINST": "Есть жалобы на пользователя",
+        "REMOVED_BIDS_3PLUS": "3+ снятые ставки",
+        "REMOVED_BIDS": "Есть снятые ставки",
+    }
+    return labels.get(reason_code, reason_code)
+
+
 def evaluate_user_risk_snapshot(
     *,
     complaints_against: int,

--- a/app/web/main.py
+++ b/app/web/main.py
@@ -60,7 +60,7 @@ from app.services.points_service import (
     grant_points,
     list_user_points_entries,
 )
-from app.services.risk_eval_service import evaluate_user_risk_snapshot
+from app.services.risk_eval_service import evaluate_user_risk_snapshot, format_risk_reason_label
 from app.web.auth import (
     AdminAuthContext,
     build_admin_session_cookie,
@@ -488,18 +488,6 @@ def _points_event_label(event_type: PointsEventType) -> str:
     if event_type == PointsEventType.FEEDBACK_APPROVED:
         return "Награда за фидбек"
     return "Ручная корректировка"
-
-
-def _risk_reason_label(reason_code: str) -> str:
-    labels = {
-        "ACTIVE_BLACKLIST": "Активный бан",
-        "OPEN_FRAUD_SIGNAL": "Есть открытые фрод-сигналы",
-        "COMPLAINTS_AGAINST_3PLUS": "3+ жалобы на пользователя",
-        "COMPLAINTS_AGAINST": "Есть жалобы на пользователя",
-        "REMOVED_BIDS_3PLUS": "3+ снятые ставки",
-        "REMOVED_BIDS": "Есть снятые ставки",
-    }
-    return labels.get(reason_code, reason_code)
 
 
 def _is_safe_local_path(path: str | None) -> bool:
@@ -1267,7 +1255,7 @@ async def manage_user(
     )
     risk_reasons_text = "-"
     if risk_snapshot.reasons:
-        risk_reasons_text = ", ".join(_risk_reason_label(code) for code in risk_snapshot.reasons)
+        risk_reasons_text = ", ".join(format_risk_reason_label(code) for code in risk_snapshot.reasons)
 
     complaints_rows = "".join(
         "<tr>"

--- a/tests/integration/test_publish_gate_service.py
+++ b/tests/integration/test_publish_gate_service.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.db.enums import AuctionStatus, GuarantorRequestStatus
+from app.db.models import Auction, Complaint, FraudSignal, GuarantorRequest, User
+from app.services.publish_gate_service import evaluate_seller_publish_gate
+
+
+def _make_auction(*, seller_user_id: int, description: str) -> Auction:
+    return Auction(
+        seller_user_id=seller_user_id,
+        description=description,
+        photo_file_id="photo",
+        start_price=100,
+        buyout_price=None,
+        min_step=5,
+        duration_hours=24,
+        status=AuctionStatus.ACTIVE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_gate_allows_low_risk_user(integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with session_factory() as session:
+        async with session.begin():
+            seller = User(tg_user_id=93901, username="low_risk_seller")
+            session.add(seller)
+            await session.flush()
+
+            gate = await evaluate_seller_publish_gate(session, seller_user_id=seller.id)
+
+    assert gate.allowed is True
+    assert gate.risk_level == "LOW"
+    assert gate.risk_score == 0
+    assert gate.block_message is None
+
+
+@pytest.mark.asyncio
+async def test_publish_gate_blocks_high_risk_without_guarantor(integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with session_factory() as session:
+        async with session.begin():
+            seller = User(tg_user_id=93911, username="high_risk_seller")
+            reporter = User(tg_user_id=93912, username="reporter")
+            session.add_all([seller, reporter])
+            await session.flush()
+
+            auction = _make_auction(seller_user_id=seller.id, description="risk-lot")
+            session.add(auction)
+            await session.flush()
+
+            session.add_all(
+                [
+                    Complaint(
+                        auction_id=auction.id,
+                        reporter_user_id=reporter.id,
+                        target_user_id=seller.id,
+                        reason=f"complaint-{idx}",
+                        status="OPEN",
+                    )
+                    for idx in range(3)
+                ]
+            )
+            session.add(
+                FraudSignal(
+                    auction_id=auction.id,
+                    user_id=seller.id,
+                    bid_id=None,
+                    score=85,
+                    reasons={"rules": [{"code": "TEST", "detail": "risk", "score": 85}]},
+                    status="OPEN",
+                )
+            )
+            await session.flush()
+
+            gate = await evaluate_seller_publish_gate(session, seller_user_id=seller.id)
+
+    assert gate.allowed is False
+    assert gate.risk_level == "HIGH"
+    assert gate.risk_score >= 70
+    assert gate.block_message is not None
+    assert "/guarant" in gate.block_message
+
+
+@pytest.mark.asyncio
+async def test_publish_gate_allows_high_risk_with_recent_assigned_guarantor(integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with session_factory() as session:
+        async with session.begin():
+            seller = User(tg_user_id=93921, username="high_risk_allowed")
+            reporter = User(tg_user_id=93922, username="reporter2")
+            moderator = User(tg_user_id=93923, username="mod2")
+            session.add_all([seller, reporter, moderator])
+            await session.flush()
+
+            auction = _make_auction(seller_user_id=seller.id, description="risk-lot-ok")
+            session.add(auction)
+            await session.flush()
+
+            session.add_all(
+                [
+                    Complaint(
+                        auction_id=auction.id,
+                        reporter_user_id=reporter.id,
+                        target_user_id=seller.id,
+                        reason=f"complaint-{idx}",
+                        status="OPEN",
+                    )
+                    for idx in range(3)
+                ]
+            )
+            session.add(
+                FraudSignal(
+                    auction_id=auction.id,
+                    user_id=seller.id,
+                    bid_id=None,
+                    score=90,
+                    reasons={"rules": [{"code": "TEST", "detail": "risk", "score": 90}]},
+                    status="OPEN",
+                )
+            )
+            now = datetime.now(UTC)
+            session.add(
+                GuarantorRequest(
+                    status=GuarantorRequestStatus.ASSIGNED,
+                    submitter_user_id=seller.id,
+                    moderator_user_id=moderator.id,
+                    details="assigned guarantor",
+                    resolution_note="ok",
+                    resolved_at=now,
+                    updated_at=now,
+                )
+            )
+            await session.flush()
+
+            gate = await evaluate_seller_publish_gate(session, seller_user_id=seller.id)
+
+    assert gate.allowed is True
+    assert gate.risk_level == "HIGH"
+    assert gate.block_message is None
+
+
+@pytest.mark.asyncio
+async def test_publish_gate_blocks_with_stale_assigned_guarantor(integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with session_factory() as session:
+        async with session.begin():
+            seller = User(tg_user_id=93931, username="high_risk_stale")
+            reporter = User(tg_user_id=93932, username="reporter3")
+            moderator = User(tg_user_id=93933, username="mod3")
+            session.add_all([seller, reporter, moderator])
+            await session.flush()
+
+            auction = _make_auction(seller_user_id=seller.id, description="risk-lot-stale")
+            session.add(auction)
+            await session.flush()
+
+            session.add_all(
+                [
+                    Complaint(
+                        auction_id=auction.id,
+                        reporter_user_id=reporter.id,
+                        target_user_id=seller.id,
+                        reason=f"complaint-{idx}",
+                        status="OPEN",
+                    )
+                    for idx in range(3)
+                ]
+            )
+            session.add(
+                FraudSignal(
+                    auction_id=auction.id,
+                    user_id=seller.id,
+                    bid_id=None,
+                    score=88,
+                    reasons={"rules": [{"code": "TEST", "detail": "risk", "score": 88}]},
+                    status="OPEN",
+                )
+            )
+
+            stale = datetime.now(UTC) - timedelta(days=90)
+            session.add(
+                GuarantorRequest(
+                    status=GuarantorRequestStatus.ASSIGNED,
+                    submitter_user_id=seller.id,
+                    moderator_user_id=moderator.id,
+                    details="stale assigned guarantor",
+                    resolution_note="old",
+                    resolved_at=stale,
+                    updated_at=stale,
+                )
+            )
+            await session.flush()
+
+            gate = await evaluate_seller_publish_gate(session, seller_user_id=seller.id)
+
+    assert gate.allowed is False
+    assert gate.risk_level == "HIGH"
+    assert gate.block_message is not None


### PR DESCRIPTION
## Summary
- add seller publish gate evaluation based on deterministic risk snapshot (complaints against, open fraud signals, blacklist, removed bids)
- require an assigned guarantor request for HIGH risk sellers before allowing draft auction publish; include configurable assignment freshness window
- apply the gate in draft creation publish flow and inline publish flow, and send clear user-facing reason with `/guarant` guidance when blocked
- add integration coverage for publish gate behavior (low-risk pass, high-risk block, assigned guarantor pass, stale guarantor block)
- update README with high-risk publish gate behavior and new env settings

## Validation
- `.venv/bin/python -m ruff check app tests alembic`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@172.20.0.2:5432/auction_test .venv/bin/python -m pytest -q tests/integration`
- same integration command repeated once (anti-flaky)