### PR TITLE
feat: add points utility visibility across bot and web

### DIFF
--- a/app/bot/handlers/moderation.py
+++ b/app/bot/handlers/moderation.py
@@ -482,7 +482,13 @@ async def _render_mod_stats_text() -> str:
         f"- С hint: {snapshot.users_with_soft_gate_hint}\n"
         f"- Конверсия после hint: {snapshot.users_converted_after_hint} ({hint_conv})\n"
         f"- Вовлеченные без private /start: {snapshot.users_engaged_without_private_start}\n"
-        f"- Вовлеченные с private /start: {engaged_with_private}"
+        f"- Вовлеченные с private /start: {engaged_with_private}\n"
+        "\n"
+        "Points utility\n"
+        f"- Активные points-пользователи (7д): {snapshot.points_active_users_7d}\n"
+        f"- Points начислено (24ч): +{snapshot.points_earned_24h}\n"
+        f"- Points списано (24ч): -{snapshot.points_spent_24h}\n"
+        f"- Бустов фидбека (24ч): {snapshot.feedback_boost_redeems_24h}"
     )
 
 

--- a/docs/planning/sprint-32-implementation-plan.md
+++ b/docs/planning/sprint-32-implementation-plan.md
@@ -22,10 +22,13 @@ Reduce complaint pressure and improve trust transparency without introducing hea
   - PR #48: trust indicators on appeals and fraud signals lists.
   - PR #49: post-trade feedback foundation (bot intake + web moderation list).
   - PR #50: manage user reputation summary based on trade feedback.
+  - PR #51: docs sync for sprint status and RC-2 notes.
+  - PR #52: trade feedback moderation ergonomics.
+  - PR #53: points utility v1 feedback priority boost.
 - In progress:
-  - Reputation layer hardening (moderation ergonomics + reporting slices).
+  - Points utility visibility slices in bot/web moderation surfaces.
 - Next:
-  - Points utility/redemption first usable scenario.
+  - Additional redeem mechanics after boost baseline.
 
 ## P0 Scope (Recommended)
 
@@ -115,6 +118,12 @@ Acceptance:
 - Introduce first redeemable utility path for points.
 - Add anti-abuse limits and ledger-safe spend semantics.
 - Add basic user-facing usage docs and moderator controls.
+
+### PR-54: Points Utility v1.1 Visibility
+
+- Add points utility KPIs to web and bot moderation stats output.
+- Add per-user boost usage counters on `/manage/user/{id}`.
+- Add user-facing `/points` policy hints for boost cost and remaining daily limit.
 
 ## Non-Goals for Sprint 32
 


### PR DESCRIPTION
## Summary
- Add points utility visibility to user and moderator surfaces: `/points` now shows boost cost and remaining daily limit, `/modstats` now includes points utility KPIs, and web dashboard includes the same points utility slice.
- Add per-user boost usage counters on `/manage/user/{id}` (`boost count` and `total points spent on boosts`) for faster moderation triage and support context.
- Introduce integration coverage for new visibility outputs in points, modstats, manage-user, and dashboard views; update Sprint 32 plan status with PR #53 done and PR #54 scope.

## Validation
- `.venv/bin/python -m ruff check app tests alembic` ✅
- `.venv/bin/python -m pytest -q tests` ✅ (`42 passed, 1 skipped`)
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@<liteauction-db-ip>:5432/auction_test .venv/bin/python -m pytest -q tests/integration` ✅ (`99 passed`)
- Re-ran integration suite for anti-flaky gate ✅ (`99 passed`)