### PR TITLE
feat: surface appeals SLA states and escalation markers

### DIFF
--- a/app/web/main.py
+++ b/app/web/main.py
@@ -126,6 +126,13 @@ def _parse_appeal_overdue_filter(raw: str) -> str:
     raise HTTPException(status_code=400, detail="Invalid appeals overdue filter")
 
 
+def _parse_appeal_escalated_filter(raw: str) -> str:
+    value = raw.strip().lower()
+    if value in {"all", "only", "none"}:
+        return value
+    raise HTTPException(status_code=400, detail="Invalid appeals escalated filter")
+
+
 def _appeal_source_label(source_type: AppealSourceType, source_id: int | None) -> str:
     if source_type == AppealSourceType.COMPLAINT:
         return f"Жалоба #{source_id}" if source_id is not None else "Жалоба"
@@ -156,6 +163,44 @@ def _appeal_is_overdue(appeal: Appeal, *, now: datetime | None = None) -> bool:
         return False
     current_time = now or datetime.now(UTC)
     return appeal.sla_deadline_at <= current_time
+
+
+def _format_duration_compact(delta: timedelta) -> str:
+    total_seconds = max(int(delta.total_seconds()), 0)
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes = remainder // 60
+    if hours > 0:
+        return f"{hours}ч {minutes}м"
+    return f"{minutes}м"
+
+
+def _appeal_sla_state_label(appeal: Appeal, *, now: datetime | None = None) -> str:
+    status = AppealStatus(appeal.status)
+    if status not in {AppealStatus.OPEN, AppealStatus.IN_REVIEW}:
+        return "Закрыта"
+
+    if appeal.sla_deadline_at is None:
+        return "Без SLA"
+
+    current_time = now or datetime.now(UTC)
+    if appeal.sla_deadline_at <= current_time:
+        escalation_level = int(appeal.escalation_level or 0)
+        if appeal.escalated_at is not None or escalation_level > 0:
+            return f"Просрочена, эскалация L{max(escalation_level, 1)}"
+        return "Просрочена"
+
+    return f"До SLA: {_format_duration_compact(appeal.sla_deadline_at - current_time)}"
+
+
+def _appeal_escalation_marker(appeal: Appeal) -> str:
+    escalation_level = int(appeal.escalation_level or 0)
+    if appeal.escalated_at is None and escalation_level <= 0:
+        return "-"
+
+    normalized_level = max(escalation_level, 1)
+    if appeal.escalated_at is None:
+        return f"L{normalized_level}"
+    return f"L{normalized_level} ({_fmt_ts(appeal.escalated_at)})"
 
 
 def _violator_status_label(status: str) -> str:
@@ -1690,6 +1735,7 @@ async def appeals(
     status: str = "open",
     source: str = "all",
     overdue: str = "all",
+    escalated: str = "all",
     page: int = 0,
     q: str = "",
 ) -> Response:
@@ -1704,6 +1750,7 @@ async def appeals(
     status_value = status.strip().lower()
     source_value = source.strip().lower()
     overdue_value = _parse_appeal_overdue_filter(overdue)
+    escalated_value = _parse_appeal_escalated_filter(escalated)
     now = datetime.now(UTC)
 
     status_filter = _parse_appeal_status_filter(status_value)
@@ -1736,6 +1783,11 @@ async def appeals(
             )
         )
 
+    if escalated_value == "only":
+        stmt = stmt.where(or_(Appeal.escalated_at.is_not(None), Appeal.escalation_level > 0))
+    elif escalated_value == "none":
+        stmt = stmt.where(Appeal.escalated_at.is_(None), Appeal.escalation_level <= 0)
+
     if query_value:
         if query_value.isdigit():
             q_int = int(query_value)
