### PR TITLE
fix: isolate integration database from runtime compose DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,10 +321,14 @@ python -m venv .venv
 - Run DB integration tests (use a dedicated test database):
 
 ```bash
+docker compose exec -T db psql -U auction -d postgres -c "CREATE DATABASE auction_test OWNER auction;" || true
+DB_IP=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' liteauction-db)
 RUN_INTEGRATION_TESTS=1 \
-TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_test \
+TEST_DATABASE_URL="postgresql+asyncpg://auction:auction@${DB_IP}:5432/auction_test" \
 .venv/bin/python -m pytest -q tests/integration
 ```
+
+Integration tests refuse to run unless `TEST_DATABASE_URL` is set and points to a database name containing `test`.
 
 - Open moderation command list in bot private chat:
 
@@ -394,6 +398,15 @@ Use it as a reply to a message that contains premium/custom emoji.
 High-risk sellers cannot publish drafts until a guarantor request is assigned by moderation.
 
 Trade feedback moderation list is available in admin web: `/trade-feedback` (status/rating/actor filters).
+
+Current points redemption guardrails:
+
+- Global kill-switch for all redemptions.
+- Global cooldown between redemptions.
+- Global redemption count caps: daily, weekly.
+- Global redemption spend caps: daily, weekly, monthly.
+- Global account gates: minimum retained balance, minimum account age, minimum earned points.
+- Policy visibility in `/points`, `/modstats`, dashboard, and `/manage/user/{id}`.
 
 - Include moderation queue destination in env (recommended):
 

--- a/docs/planning/sprint-32-implementation-plan.md
+++ b/docs/planning/sprint-32-implementation-plan.md
@@ -41,10 +41,29 @@ Reduce complaint pressure and improve trust transparency without introducing hea
   - PR #67: points utility v3.2 minimum earned points guardrail.
   - PR #68: points utility v3.3 weekly spend cap guardrail.
   - PR #69: points utility v3.4 weekly redemption cap guardrail.
+- PR #70: points utility v3.5 monthly spend cap guardrail.
 - In progress:
-  - PR #70: points utility v3.5 monthly spend cap guardrail.
+  - None (ready for next incremental redeem-mechanics slice).
 - Next:
+  - PR #71 candidate: points utility v3.6 monthly redemption cap guardrail.
   - Additional redeem mechanics after feedback/guarantor/appeal boosts baseline.
+
+## Functional Coverage Snapshot (After PR-70)
+
+- Redeem paths: `feedback`, `guarantor`, `appeal`.
+- Global gates: redemption on/off, cooldown, min retained balance, min account age, min earned points.
+- Global volume caps: daily + weekly redemption count caps.
+- Global spend caps: daily + weekly + monthly spend caps.
+- Policy visibility parity: `/points`, `/modstats`, web dashboard, `/manage/user/{id}`.
+- Integration coverage includes positive and negative paths for all listed global guardrails.
+
+## Remaining Gaps / Not Yet Implemented
+
+- Global monthly redemption count cap (count-based, parity with monthly spend cap).
+- Per-utility global spend/count caps (separate from per-utility daily limits and cooldowns).
+- Configurable period semantics (fixed UTC calendar windows are used now).
+- Operator runtime policy editing UI/API (current model is env-driven config + deploy cycle).
+- Boundary-focused integration scenarios for week/month rollover timestamps.
 
 ## P0 Scope (Recommended)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from urllib.parse import urlsplit
 
 import pytest
 import pytest_asyncio
@@ -14,9 +15,17 @@ if os.getenv("RUN_INTEGRATION_TESTS") != "1":
 
 @pytest_asyncio.fixture
 async def integration_engine():
-    db_url = os.getenv("TEST_DATABASE_URL") or os.getenv("DATABASE_URL")
+    db_url = (os.getenv("TEST_DATABASE_URL") or "").strip()
     if not db_url:
-        pytest.skip("No TEST_DATABASE_URL or DATABASE_URL set")
+        pytest.skip("No TEST_DATABASE_URL set")
+
+    parsed = urlsplit(db_url)
+    db_name = parsed.path.lstrip("/").lower()
+    if "test" not in db_name:
+        pytest.exit(
+            "Refusing to run integration tests: TEST_DATABASE_URL must point to a dedicated test database",
+            returncode=2,
+        )
 
     engine = create_async_engine(db_url, future=True)
     try:


### PR DESCRIPTION
## Summary
- harden integration test setup to require `TEST_DATABASE_URL` and refuse unsafe DB names, preventing accidental drops against runtime compose databases
- update local integration runbook to use a dedicated `auction_test` database endpoint and document the enforced safety behavior
- synchronize sprint-32 planning status after PR70 and add a current functional coverage/gaps snapshot for the next slice

## Testing
- `.venv/bin/ruff check app tests`
- `.venv/bin/pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@<db-ip>:5432/auction_test .venv/bin/pytest -q tests/integration` (pass 1)
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@<db-ip>:5432/auction_test .venv/bin/pytest -q tests/integration` (pass 2)