### PR TITLE
fix: stabilize auction photo intake and add gallery support

### DIFF
--- a/alembic/versions/0023_add_auction_photos.py
+++ b/alembic/versions/0023_add_auction_photos.py
@@ -1,0 +1,46 @@
+"""add auction photos table
+
+Revision ID: 0023_add_auction_photos
+Revises: 0022_appeal_boost_cols
+Create Date: 2026-02-15 13:30:00
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0023_add_auction_photos"
+down_revision: str | None = "0022_appeal_boost_cols"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "auction_photos",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("auction_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("file_id", sa.Text(), nullable=False),
+        sa.Column("position", sa.SmallInteger(), nullable=False),
+        sa.ForeignKeyConstraint(["auction_id"], ["auctions.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("auction_id", "position", name="uq_auction_photos_auction_position"),
+    )
+    op.create_index("ix_auction_photos_auction_id", "auction_photos", ["auction_id"], unique=False)
+
+    op.execute(
+        """
+        INSERT INTO auction_photos (auction_id, file_id, position)
+        SELECT id, photo_file_id, 0
+        FROM auctions
+        WHERE photo_file_id IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_auction_photos_auction_id", table_name="auction_photos")
+    op.drop_table("auction_photos")

--- a/app/bot/handlers/inline_auction.py
+++ b/app/bot/handlers/inline_auction.py
@@ -70,6 +70,7 @@ async def handle_inline_auction_query(inline_query: InlineQuery) -> None:
             auction_id=str(view.auction.id),
             min_step=view.auction.min_step,
             has_buyout=view.auction.buyout_price is not None,
+            photo_count=view.photo_count,
         ),
         title=f"Аукцион #{str(view.auction.id)[:8]}",
         description="Опубликовать аукцион",

--- a/app/bot/keyboards/auction.py
+++ b/app/bot/keyboards/auction.py
@@ -64,6 +64,14 @@ def buyout_choice_keyboard() -> InlineKeyboardMarkup:
     )
 
 
+def photos_done_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [styled_button(text="Готово", callback_data="create:photos:done", style="success")],
+        ]
+    )
+
+
 def duration_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         inline_keyboard=[
@@ -90,7 +98,7 @@ def anti_sniper_keyboard() -> InlineKeyboardMarkup:
     )
 
 
-def draft_publish_keyboard(auction_id: str) -> InlineKeyboardMarkup:
+def draft_publish_keyboard(auction_id: str, photo_count: int) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         inline_keyboard=[
             [
@@ -101,13 +109,32 @@ def draft_publish_keyboard(auction_id: str) -> InlineKeyboardMarkup:
                     icon_custom_emoji_id=_icon(settings.ui_emoji_publish_id),
                 )
             ],
+            [
+                styled_button(
+                    text=f"Все фото ({photo_count})",
+                    callback_data=f"gallery:{auction_id}",
+                    style="primary",
+                )
+            ],
             [styled_button(text="Создать новый лот", callback_data="create:new")],
         ]
     )
 
 
