### PR TITLE
docs: sync sprint 32 status and add rc-2 release docs

### DIFF
--- a/docs/planning/sprint-32-implementation-plan.md
+++ b/docs/planning/sprint-32-implementation-plan.md
@@ -12,6 +12,21 @@ Inputs:
 
 Reduce complaint pressure and improve trust transparency without introducing heavy user friction.
 
+## Execution Status (Current)
+
+- Done:
+  - PR #44: user risk snapshot indicators in admin.
+  - PR #45: high-risk guarantor publish gate.
+  - PR #46: appeals SLA states and escalation markers.
+  - PR #47: trust indicators on admin users and auctions lists.
+  - PR #48: trust indicators on appeals and fraud signals lists.
+  - PR #49: post-trade feedback foundation (bot intake + web moderation list).
+  - PR #50: manage user reputation summary based on trade feedback.
+- In progress:
+  - Reputation layer hardening (moderation ergonomics + reporting slices).
+- Next:
+  - Points utility/redemption first usable scenario.
+
 ## P0 Scope (Recommended)
 
 Implement shortlist items 1-3 first:
@@ -20,9 +35,9 @@ Implement shortlist items 1-3 first:
 2. Dispute SLA transparency and auto-escalation markers.
 3. Lightweight trust signals in admin/user-facing surfaces.
 
-## PR Sequence (Small Scoped)
+## Implemented Sequence
 
-### PR-43: Risk Flag Foundation
+### PR-44: Risk Flag Foundation
 
 - Add deterministic risk evaluation helper (auction + user context).
 - Persist evaluation payload in moderation-friendly format.
@@ -33,7 +48,7 @@ Acceptance:
 - Risk score and reasons visible in admin flow.
 - Integration tests for low/high-risk classification and payload stability.
 
-### PR-44: High-Risk Guarantor Gate
+### PR-45: High-Risk Guarantor Gate
 
 - Enforce guarantor requirement for high-risk auction paths.
 - Add explicit user-facing reason when action is blocked.
@@ -44,7 +59,7 @@ Acceptance:
 - High-risk paths blocked without guarantor.
 - Override requires scoped actor and is logged.
 
-### PR-45: Dispute SLA Surfacing
+### PR-46: Dispute SLA Surfacing
 
 - Display SLA deadline and escalation status in admin dispute views.
 - Add proactive escalation marker when deadline is near/past.
@@ -55,7 +70,7 @@ Acceptance:
 - SLA and escalation state visible in web panel.
 - Integration tests for on-time and overdue states.
 
-### PR-46: Trust Signal Surface
+### PR-47 + PR-48: Trust Signal Surface Expansion
 
 - Add lightweight trust badge/summary fields on manage user and auction-related admin views.
 - Source trust indicators from existing complaint/ban/moderation signals.
@@ -65,6 +80,41 @@ Acceptance:
 
 - Trust summary consistently renders for users with and without history.
 - Explanations remain stable under test fixtures.
+
+### PR-49: Post-Trade Feedback Foundation
+
+- Add `trade_feedback` domain table and migration.
+- Add bot intake command `/tradefeedback <auction_id> <1..5> [comment]`.
+- Add web moderation queue `/trade-feedback` with hide/unhide actions.
+
+Acceptance:
+
+- Feedback is accepted only for seller/winner on completed auctions.
+- Web moderation list supports filtering/search and visibility actions.
+
+### PR-50: Manage User Reputation Summary
+
+- Add reputation KPI block on `/manage/user/{id}`.
+- Show recent received feedback with status context.
+- Link profile-level view to moderation queue.
+
+Acceptance:
+
+- Reputation summary renders for users with and without feedback history.
+- Integration coverage validates summary math and table rendering.
+
+## Next Sequence (Planned)
+
+### PR-51: Reputation Moderation Ergonomics
+
+- Add faster moderation filters (rating thresholds, hidden-only shortcuts, actor-based drilldown).
+- Add moderation audit payload standardization for feedback visibility actions.
+
+### PR-52: Points Utility v1
+
+- Introduce first redeemable utility path for points.
+- Add anti-abuse limits and ledger-safe spend semantics.
+- Add basic user-facing usage docs and moderator controls.
 
 ## Non-Goals for Sprint 32
 

