### PR TITLE
feat: show trade feedback reputation on manage user

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - Telegram Login auth for web admin and dispute timeline pages
 - Web moderation actions with role-based permissions
 - Risk/trust indicators on admin user, auction, appeal, and signal views
+- Post-trade feedback foundation with bot intake and admin moderation view
 - Fine-grained web RBAC scopes (`auction`, `bid`, `user-ban`, `role-manage`)
 - Telegram moderation RBAC synced with scope model + `/role` commands
 - Web CSRF protection and confirm-step for dangerous moderation actions


### PR DESCRIPTION
## Summary
- extend manage user page with trade feedback reputation KPIs (received, visible, hidden, average visible rating)
- add recent received trade feedback table on `/manage/user/{id}` with author, rating, status, comment, and auction context
- add helper queries in trade feedback service for user-level summary and recent received feedback list
- add integration coverage for the new reputation section rendering and update README feature list

## Validation
- `.venv/bin/python -m ruff check app tests alembic`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@172.20.0.2:5432/auction_test .venv/bin/python -m pytest -q tests/integration`
- same integration command repeated once (anti-flaky)