-def auction_active_keyboard(auction_id: str, min_step: int, has_buyout: bool) -> InlineKeyboardMarkup:
+def auction_active_keyboard(
+    auction_id: str,
+    min_step: int,
+    has_buyout: bool,
+    photo_count: int = 1,
+) -> InlineKeyboardMarkup:
     rows: list[list[InlineKeyboardButton]] = [
+        [
+            styled_button(
+                text=f"Все фото ({photo_count})",
+                callback_data=f"gallery:{auction_id}",
+                style="primary",
+            )
+        ],
         [
             styled_button(
                 text=f"+ ${min_step} x1",

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -105,6 +105,23 @@ class Auction(Base, TimestampMixin):
     )
 
 
+class AuctionPhoto(Base):
+    __tablename__ = "auction_photos"
+    __table_args__ = (
+        UniqueConstraint("auction_id", "position", name="uq_auction_photos_auction_position"),
+        Index("ix_auction_photos_auction_id", "auction_id"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    auction_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("auctions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    file_id: Mapped[str] = mapped_column(Text, nullable=False)
+    position: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+
+
 class Bid(Base):
     __tablename__ = "bids"
     __table_args__ = (CheckConstraint("amount >= 1", name="bids_amount_positive"),)

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ import logging
 from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
+from aiogram.fsm.storage.memory import MemoryStorage, SimpleEventIsolation
 from aiogram.types import BotCommand, BotCommandScopeAllPrivateChats
 
 from app.bot.handlers import router as start_router
@@ -49,7 +50,7 @@ async def run() -> None:
         token=settings.bot_token,
         default=DefaultBotProperties(parse_mode=ParseMode.HTML),
     )
-    dp = Dispatcher()
+    dp = Dispatcher(storage=MemoryStorage(), events_isolation=SimpleEventIsolation())
     dp.include_router(start_router)
 
     await startup_checks()

--- a/tests/test_create_auction_handlers.py
+++ b/tests/test_create_auction_handlers.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import pytest
+
+from app.bot.handlers.create_auction import (
+    create_description_collect_photo,
+    create_photo_step,
+    create_photos_done,
+)
+from app.bot.states.auction_create import AuctionCreateStates
+
+
+class _DummyPhoto:
+    def __init__(self, file_id: str) -> None:
+        self.file_id = file_id
+
+
+class _DummyMessage:
+    def __init__(
+        self,
+        *,
+        text: str | None = None,
+        photo_file_id: str | None = None,
+        media_group_id: str | None = None,
+    ) -> None:
+        self.text = text
+        self.photo = [_DummyPhoto(photo_file_id)] if photo_file_id is not None else []
+        self.media_group_id = media_group_id
+        self.answers: list[str] = []
+
+    async def answer(self, text: str, **_kwargs) -> None:
+        self.answers.append(text)
+
+
+class _DummyCallback:
+    def __init__(self, data: str, message: _DummyMessage | None = None) -> None:
+        self.data = data
+        self.message = message
+        self.from_user = object()
+        self.answers: list[tuple[str, bool]] = []
+
+    async def answer(self, text: str = "", show_alert: bool = False, **_kwargs) -> None:
+        self.answers.append((text, show_alert))
+
+
+class _DummyState:
+    def __init__(self) -> None:
+        self.state = None
+        self.data: dict[str, object] = {}
+
+    async def clear(self) -> None:
+        self.state = None
+        self.data = {}
+
+    async def set_state(self, state) -> None:
+        self.state = state
+
+    async def update_data(self, **kwargs) -> None:
+        self.data.update(kwargs)
+
+    async def get_data(self) -> dict[str, object]:
+        return dict(self.data)
+
+
+@pytest.mark.asyncio
+async def test_album_flow_prompts_description_once() -> None:
+    state = _DummyState()
+    await state.set_state(AuctionCreateStates.waiting_photo)
+
+    first_photo = _DummyMessage(photo_file_id="photo-1", media_group_id="album-1")
+    second_photo = _DummyMessage(photo_file_id="photo-2", media_group_id="album-1")
+    await create_photo_step(first_photo, state)
+    await create_photo_step(second_photo, state)
+
+    callback_message = _DummyMessage()
+    done_callback = _DummyCallback("create:photos:done", message=callback_message)
+    await create_photos_done(done_callback, state)
+
+    trailing_album_photo = _DummyMessage(photo_file_id="photo-3", media_group_id="album-1")
+    await create_description_collect_photo(trailing_album_photo, state)
+
+    assert state.state == AuctionCreateStates.waiting_description
+    assert callback_message.answers.count("Отлично. Теперь отправьте описание лота.") == 1
+    assert trailing_album_photo.answers == []
+
+
+@pytest.mark.asyncio
+async def test_done_without_photos_shows_alert() -> None:
+    state = _DummyState()
+    await state.set_state(AuctionCreateStates.waiting_photo)
+
+    done_callback = _DummyCallback("create:photos:done", message=_DummyMessage())
+    await create_photos_done(done_callback, state)
+
+    assert done_callback.answers == [("Сначала добавьте хотя бы одно фото", True)]
+    assert state.state == AuctionCreateStates.waiting_photo


### PR DESCRIPTION
## Summary
- Fixes duplicate "Пришлите описание текстом" / description prompts when a seller sends multiple photos (album/media group) during `/newauction`.
- Adds full multi-photo support for auction drafts (up to 10 photos), while preserving one-photo interactive auction cards for bidding.
- Introduces a "Все фото (N)" gallery action so buyers can open all lot photos in private chat without breaking current inline publication flow.

## Problem
When users sent more than one photo while creating an auction, Telegram delivered album messages as separate updates. In the previous flow, photo intake moved to description state too early and remaining album updates triggered repeated invalid-state prompts ("Пришлите описание текстом"), creating noisy UX.

## What changed
### 1) Stable photo intake in create flow
- `app/bot/handlers/create_auction.py`
  - Reworked `waiting_photo` step into multi-photo collection mode (up to 10 photos).
  - Added explicit completion action via `Готово` callback (`create:photos:done`) before moving to description.
  - Deduplicates photo file ids in FSM data and preserves the first as cover photo.
  - Allows adding extra photos even on `waiting_description` if user continues sending images.
  - Prevents album tail updates from spamming repeated description error prompts.

### 2) FSM update isolation (race reduction)
- `app/main.py`
  - Dispatcher now uses `MemoryStorage` + `SimpleEventIsolation` to serialize per-user FSM event handling and reduce state races.

### 3) Persistent storage for multiple lot photos
- `app/db/models.py`
  - Added `AuctionPhoto` model with ordered positions and uniqueness per `(auction_id, position)`.
- `alembic/versions/0023_add_auction_photos.py`
  - Creates `auction_photos` table and index.
  - Backfills existing auctions into gallery table from legacy `auctions.photo_file_id` as position `0`.

### 4) Service layer updates
- `app/services/auction_service.py`
  - `create_draft_auction(...)` now accepts `photo_file_ids` and stores ordered gallery rows.
  - Added `load_auction_photo_ids(...)`.
  - `AuctionView` now includes `photo_count`.
  - Auction caption now displays `Фото: N`.
  - Active post keyboard refresh now includes gallery photo count.

### 5) UI/keyboard/gallery behavior
- `app/bot/keyboards/auction.py`
  - Added `photos_done_keyboard()` for create flow.
  - `draft_publish_keyboard(...)` and `auction_active_keyboard(...)` now include `Все фото (N)`.
- `app/bot/handlers/bid_actions.py`
  - Added `gallery:<auction_id>` callback handler.
  - Sends all lot photos to user DM (`send_photo` for single, `send_media_group` chunks for multiple).
  - Handles forbidden/bad request cases with user-friendly alerts.
- `app/bot/handlers/inline_auction.py`
  - Passes `photo_count` into active keyboard for inline publication preview.

## Backward compatibility
- Existing auction cards remain interactive single-photo cards (required by current inline + edit-caption flow).
- Existing data is preserved; migration backfills current `photo_file_id` into new gallery storage.

## Testing
### Automated
- `./.venv/bin/python -m ruff check app tests alembic`
- `./.venv/bin/python -m pytest -q tests/test_create_auction_handlers.py`

### Added regression tests
- `tests/test_create_auction_handlers.py`
  - album flow prompts description once after `Готово`
  - pressing `Готово` without photos shows alert and keeps state

### Migration check
- Applied and verified in dockerized environment:
  - `alembic upgrade head`
  - current revision: `0023_add_auction_photos (head)`

## Risks / notes
- Gallery delivery depends on user having opened bot DM (handled with existing soft-gate style alert when forbidden).
- Photo cap is intentionally limited to 10 for predictable Telegram media-group batching and UX consistency.