@@ -1767,7 +1819,7 @@ async def appeals(
     rows = rows[:page_size]
 
     return_to = (
-        f"/appeals?status={status_value}&source={source_value}&overdue={overdue_value}&page={page}&q={query_value}"
+        f"/appeals?status={status_value}&source={source_value}&overdue={overdue_value}&escalated={escalated_value}&page={page}&q={query_value}"
     )
     csrf_input = _csrf_hidden_input(request, auth)
     table_rows = ""
@@ -1782,6 +1834,13 @@ async def appeals(
         actions = "-"
         appeal_status = AppealStatus(appeal.status)
         is_overdue = _appeal_is_overdue(appeal, now=now)
+        status_label = _appeal_status_label(appeal_status)
+        if is_overdue:
+            status_label += " ⏰"
+        if appeal.escalated_at is not None or int(appeal.escalation_level or 0) > 0:
+            status_label += " ⚠"
+        sla_state_label = _appeal_sla_state_label(appeal, now=now)
+        escalation_marker = _appeal_escalation_marker(appeal)
         if appeal_status in {AppealStatus.OPEN, AppealStatus.IN_REVIEW}:
             action_forms: list[str] = []
             if appeal_status == AppealStatus.OPEN:
@@ -1818,27 +1877,28 @@ async def appeals(
             f"<td>{escape(appeal.appeal_ref)}</td>"
             f"<td>{escape(source_label)}</td>"
             f"<td><a href='{escape(_path_with_auth(request, f'/manage/user/{appellant.id}'))}'>{escape(appellant_label)}</a></td>"
-            f"<td>{escape(_appeal_status_label(appeal_status))}{' ⏰' if is_overdue else ''}</td>"
+            f"<td>{escape(status_label)}</td>"
             f"<td>{escape((appeal.resolution_note or '-')[:160])}</td>"
             f"<td>{escape(resolver_label)}</td>"
             f"<td>{escape(_fmt_ts(appeal.created_at))}</td>"
+            f"<td>{escape(sla_state_label)}</td>"
             f"<td>{escape(_fmt_ts(appeal.sla_deadline_at))}</td>"
-            f"<td>{escape(_fmt_ts(appeal.escalated_at))}</td>"
+            f"<td>{escape(escalation_marker)}</td>"
             f"<td>{escape(_fmt_ts(appeal.resolved_at))}</td>"
             f"<td>{actions}</td>"
             "</tr>"
         )
 
     if not table_rows:
-        table_rows = "<tr><td colspan='12'><span class='empty-state'>Нет записей</span></td></tr>"
+        table_rows = "<tr><td colspan='13'><span class='empty-state'>Нет записей</span></td></tr>"
 
     prev_link = (
-        f"<a href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source={source_value}&overdue={overdue_value}&page={page-1}&q={query_value}'))}'>← Назад</a>"
+        f"<a href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source={source_value}&overdue={overdue_value}&escalated={escalated_value}&page={page-1}&q={query_value}'))}'>← Назад</a>"
         if page > 0
         else ""
     )
     next_link = (
-        f"<a href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source={source_value}&overdue={overdue_value}&page={page+1}&q={query_value}'))}'>Вперед →</a>"
+        f"<a href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source={source_value}&overdue={overdue_value}&escalated={escalated_value}&page={page+1}&q={query_value}'))}'>Вперед →</a>"
         if has_next
         else ""
     )
@@ -1852,25 +1912,30 @@ async def appeals(
         f"<input type='hidden' name='status' value='{escape(status_value)}'>"
         f"<input type='hidden' name='source' value='{escape(source_value)}'>"
         f"<input type='hidden' name='overdue' value='{escape(overdue_value)}'>"
+        f"<input type='hidden' name='escalated' value='{escape(escalated_value)}'>"
         f"<input name='q' value='{escape(query_value)}' placeholder='референс / tg id / username' style='width:300px'>"
         "<button type='submit'>Поиск</button>"
         "</form>"
         f"<p>Статус: "
-        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status=open&source={source_value}&overdue={overdue_value}&q={query_value}'))}'>Открытые</a> "
-        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status=in_review&source={source_value}&overdue={overdue_value}&q={query_value}'))}'>На рассмотрении</a> "
-        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status=resolved&source={source_value}&overdue={overdue_value}&q={query_value}'))}'>Удовлетворенные</a> "
-        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status=rejected&source={source_value}&overdue={overdue_value}&q={query_value}'))}'>Отклоненные</a> "
-        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status=all&source={source_value}&overdue={overdue_value}&q={query_value}'))}'>Все</a></p>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status=open&source={source_value}&overdue={overdue_value}&escalated={escalated_value}&q={query_value}'))}'>Открытые</a> "
+        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status=in_review&source={source_value}&overdue={overdue_value}&escalated={escalated_value}&q={query_value}'))}'>На рассмотрении</a> "
+        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status=resolved&source={source_value}&overdue={overdue_value}&escalated={escalated_value}&q={query_value}'))}'>Удовлетворенные</a> "
+        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status=rejected&source={source_value}&overdue={overdue_value}&escalated={escalated_value}&q={query_value}'))}'>Отклоненные</a> "
+        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status=all&source={source_value}&overdue={overdue_value}&escalated={escalated_value}&q={query_value}'))}'>Все</a></p>"
         f"<p>Источник: "
-        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source=complaint&overdue={overdue_value}&q={query_value}'))}'>Жалобы</a> "
-        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source=risk&overdue={overdue_value}&q={query_value}'))}'>Фрод</a> "
-        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source=manual&overdue={overdue_value}&q={query_value}'))}'>Ручные</a> "
-        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source=all&overdue={overdue_value}&q={query_value}'))}'>Все</a></p>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source=complaint&overdue={overdue_value}&escalated={escalated_value}&q={query_value}'))}'>Жалобы</a> "
+        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source=risk&overdue={overdue_value}&escalated={escalated_value}&q={query_value}'))}'>Фрод</a> "
+        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source=manual&overdue={overdue_value}&escalated={escalated_value}&q={query_value}'))}'>Ручные</a> "
+        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source=all&overdue={overdue_value}&escalated={escalated_value}&q={query_value}'))}'>Все</a></p>"
         f"<p>SLA: "
-        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source={source_value}&overdue=all&q={query_value}'))}'>Все</a> "
-        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source={source_value}&overdue=only&q={query_value}'))}'>Просроченные</a> "
-        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source={source_value}&overdue=none&q={query_value}'))}'>Непросроченные</a></p>"
-        "<table><thead><tr><th>ID</th><th>Референс</th><th>Источник</th><th>Апеллянт</th><th>Статус</th><th>Решение</th><th>Модератор</th><th>Создано</th><th>SLA дедлайн</th><th>Эскалация</th><th>Закрыто</th><th>Действия</th></tr></thead>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source={source_value}&overdue=all&escalated={escalated_value}&q={query_value}'))}'>Все</a> "
+        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source={source_value}&overdue=only&escalated={escalated_value}&q={query_value}'))}'>Просроченные</a> "
+        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source={source_value}&overdue=none&escalated={escalated_value}&q={query_value}'))}'>Непросроченные</a></p>"
+        f"<p>Эскалация: "
+        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source={source_value}&overdue={overdue_value}&escalated=all&q={query_value}'))}'>Все</a> "
+        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source={source_value}&overdue={overdue_value}&escalated=only&q={query_value}'))}'>Эскалированные</a> "
+        f"<a class='chip' href='{escape(_path_with_auth(request, f'/appeals?status={status_value}&source={source_value}&overdue={overdue_value}&escalated=none&q={query_value}'))}'>Без эскалации</a></p>"
+        "<table><thead><tr><th>ID</th><th>Референс</th><th>Источник</th><th>Апеллянт</th><th>Статус</th><th>Решение</th><th>Модератор</th><th>Создано</th><th>SLA статус</th><th>SLA дедлайн</th><th>Эскалация</th><th>Закрыто</th><th>Действия</th></tr></thead>"
         f"<tbody>{table_rows}</tbody></table>"
         f"<p>{prev_link} {' | ' if prev_link and next_link else ''} {next_link}</p>"
     )


### PR DESCRIPTION
## Summary
- extend `/appeals` with explicit SLA state rendering (`Просрочена`, `Просрочена, эскалация Lx`, `До SLA: ...`, `Закрыта`) and clearer escalation markers in table rows
- add escalation filtering (`escalated=all|only|none`) and preserve it across search, chips, paging, and return paths
- keep overdue logic intact while adding escalation visibility badges in status for faster moderator triage
- expand integration coverage for invalid escalated filter, escalated/non-escalated filtering, and updated paging links

## Validation
- `.venv/bin/python -m ruff check app tests alembic`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@172.20.0.2:5432/auction_test .venv/bin/python -m pytest -q tests/integration`
- same integration command repeated once (anti-flaky)