--- a/docs/release/rc-2-manual-qa-matrix.md
+++ b/docs/release/rc-2-manual-qa-matrix.md
@@ -1,0 +1,54 @@
+# RC-2 Manual QA Matrix
+
+Date: 2026-02-14
+Tester: 
+
+How to fill quickly:
+
+- Put `PASS` or `FAIL` in `Result`.
+- In `Notes`, add short proof (`ids/action/screenshot`).
+- If `FAIL`, include blocker id and expected fix owner.
+
+## Core Flow Cases
+
+| Case | Result | Notes |
+|---|---|---|
+| RK-01 Manage user page shows risk level/score/reasons | PENDING | user_id=<id>, evidence=<file> |
+| RK-02 High-risk seller cannot publish without assigned guarantor | PENDING | seller_tg=<id>, blocked message includes `/guarant`, evidence=<file> |
+| RK-03 High-risk seller with recent assigned guarantor can publish | PENDING | seller_tg=<id>, assigned request id=<id>, evidence=<file> |
+| AP-01 Appeals page shows SLA status labels correctly | PENDING | open/in_review/resolved samples, evidence=<file> |
+| AP-02 Appeals escalation filter (`all/only/none`) works | PENDING | query params + list contents, evidence=<file> |
+| TS-01 Trust indicators visible on `/manage/users` | PENDING | risk column with tooltips, evidence=<file> |
+| TS-02 Trust indicators visible on `/auctions` | PENDING | seller risk column rendered, evidence=<file> |
+| TS-03 Trust indicators visible on `/signals` and `/appeals` | PENDING | user/appellant risk columns rendered, evidence=<file> |
+| TF-01 `/tradefeedback` accepts valid seller/winner input | PENDING | auction_id=<uuid>, rating/comment stored, evidence=<file> |
+| TF-02 `/tradefeedback` rejects non-participant | PENDING | outsider tg=<id>, denial message, evidence=<file> |
+| TF-03 `/trade-feedback` list filters/search and pagination | PENDING | status filters + query checks, evidence=<file> |
+| TF-04 Hide/Unhide feedback actions update status with CSRF and scope checks | PENDING | feedback_id=<id>, status transitions, evidence=<file> |
+| RP-01 `/manage/user/{id}` reputation summary math is correct | PENDING | received/visible/hidden/avg values, evidence=<file> |
+| RP-02 Recent feedback table on profile matches moderation queue | PENDING | profile vs `/trade-feedback`, evidence=<file> |
+
+## Visual/Release Cases
+
+| Case | Result | Notes |
+|---|---|---|
+| Manage user profile readability on desktop | PENDING | risk + rewards + reputation sections readable, evidence=<file> |
+| Manage user profile readability on mobile width | PENDING | tables scrollable and labels visible, evidence=<file> |
+| Appeals table readability after SLA/escalation columns | PENDING | narrow viewport check, evidence=<file> |
+| Trade feedback moderation table readability | PENDING | filters/actions accessible, evidence=<file> |
+
+## Evidence
+
+- Risk gate screenshots/log snippets:
+- Appeals SLA/escalation screenshots:
+- Trust surface screenshots (`/manage/users`, `/auctions`, `/signals`, `/appeals`):
+- Trade feedback command traces and DB rows:
+- Trade feedback moderation screenshots:
+- Manage user reputation screenshots:
+- Other notes/artifacts:
+
+## Final Verdict
+
+- Release candidate readiness:
+- Blocking issues (if any):
+- Follow-up tasks (if any):

--- a/docs/release/rc-2-notes.md
+++ b/docs/release/rc-2-notes.md
@@ -1,0 +1,56 @@
+# Release Candidate 2 Notes
+
+Date: 2026-02-14
+Last automated re-check: 2026-02-14
+Branch: `main`
+
+## Scope Included
+
+- Sprint 32 trust/risk implementation increments.
+- High-risk publish gate for sellers without assigned guarantor.
+- Appeals SLA and escalation visibility improvements in web admin.
+- Trust indicators expansion across user/auction/appeal/signal views.
+- Post-trade feedback foundation and moderation controls.
+- User profile reputation summary based on trade feedback.
+
+## Merged Release Increments
+
+- PR #44: user risk snapshot indicators in admin.
+- PR #45: high-risk guarantor publish gate.
+- PR #46: appeals SLA states and escalation markers.
+- PR #47: trust indicators on admin user/auction lists.
+- PR #48: trust indicators on appeals/signals views.
+- PR #49: post-trade feedback foundation + moderation view.
+- PR #50: manage user reputation summary.
+
+## Automated Verification (latest)
+
+- `.venv/bin/python -m ruff check app tests alembic` -> PASS
+- `.venv/bin/python -m pytest -q tests` -> PASS (`42 passed, 1 skipped`)
+- Integration run #1 -> PASS (`90 passed`)
+- Integration run #2 (anti-flaky) -> PASS (`90 passed`)
+
+## Manual QA Status
+
+- RC-2 matrix prepared: `docs/release/rc-2-manual-qa-matrix.md`.
+- Execution status: pending manual run/sign-off.
+
+## Current Verdict
+
+- Automated quality gates: PASS
+- Manual QA evidence: IN PROGRESS
+- RC status: HOLD (until matrix sign-off)
+
+## Go-Live Checklist
+
+- [x] Code quality gates and anti-flaky rerun are green.
+- [ ] Manual RC-2 matrix finalized.
+- [ ] Product/owner rollout window confirmed.
+
+## Rollback Guidance
+
+If post-release validation fails:
+
+1. Revert only the failing increment(s) from PR #44-#50.
+2. Re-run lint + unit + integration gates.
+3. Keep independent stable trust/reputation increments unless directly implicated.


### PR DESCRIPTION
## Summary
- update Sprint 32 implementation plan with actual execution status and merged increments through PR #50
- add `docs/release/rc-2-notes.md` with current scope, automated verification snapshot, and go-live gates
- add `docs/release/rc-2-manual-qa-matrix.md` to track manual verification for trust/risk/reputation changes

## Notes
- documentation-only change
- no runtime code path changes