### PR TITLE
feat: add trust indicators to appeals and signals views

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - Historical cross-auction baseline heuristic and web admin panel
 - Telegram Login auth for web admin and dispute timeline pages
 - Web moderation actions with role-based permissions
-- Risk/trust indicators on admin user and auction lists
+- Risk/trust indicators on admin user, auction, appeal, and signal views
 - Fine-grained web RBAC scopes (`auction`, `bid`, `user-ban`, `role-manage`)
 - Telegram moderation RBAC synced with scope model + `/role` commands
 - Web CSRF protection and confirm-step for dangerous moderation actions

--- a/tests/integration/test_web_signals.py
+++ b/tests/integration/test_web_signals.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import pytest
+from starlette.requests import Request
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.db.enums import AuctionStatus
+from app.db.models import Auction, Complaint, FraudSignal, User
+from app.services.rbac_service import SCOPE_USER_BAN
+from app.web.auth import AdminAuthContext
+from app.web.main import signals
+
+
+def _make_request(path: str) -> Request:
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("utf-8"),
+        "query_string": b"",
+        "headers": [],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(scope, receive)
+
+
+def _stub_auth() -> AdminAuthContext:
+    return AdminAuthContext(
+        authorized=True,
+        via="token",
+        role="owner",
+        can_manage=True,
+        scopes=frozenset({SCOPE_USER_BAN}),
+        tg_user_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_signals_page_shows_user_risk_column(monkeypatch, integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with session_factory() as session:
+        async with session.begin():
+            risky = User(tg_user_id=99511, username="signals_risky")
+            safe = User(tg_user_id=99512, username="signals_safe")
+            reporter = User(tg_user_id=99513, username="signals_reporter")
+            seller = User(tg_user_id=99514, username="signals_seller")
+            session.add_all([risky, safe, reporter, seller])
+            await session.flush()
+
+            auction = Auction(
+                seller_user_id=seller.id,
+                description="signals lot",
+                photo_file_id="photo",
+                start_price=100,
+                buyout_price=None,
+                min_step=5,
+                duration_hours=24,
+                status=AuctionStatus.ACTIVE,
+            )
+            session.add(auction)
+            await session.flush()
+
+            session.add_all(
+                [
+                    Complaint(
+                        auction_id=auction.id,
+                        reporter_user_id=reporter.id,
+                        target_user_id=risky.id,
+                        reason=f"complaint-{idx}",
+                        status="OPEN",
+                    )
+                    for idx in range(3)
+                ]
+            )
+
+            session.add_all(
+                [
+                    FraudSignal(
+                        auction_id=auction.id,
+                        user_id=risky.id,
+                        bid_id=None,
+                        score=91,
+                        reasons={"rules": [{"code": "TEST", "detail": "risk", "score": 91}]},
+                        status="OPEN",
+                    ),
+                    FraudSignal(
+                        auction_id=auction.id,
+                        user_id=safe.id,
+                        bid_id=None,
+                        score=28,
+                        reasons={"rules": [{"code": "TEST", "detail": "low", "score": 28}]},
+                        status="OPEN",
+                    ),
+                ]
+            )
+
+    monkeypatch.setattr("app.web.main.SessionFactory", session_factory)
+    monkeypatch.setattr("app.web.main._auth_context_or_unauthorized", lambda _req: (None, _stub_auth()))
+
+    request = _make_request("/signals")
+    response = await signals(request, status="OPEN", page=0)
+
+    body = bytes(response.body).decode("utf-8")
+    assert response.status_code == 200
+    assert "User Risk" in body
+    assert "HIGH (" in body
+    assert "MEDIUM (40)" in body


### PR DESCRIPTION
## Summary
- extend `/appeals` with appellant risk indicators (`LOW/MEDIUM/HIGH + score`) and keep list filters/pagination behavior unchanged
- extend `/signals` with user risk indicator column to improve fraud queue triage context
- reuse existing risk snapshot logic from admin web and keep reason tooltips for explainability
- add integration coverage for appellant risk rendering and signals risk column
- update README capability line to reflect trust indicators on appeal/signal views

## Validation
- `.venv/bin/python -m ruff check app tests alembic`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@172.20.0.2:5432/auction_test .venv/bin/python -m pytest -q tests/integration`
- same integration command repeated once (anti-flaky)