### PR TITLE
feat: add post-trade feedback foundation and moderation view

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,11 +382,14 @@ Use it as a reply to a message that contains premium/custom emoji.
 /bug <описание>
 /suggest <предложение>
 /guarant <запрос на гаранта>
+/tradefeedback <auction_id> <1..5> [комментарий]
 /points
 /points <1..20>
 ```
 
 High-risk sellers cannot publish drafts until a guarantor request is assigned by moderation.
+
+Trade feedback moderation list is available in admin web: `/trade-feedback`.
 
 - Include moderation queue destination in env (recommended):
 

--- a/alembic/versions/0015_trade_feedback.py
+++ b/alembic/versions/0015_trade_feedback.py
@@ -1,0 +1,78 @@
+"""add post trade feedback table
+
+Revision ID: 0015_trade_feedback
+Revises: 0014_adjust_user_points_action
+Create Date: 2026-02-14 16:10:00
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0015_trade_feedback"
+down_revision: str | None = "0014_adjust_user_points_action"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "trade_feedback",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("auction_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("author_user_id", sa.BigInteger(), nullable=False),
+        sa.Column("target_user_id", sa.BigInteger(), nullable=False),
+        sa.Column("rating", sa.SmallInteger(), nullable=False),
+        sa.Column("comment", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=16), server_default=sa.text("'VISIBLE'"), nullable=False),
+        sa.Column("moderator_user_id", sa.BigInteger(), nullable=True),
+        sa.Column("moderation_note", sa.Text(), nullable=True),
+        sa.Column("moderated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("TIMEZONE('utc', NOW())"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("TIMEZONE('utc', NOW())"),
+            nullable=False,
+        ),
+        sa.CheckConstraint("rating BETWEEN 1 AND 5", name="trade_feedback_rating_range"),
+        sa.CheckConstraint("status IN ('VISIBLE', 'HIDDEN')", name="trade_feedback_status_values"),
+        sa.CheckConstraint("author_user_id <> target_user_id", name="trade_feedback_distinct_users"),
+        sa.ForeignKeyConstraint(["auction_id"], ["auctions.id"], name=op.f("fk_trade_feedback_auction_id_auctions"), ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["author_user_id"],
+            ["users.id"],
+            name=op.f("fk_trade_feedback_author_user_id_users"),
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["target_user_id"],
+            ["users.id"],
+            name=op.f("fk_trade_feedback_target_user_id_users"),
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["moderator_user_id"],
+            ["users.id"],
+            name=op.f("fk_trade_feedback_moderator_user_id_users"),
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_trade_feedback")),
+        sa.UniqueConstraint("auction_id", "author_user_id", name="uq_trade_feedback_auction_author"),
+    )
+    op.create_index("ix_trade_feedback_status_created_at", "trade_feedback", ["status", "created_at"], unique=False)
+    op.create_index("ix_trade_feedback_target_created_at", "trade_feedback", ["target_user_id", "created_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_trade_feedback_target_created_at", table_name="trade_feedback")
+    op.drop_index("ix_trade_feedback_status_created_at", table_name="trade_feedback")
+    op.drop_table("trade_feedback")

--- a/app/bot/handlers/__init__.py
+++ b/app/bot/handlers/__init__.py
@@ -9,6 +9,7 @@ from .inline_auction import router as inline_auction_router
 from .moderation import router as moderation_router
 from .points import router as points_router
 from .start import router as start_router
+from .trade_feedback import router as trade_feedback_router
 
 router = Router(name="root")
 router.include_router(start_router)
@@ -19,6 +20,7 @@ router.include_router(inline_auction_router)
 router.include_router(feedback_router)
 router.include_router(guarantor_router)
 router.include_router(points_router)
+router.include_router(trade_feedback_router)
 router.include_router(moderation_router)
 
 __all__ = ["router"]

--- a/app/bot/handlers/trade_feedback.py
+++ b/app/bot/handlers/trade_feedback.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import uuid
+
+from aiogram import F, Router
+from aiogram.enums import ChatType
+from aiogram.filters import Command
+from aiogram.types import Message
+
+from app.db.session import SessionFactory
+from app.services.trade_feedback_service import submit_trade_feedback
+from app.services.user_service import upsert_user
+
+router = Router(name="trade_feedback")
+
+
+def _usage_text() -> str:
+    return "Формат: /tradefeedback <auction_id> <1..5> [комментарий]"
+
+
+@router.message(Command("tradefeedback"), F.chat.type == ChatType.PRIVATE)
+async def command_tradefeedback(message: Message) -> None:
+    if message.from_user is None:
+        return
+
+    text = (message.text or "").strip()
+    parts = text.split(maxsplit=3)
+    if len(parts) < 3:
+        await message.answer(_usage_text())
+        return
+
+    auction_id_raw = parts[1].strip()
+    rating_raw = parts[2].strip()
+    comment = parts[3].strip() if len(parts) > 3 else None
+
+    try:
+        auction_id = uuid.UUID(auction_id_raw)
+    except ValueError:
+        await message.answer("Некорректный auction_id")
+        return
+
+    if not rating_raw.isdigit():
+        await message.answer(_usage_text())
+        return
+
+    rating = int(rating_raw)
+    if rating < 1 or rating > 5:
+        await message.answer("Оценка должна быть от 1 до 5")
+        return
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            actor = await upsert_user(session, message.from_user, mark_private_started=True)
+            result = await submit_trade_feedback(
+                session,
+                auction_id=auction_id,
+                author_user_id=actor.id,
+                rating=rating,
+                comment=comment,
+            )
+
+    if not result.ok:
+        await message.answer(result.message)
+        return
+
+    await message.answer(f"{result.message}. Оценка: {rating}/5")

--- a/app/services/trade_feedback_service.py
+++ b/app/services/trade_feedback_service.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.enums import AuctionStatus
+from app.db.models import Auction, TradeFeedback
+
+
+@dataclass(slots=True)
+class TradeFeedbackSubmitResult:
+    ok: bool
+    message: str
+    item: TradeFeedback | None = None
+    created: bool = False
+    updated: bool = False
+
+
+@dataclass(slots=True)
+class TradeFeedbackModerationResult:
+    ok: bool
+    message: str
+    item: TradeFeedback | None = None
+    changed: bool = False
+
+
+def _normalize_comment(comment: str | None) -> str | None:
+    if comment is None:
+        return None
+    normalized = "\n".join(line.rstrip() for line in comment.strip().splitlines()).strip()
+    if not normalized:
+        return None
+    if len(normalized) > 1000:
+        normalized = normalized[:1000].rstrip()
+    return normalized
+
+
+async def submit_trade_feedback(
+    session: AsyncSession,
+    *,
+    auction_id: uuid.UUID,
+    author_user_id: int,
+    rating: int,
+    comment: str | None,
+) -> TradeFeedbackSubmitResult:
+    if rating < 1 or rating > 5:
+        return TradeFeedbackSubmitResult(False, "Оценка должна быть от 1 до 5")
+
+    auction = await session.scalar(select(Auction).where(Auction.id == auction_id).with_for_update())
+    if auction is None:
+        return TradeFeedbackSubmitResult(False, "Аукцион не найден")
+
+    if auction.status not in {AuctionStatus.ENDED, AuctionStatus.BOUGHT_OUT}:
+        return TradeFeedbackSubmitResult(False, "Оставить отзыв можно только по завершенному аукциону")
+
+    if auction.winner_user_id is None:
+        return TradeFeedbackSubmitResult(False, "У аукциона нет победителя, отзыв недоступен")
+
+    if author_user_id == auction.seller_user_id:
+        target_user_id = auction.winner_user_id
+    elif author_user_id == auction.winner_user_id:
+        target_user_id = auction.seller_user_id
+    else:
+        return TradeFeedbackSubmitResult(False, "Оставить отзыв могут только продавец и победитель")
+
+    normalized_comment = _normalize_comment(comment)
+    now = datetime.now(UTC)
+
+    item = await session.scalar(
+        select(TradeFeedback)
+        .where(TradeFeedback.auction_id == auction.id, TradeFeedback.author_user_id == author_user_id)
+        .with_for_update()
+    )
+    if item is not None:
+        item.target_user_id = target_user_id
+        item.rating = rating
+        item.comment = normalized_comment
+        item.updated_at = now
+        return TradeFeedbackSubmitResult(True, "Отзыв обновлен", item=item, updated=True)
+
+    created = TradeFeedback(
+        auction_id=auction.id,
+        author_user_id=author_user_id,
+        target_user_id=target_user_id,
+        rating=rating,
+        comment=normalized_comment,
+        status="VISIBLE",
+        updated_at=now,
+    )
+    session.add(created)
+    await session.flush()
+    return TradeFeedbackSubmitResult(True, "Отзыв сохранен", item=created, created=True)
+
+
+async def set_trade_feedback_visibility(
+    session: AsyncSession,
+    *,
+    feedback_id: int,
+    visible: bool,
+    moderator_user_id: int,
+    note: str,
+) -> TradeFeedbackModerationResult:
+    item = await session.scalar(select(TradeFeedback).where(TradeFeedback.id == feedback_id).with_for_update())
+    if item is None:
+        return TradeFeedbackModerationResult(False, "Отзыв не найден")
+
+    target_status = "VISIBLE" if visible else "HIDDEN"
+    if item.status == target_status:
+        return TradeFeedbackModerationResult(True, "Статус уже установлен", item=item, changed=False)
+
+    now = datetime.now(UTC)
+    item.status = target_status
+    item.moderator_user_id = moderator_user_id
+    item.moderation_note = (note or "").strip() or None
+    item.moderated_at = now
+    item.updated_at = now
+    return TradeFeedbackModerationResult(True, "Статус отзыва обновлен", item=item, changed=True)

--- a/tests/integration/test_trade_feedback_command.py
+++ b/tests/integration/test_trade_feedback_command.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.bot.handlers.trade_feedback import command_tradefeedback
+from app.db.enums import AuctionStatus
+from app.db.models import Auction, TradeFeedback, User
+
+
+class _DummyFromUser:
+    def __init__(self, user_id: int) -> None:
+        self.id = user_id
+        self.username = f"user{user_id}"
+        self.first_name = "Test"
+        self.last_name = "User"
+
+
+class _DummyMessage:
+    def __init__(self, from_user_id: int, text: str) -> None:
+        self.from_user = _DummyFromUser(from_user_id)
+        self.text = text
+        self.answers: list[str] = []
+
+    async def answer(self, text: str, **_kwargs) -> None:
+        self.answers.append(text)
+
+
+@pytest.mark.asyncio
+async def test_tradefeedback_command_creates_feedback(monkeypatch, integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr("app.bot.handlers.trade_feedback.SessionFactory", session_factory)
+
+    auction_id = uuid.uuid4()
+
+    async with session_factory() as session:
+        async with session.begin():
+            seller = User(tg_user_id=99601, username="seller")
+            winner = User(tg_user_id=99602, username="winner")
+            session.add_all([seller, winner])
+            await session.flush()
+
+            session.add(
+                Auction(
+                    id=auction_id,
+                    seller_user_id=seller.id,
+                    winner_user_id=winner.id,
+                    description="ended auction",
+                    photo_file_id="photo",
+                    start_price=100,
+                    buyout_price=None,
+                    min_step=5,
+                    duration_hours=24,
+                    status=AuctionStatus.ENDED,
+                )
+            )
+
+    message = _DummyMessage(from_user_id=99601, text=f"/tradefeedback {auction_id} 5 Отличная сделка")
+    await command_tradefeedback(message)
+
+    assert message.answers
+    assert "Отзыв сохранен" in message.answers[-1]
+
+    async with session_factory() as session:
+        rows = (await session.execute(select(TradeFeedback))).scalars().all()
+
+    assert len(rows) == 1
+    assert rows[0].rating == 5
+    assert rows[0].comment == "Отличная сделка"
+    assert rows[0].status == "VISIBLE"
+
+
+@pytest.mark.asyncio
+async def test_tradefeedback_command_rejects_non_participant(monkeypatch, integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr("app.bot.handlers.trade_feedback.SessionFactory", session_factory)
+
+    auction_id = uuid.uuid4()
+
+    async with session_factory() as session:
+        async with session.begin():
+            seller = User(tg_user_id=99611, username="seller2")
+            winner = User(tg_user_id=99612, username="winner2")
+            outsider = User(tg_user_id=99613, username="outsider")
+            session.add_all([seller, winner, outsider])
+            await session.flush()
+
+            session.add(
+                Auction(
+                    id=auction_id,
+                    seller_user_id=seller.id,
+                    winner_user_id=winner.id,
+                    description="ended auction",
+                    photo_file_id="photo",
+                    start_price=100,
+                    buyout_price=None,
+                    min_step=5,
+                    duration_hours=24,
+                    status=AuctionStatus.BOUGHT_OUT,
+                )
+            )
+
+    message = _DummyMessage(from_user_id=99613, text=f"/tradefeedback {auction_id} 4")
+    await command_tradefeedback(message)
+
+    assert message.answers
+    assert "только продавец и победитель" in message.answers[-1]
+
+    async with session_factory() as session:
+        rows = (await session.execute(select(TradeFeedback))).scalars().all()
+
+    assert rows == []

--- a/tests/integration/test_web_trade_feedback.py
+++ b/tests/integration/test_web_trade_feedback.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.db.enums import AuctionStatus
+from app.db.models import Auction, TradeFeedback, User
+from app.services.rbac_service import SCOPE_USER_BAN
+from app.web.auth import AdminAuthContext
+from app.web.main import action_hide_trade_feedback, trade_feedback
+
+
+def _make_request(path: str, *, method: str = "GET") -> Request:
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("utf-8"),
+        "query_string": b"",
+        "headers": [],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(scope, receive)
+
+
+def _stub_auth() -> AdminAuthContext:
+    return AdminAuthContext(
+        authorized=True,
+        via="token",
+        role="owner",
+        can_manage=True,
+        scopes=frozenset({SCOPE_USER_BAN}),
+        tg_user_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_trade_feedback_page_filters_by_status(monkeypatch, integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    auction_id = uuid.uuid4()
+
+    async with session_factory() as session:
+        async with session.begin():
+            seller = User(tg_user_id=99701, username="seller")
+            winner = User(tg_user_id=99702, username="winner")
+            moderator = User(tg_user_id=99703, username="moderator")
+            session.add_all([seller, winner, moderator])
+            await session.flush()
+
+            session.add(
+                Auction(
+                    id=auction_id,
+                    seller_user_id=seller.id,
+                    winner_user_id=winner.id,
+                    description="ended lot",
+                    photo_file_id="photo",
+                    start_price=100,
+                    buyout_price=None,
+                    min_step=5,
+                    duration_hours=24,
+                    status=AuctionStatus.ENDED,
+                )
+            )
+            session.add_all(
+                [
+                    TradeFeedback(
+                        auction_id=auction_id,
+                        author_user_id=seller.id,
+                        target_user_id=winner.id,
+                        rating=5,
+                        comment="visible feedback",
+                        status="VISIBLE",
+                    ),
+                    TradeFeedback(
+                        auction_id=auction_id,
+                        author_user_id=winner.id,
+                        target_user_id=seller.id,
+                        rating=2,
+                        comment="hidden feedback",
+                        status="HIDDEN",
+                        moderator_user_id=moderator.id,
+                    ),
+                ]
+            )
+
+    monkeypatch.setattr("app.web.main.SessionFactory", session_factory)
+    monkeypatch.setattr("app.web.main._require_scope_permission", lambda _req, _scope: (None, _stub_auth()))
+
+    request = _make_request("/trade-feedback")
+    response = await trade_feedback(request, status="visible", page=0, q="")
+
+    body = bytes(response.body).decode("utf-8")
+    assert response.status_code == 200
+    assert "visible feedback" in body
+    assert "hidden feedback" not in body
+
+
+@pytest.mark.asyncio
+async def test_trade_feedback_hide_action_updates_status(monkeypatch, integration_engine) -> None:
+    session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
+    auction_id = uuid.uuid4()
+
+    async with session_factory() as session:
+        async with session.begin():
+            seller = User(tg_user_id=99711, username="seller")
+            winner = User(tg_user_id=99712, username="winner")
+            moderator = User(tg_user_id=99713, username="moderator")
+            session.add_all([seller, winner, moderator])
+            await session.flush()
+            moderator_user_id = moderator.id
+
+            session.add(
+                Auction(
+                    id=auction_id,
+                    seller_user_id=seller.id,
+                    winner_user_id=winner.id,
+                    description="ended lot",
+                    photo_file_id="photo",
+                    start_price=100,
+                    buyout_price=None,
+                    min_step=5,
+                    duration_hours=24,
+                    status=AuctionStatus.ENDED,
+                )
+            )
+            feedback = TradeFeedback(
+                auction_id=auction_id,
+                author_user_id=seller.id,
+                target_user_id=winner.id,
+                rating=4,
+                comment="needs review",
+                status="VISIBLE",
+            )
+            session.add(feedback)
+            await session.flush()
+            feedback_id = feedback.id
+
+    monkeypatch.setattr("app.web.main.SessionFactory", session_factory)
+    monkeypatch.setattr("app.web.main._require_scope_permission", lambda _req, _scope: (None, _stub_auth()))
+    monkeypatch.setattr("app.web.main._validate_csrf_token", lambda *_args, **_kwargs: True)
+
+    async def _resolve_actor(_auth):
+        return moderator_user_id
+
+    monkeypatch.setattr("app.web.main._resolve_actor_user_id", _resolve_actor)
+
+    request = _make_request("/actions/trade-feedback/hide", method="POST")
+    response = await action_hide_trade_feedback(
+        request,
+        feedback_id=feedback_id,
+        reason="spam",
+        return_to="/trade-feedback?status=visible",
+        csrf_token="ok",
+    )
+
+    assert response.status_code == 303
+
+    async with session_factory() as session:
+        row = await session.scalar(select(TradeFeedback).where(TradeFeedback.id == feedback_id))
+
+    assert row is not None
+    assert row.status == "HIDDEN"
+    assert row.moderation_note == "spam"
+    assert row.moderator_user_id == moderator_user_id
+
+
+@pytest.mark.asyncio
+async def test_trade_feedback_page_rejects_invalid_status(monkeypatch) -> None:
+    monkeypatch.setattr("app.web.main._require_scope_permission", lambda _req, _scope: (None, _stub_auth()))
+
+    request = _make_request("/trade-feedback")
+    with pytest.raises(HTTPException) as exc:
+        await trade_feedback(request, status="broken", page=0, q="")
+
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary
- add DB-backed post-trade feedback foundation (`trade_feedback`) with rating/comment, author/target links, and visibility moderation fields
- add private bot intake command `/tradefeedback <auction_id> <1..5> [comment]` with participant and auction-state validation
- add admin web moderation list `/trade-feedback` with status filters, search, and hide/unhide actions protected by scope + CSRF
- add Alembic migration `0015_trade_feedback` and integration coverage for command flow and web moderation behavior
- update README command/admin usage docs for trade feedback

## Validation
- `.venv/bin/python -m ruff check app tests alembic`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@172.20.0.2:5432/auction_test .venv/bin/python -m pytest -q tests/integration`
- same integration command repeated once (anti-flaky)