### PR TITLE
feat: improve trade feedback moderation drilldowns

### DIFF
--- a/docs/planning/sprint-32-implementation-plan.md
+++ b/docs/planning/sprint-32-implementation-plan.md
@@ -43,11 +43,11 @@ Reduce complaint pressure and improve trust transparency without introducing hea
   - PR #69: points utility v3.4 weekly redemption cap guardrail.
   - PR #70: points utility v3.5 monthly spend cap guardrail.
   - PR #71: integration DB safety hardening + docs sync.
+  - PR #72: CI/test-db hardening and points stream pause.
 - In progress:
-  - None.
+  - PR #73: moderation ergonomics pass on trade feedback queue and manage-user trust context.
 - Next:
-  - Switch feature stream from points mechanics to trust/moderation product increments.
-  - Candidate PR #72: moderation ergonomics pass on trade feedback queue and manage-user trust context.
+  - Continue trust/moderation feature stream after PR #73.
 
 ## Functional Coverage Snapshot (After PR-70)
 
@@ -258,6 +258,12 @@ Acceptance:
 - Add configurable global monthly spend cap for boost redemptions.
 - Enforce monthly spend cap across `feedback`, `guarantor`, and `appeal` boost redemptions.
 - Surface monthly spend cap policy context in `/points`, `/modstats`, web dashboard, and `/manage/user/{id}`.
+
+### PR-73: Trade Feedback Moderation Ergonomics + Manage-User Trust Links
+
+- Add trade feedback moderation filters by moderation state (`all`/`only`/`none`) and moderator TG user.
+- Surface moderation note in trade feedback table for faster review context.
+- Add manage-user quick links to open trade feedback moderation queue by received/hidden/authored views.
 
 ## Non-Goals for Sprint 32
 

--- a/tests/integration/test_web_manage_user_rewards.py
+++ b/tests/integration/test_web_manage_user_rewards.py
@@ -484,7 +484,9 @@ async def test_manage_user_shows_trade_feedback_reputation(monkeypatch, integrat
     assert "Средняя оценка (видимые):</b> 5.0" in body
     assert "Отличная сделка" in body
     assert "Скрытый отзыв" in body
-    assert "Открыть отзывы пользователя в модерации" in body
+    assert "Отзывы о пользователе (все)" in body
+    assert "Отзывы о пользователе (скрытые)" in body
+    assert "Отзывы, оставленные пользователем" in body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add moderation-state (`all`/`only`/`none`) and moderator TG filters to `/trade-feedback` so operators can narrow queue review to exact moderation slices
- surface moderation note in the trade feedback table and make moderator labels clickable drilldowns for faster triage context
- add manage-user reputation quick links for received all/hidden/authored feedback views and extend integration coverage for the new filters and links

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=... .venv/bin/python -m pytest -q tests/integration` (pass 1)
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=... .venv/bin/python -m pytest -q tests/integration` (pass 2)