### PR TITLE
fix: harden trade feedback visibility moderation actions

### DIFF
--- a/app/web/main.py
+++ b/app/web/main.py
@@ -2650,8 +2650,12 @@ async def action_hide_trade_feedback(
     if not _validate_csrf_token(request, auth, csrf_token):
         return _csrf_failed_response(request, back_to=target)
 
-    actor_user_id = await _resolve_actor_user_id(auth)
     normalized_reason = reason.strip()
+    if not normalized_reason:
+        return _action_error_page(request, "Reason is required", back_to=target)
+
+    actor_user_id = await _resolve_actor_user_id(auth)
+
     async with SessionFactory() as session:
         async with session.begin():
             result = await set_trade_feedback_visibility(
@@ -2700,8 +2704,12 @@ async def action_unhide_trade_feedback(
     if not _validate_csrf_token(request, auth, csrf_token):
         return _csrf_failed_response(request, back_to=target)
 
-    actor_user_id = await _resolve_actor_user_id(auth)
     normalized_reason = reason.strip()
+    if not normalized_reason:
+        return _action_error_page(request, "Reason is required", back_to=target)
+
+    actor_user_id = await _resolve_actor_user_id(auth)
+
     async with SessionFactory() as session:
         async with session.begin():
             result = await set_trade_feedback_visibility(

--- a/docs/planning/sprint-32-implementation-plan.md
+++ b/docs/planning/sprint-32-implementation-plan.md
@@ -44,10 +44,11 @@ Reduce complaint pressure and improve trust transparency without introducing hea
   - PR #70: points utility v3.5 monthly spend cap guardrail.
   - PR #71: integration DB safety hardening + docs sync.
   - PR #72: CI/test-db hardening and points stream pause.
+  - PR #73: trade feedback moderation ergonomics + manage-user trust links.
 - In progress:
-  - PR #73: moderation ergonomics pass on trade feedback queue and manage-user trust context.
+  - PR #74: trade feedback moderation action hardening (reason-required + unhide audit regression coverage).
 - Next:
-  - Continue trust/moderation feature stream after PR #73.
+  - Continue trust/moderation feature stream after PR #74.
 
 ## Functional Coverage Snapshot (After PR-70)
 
@@ -264,6 +265,12 @@ Acceptance:
 - Add trade feedback moderation filters by moderation state (`all`/`only`/`none`) and moderator TG user.
 - Surface moderation note in trade feedback table for faster review context.
 - Add manage-user quick links to open trade feedback moderation queue by received/hidden/authored views.
+
+### PR-74: Trade Feedback Visibility Action Hardening
+
+- Require non-empty moderation reason for web hide/unhide feedback actions.
+- Keep rejected hide/unhide attempts non-destructive when reason is blank.
+- Extend integration coverage for unhide action state/log payload and reason-required validation paths.
 
 ## Non-Goals for Sprint 32
 


### PR DESCRIPTION
## Summary
- require a non-empty moderation reason for `/actions/trade-feedback/hide` and `/actions/trade-feedback/unhide` so audit trails always preserve operator intent
- keep blank-reason attempts non-destructive by returning an action error before any feedback visibility mutation
- extend integration coverage for unhide state/log payload behavior and reason-required rejection paths for both hide and unhide actions

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=... .venv/bin/python -m pytest -q tests/integration` (pass 1)
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=... .venv/bin/python -m pytest -q tests/integration` (pass 2)