### PR TITLE
feat: publish auctions to topics and harden post refresh

### DIFF
--- a/app/bot/handlers/__init__.py
+++ b/app/bot/handlers/__init__.py
@@ -8,6 +8,7 @@ from .guarantor import router as guarantor_router
 from .inline_auction import router as inline_auction_router
 from .moderation import router as moderation_router
 from .points import router as points_router
+from .publish_auction import router as publish_auction_router
 from .start import router as start_router
 from .trade_feedback import router as trade_feedback_router
 
@@ -20,6 +21,7 @@ router.include_router(inline_auction_router)
 router.include_router(feedback_router)
 router.include_router(guarantor_router)
 router.include_router(points_router)
+router.include_router(publish_auction_router)
 router.include_router(trade_feedback_router)
 router.include_router(moderation_router)
 

--- a/app/bot/handlers/create_auction.py
+++ b/app/bot/handlers/create_auction.py
@@ -331,7 +331,10 @@ async def create_anti_sniper_step(callback: CallbackQuery, state: FSMContext) ->
         return
 
     await callback.message.answer(
-        "Нажмите 'Опубликовать в чате/канале', выберите нужный чат/раздел и отправьте карточку."
+        "Для публикации в нужный раздел откройте этот раздел и отправьте команду "
+        f"<code>/publish {view.auction.id}</code>.\n"
+        "Можно нажать кнопку 'Скопировать /publish'.\n\n"
+        "Кнопка 'Опубликовать в чате/канале' доступна как fallback через inline mode."
     )
 
 

--- a/app/bot/handlers/publish_auction.py
+++ b/app/bot/handlers/publish_auction.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import uuid
+
+from aiogram import Bot, F, Router
+from aiogram.enums import ChatType
+from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError
+from aiogram.filters import Command
+from aiogram.types import InputMediaPhoto, Message
+
+from app.bot.keyboards.auction import auction_active_keyboard
+from app.db.enums import AuctionStatus
+from app.db.session import SessionFactory
+from app.services.auction_service import (
+    activate_auction_chat_post,
+    load_auction_view,
+    load_auction_photo_ids,
+    parse_auction_uuid,
+    refresh_auction_posts,
+    render_auction_caption,
+)
+from app.services.publish_gate_service import evaluate_seller_publish_gate
+from app.services.user_service import upsert_user
+
+router = Router(name="publish_auction")
+
+
+def _extract_publish_auction_id(text: str | None) -> uuid.UUID | None:
+    raw = (text or "").strip()
+    parts = raw.split(maxsplit=1)
+    if len(parts) != 2:
+        return None
+    return parse_auction_uuid(parts[1].strip())
+
+
+def _chunk_photo_ids(photo_ids: list[str], chunk_size: int = 10) -> list[list[str]]:
+    if chunk_size <= 0:
+        chunk_size = 10
+    return [photo_ids[index : index + chunk_size] for index in range(0, len(photo_ids), chunk_size)]
+
+
+async def _send_auction_album(
+    bot: Bot,
+    *,
+    chat_id: int,
+    message_thread_id: int | None,
+    photo_ids: list[str],
+) -> None:
+    for chunk_index, chunk in enumerate(_chunk_photo_ids(photo_ids, chunk_size=10)):
+        media = [
+            InputMediaPhoto(
+                media=file_id,
+                caption="Фото лота" if chunk_index == 0 and item_index == 0 else None,
+            )
+            for item_index, file_id in enumerate(chunk)
+        ]
+        if message_thread_id is not None:
+            await bot.send_media_group(chat_id=chat_id, message_thread_id=message_thread_id, media=media)
+        else:
+            await bot.send_media_group(chat_id=chat_id, media=media)
+
+
+@router.message(Command("publish"), F.chat.type.in_({ChatType.GROUP, ChatType.SUPERGROUP}))
+async def publish_auction_to_current_chat(message: Message, bot: Bot) -> None:
+    if message.from_user is None or message.chat is None:
+        return
+
+    auction_id = _extract_publish_auction_id(message.text)
+    if auction_id is None:
+        await message.answer("Формат: /publish <auction_id>")
+        return
+
+    publisher_user_id: int | None = None
+    view = None
+    photo_ids: list[str] = []
+    async with SessionFactory() as session:
+        async with session.begin():
+            publisher = await upsert_user(session, message.from_user, mark_private_started=True)
+            publisher_user_id = publisher.id
+            view = await load_auction_view(session, auction_id)
+            if view is None:
+                await message.answer("Лот не найден")
+                return
+
+            if view.seller.id != publisher.id:
+                await message.answer("Опубликовать лот может только его продавец")
+                return
+
+            if view.auction.status != AuctionStatus.DRAFT:
+                await message.answer("Этот лот уже опубликован или больше не доступен для публикации")
+                return
+
+            publish_gate = await evaluate_seller_publish_gate(session, seller_user_id=publisher.id)
+            if not publish_gate.allowed:
+                await message.answer(publish_gate.block_message or "Публикация временно ограничена")
+                return
+
+            photo_ids = await load_auction_photo_ids(session, auction_id)
+            if not photo_ids:
+                photo_ids = [view.auction.photo_file_id]
+
+    if view is None or publisher_user_id is None:
+        return
+
+    if len(photo_ids) > 1:
+        try:
+            await _send_auction_album(
+                bot,
+                chat_id=message.chat.id,
+                message_thread_id=message.message_thread_id,
+                photo_ids=photo_ids,
+            )
+        except TelegramBadRequest:
+            pass
+        except TelegramForbiddenError:
+            pass
+
+    try:
+        sent_message = await bot.send_photo(
+            chat_id=message.chat.id,
+            message_thread_id=message.message_thread_id,
+            photo=view.auction.photo_file_id,
+            caption=render_auction_caption(view, publish_pending=True),
+            reply_markup=auction_active_keyboard(
+                auction_id=str(view.auction.id),
+                min_step=view.auction.min_step,
+                has_buyout=view.auction.buyout_price is not None,
+                photo_count=view.photo_count,
+            ),
+        )
+    except TelegramForbiddenError:
+        await message.answer("Бот не может публиковать в этом чате/разделе. Проверьте права бота.")
+        return
+    except TelegramBadRequest:
+        await message.answer("Не удалось опубликовать лот в этом чате/разделе")
+        return
+
+    activated = None
+    async with SessionFactory() as session:
+        async with session.begin():
+            activated = await activate_auction_chat_post(
+                session,
+                auction_id=auction_id,
+                publisher_user_id=publisher_user_id,
+                chat_id=sent_message.chat.id,
+                message_id=sent_message.message_id,
+            )
+
+    if activated is None:
+        try:
+            await bot.delete_message(chat_id=sent_message.chat.id, message_id=sent_message.message_id)
+        except TelegramForbiddenError:
+            pass
+        except TelegramBadRequest:
+            pass
+        await message.answer("Лот уже был опубликован. Обновите статус в личном чате с ботом.")
+        return
+
+    await refresh_auction_posts(bot, auction_id)
+    try:
+        await bot.delete_message(chat_id=message.chat.id, message_id=message.message_id)
+    except TelegramForbiddenError:
+        pass
+    except TelegramBadRequest:
+        pass

--- a/app/bot/keyboards/auction.py
+++ b/app/bot/keyboards/auction.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.types import CopyTextButton, InlineKeyboardButton, InlineKeyboardMarkup
 
 from app.config import settings
 
@@ -17,9 +17,10 @@ def styled_button(
     style: str | None = None,
     icon_custom_emoji_id: str | None = None,
     switch_inline_query: str | None = None,
+    copy_text: str | None = None,
     url: str | None = None,
 ) -> InlineKeyboardButton:
-    payload: dict[str, str] = {"text": text}
+    payload: dict[str, object] = {"text": text}
     if callback_data is not None:
         payload["callback_data"] = callback_data
     if style is not None:
@@ -28,6 +29,8 @@ def styled_button(
         payload["icon_custom_emoji_id"] = icon_custom_emoji_id
     if switch_inline_query is not None:
         payload["switch_inline_query"] = switch_inline_query
+    if copy_text is not None:
+        payload["copy_text"] = CopyTextButton(text=copy_text)
     if url is not None:
         payload["url"] = url
     return InlineKeyboardButton.model_validate(payload)
@@ -107,6 +110,13 @@ def draft_publish_keyboard(auction_id: str, photo_count: int) -> InlineKeyboardM
                     switch_inline_query=f"auc_{auction_id}",
                     style="primary",
                     icon_custom_emoji_id=_icon(settings.ui_emoji_publish_id),
+                )
+            ],
+            [
+                styled_button(
+                    text="Скопировать /publish",
+                    copy_text=f"/publish {auction_id}",
+                    style="success",
                 )
             ],
             [

--- a/tests/test_auction_service_resilience.py
+++ b/tests/test_auction_service_resilience.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.db.enums import AuctionStatus
+from app.services import auction_service
+
+
+@pytest.mark.asyncio
+async def test_process_bid_action_non_active_requests_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get_auction_by_id(_session, _auction_id, *, for_update: bool = False):
+        _ = for_update
+        return SimpleNamespace(status=AuctionStatus.ENDED)
+
+    monkeypatch.setattr(auction_service, "get_auction_by_id", fake_get_auction_by_id)
+
+    result = await auction_service.process_bid_action(
+        session=object(),
+        auction_id=uuid.uuid4(),
+        bidder_user_id=1,
+        multiplier=1,
+        is_buyout=False,
+    )
+
+    assert result.success is False
+    assert result.should_refresh is True
+    assert result.alert_text == "Аукцион не активен"
+
+
+@pytest.mark.asyncio
+async def test_safe_refresh_posts_swallows_refresh_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[uuid.UUID] = []
+
+    async def fake_refresh(_bot, auction_id: uuid.UUID) -> None:
+        calls.append(auction_id)
+        raise RuntimeError("refresh failed")
+
+    monkeypatch.setattr(auction_service, "refresh_auction_posts", fake_refresh)
+
+    auction_id = uuid.uuid4()
+    await auction_service._safe_refresh_auction_posts(bot=object(), auction_id=auction_id)
+
+    assert calls == [auction_id]

--- a/tests/test_publish_auction_helpers.py
+++ b/tests/test_publish_auction_helpers.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import uuid
+
+from app.bot.handlers.publish_auction import _chunk_photo_ids, _extract_publish_auction_id
+from app.bot.keyboards.auction import draft_publish_keyboard
+
+
+def test_extract_publish_auction_id_parses_uuid() -> None:
+    auction_id = uuid.uuid4()
+    parsed = _extract_publish_auction_id(f"/publish {auction_id}")
+    assert parsed == auction_id
+
+
+def test_extract_publish_auction_id_rejects_invalid_input() -> None:
+    assert _extract_publish_auction_id("/publish") is None
+    assert _extract_publish_auction_id("/publish not-a-uuid") is None
+    assert _extract_publish_auction_id(None) is None
+
+
+def test_draft_publish_keyboard_contains_copy_publish_button() -> None:
+    auction_id = str(uuid.uuid4())
+    keyboard = draft_publish_keyboard(auction_id, photo_count=3)
+    buttons = [button for row in keyboard.inline_keyboard for button in row]
+
+    assert any(
+        button.copy_text is not None and button.copy_text.text == f"/publish {auction_id}"
+        for button in buttons
+    )
+
+
+def test_chunk_photo_ids_batches_by_ten() -> None:
+    photo_ids = [f"photo-{index}" for index in range(23)]
+    chunks = _chunk_photo_ids(photo_ids, chunk_size=10)
+
+    assert len(chunks) == 3
+    assert len(chunks[0]) == 10
+    assert len(chunks[1]) == 10
+    assert len(chunks[2]) == 3
+    assert chunks[0][0] == "photo-0"
+    assert chunks[2][-1] == "photo-22"


### PR DESCRIPTION
## Summary
- Adds a dedicated `/publish <auction_id>` flow for forum topics so sellers can publish directly into the selected section (topic), not only via inline mode.
- Improves publish UX with a one-tap copy button for `/publish`, multi-photo album posting on topic publish, and auto-cleanup of the command message after success.
- Hardens auction post refresh/finalization so stale "Активен" cards recover reliably even when Telegram API returns transient errors.

## Problem
Two production issues were observed:
1. Publishing to a forum chat via inline flow opened General and didn’t reliably target the intended topic section.
2. Some posts stayed visually "Активен" after auction end, while bid callbacks already returned "Аукцион завершен" (state in DB was updated, UI refresh could be missed).

## What changed
### 1) Topic-aware publish command
- New handler: `app/bot/handlers/publish_auction.py`
  - Adds `/publish <auction_id>` in group/supergroup chats.
  - Validates auction id, ownership, draft status, and seller publish gate.
  - Publishes into the current topic via `message_thread_id` from the command context.
  - Uses service activation path to create chat-based `AuctionPost` record and switch auction to `ACTIVE`.

### 2) Multi-photo publish in topic flow
- On `/publish`, the bot now loads all stored lot photos and sends them as media groups (chunks of 10), then posts the interactive auction card.
- Keeps one dedicated interactive card (photo + caption + buttons) for further bid-driven updates.

### 3) Chat cleanliness after publish
- After successful `/publish`, bot attempts to delete the user command message.
- If deletion rights are missing, publish still succeeds (errors are swallowed for this cleanup step).

### 4) Draft UX improvements for `/publish`
- `app/bot/keyboards/auction.py`
  - Adds `copy_text` support to `styled_button(...)`.
  - Adds `Скопировать /publish` button in draft publish keyboard.
- `app/bot/handlers/create_auction.py`
  - Replaces final publish hint with explicit topic-first instructions and inline as fallback.
- `app/bot/handlers/__init__.py`
  - Registers `publish_auction` router.

### 5) Refresh/finalization resilience
- `app/services/auction_service.py`
  - `process_bid_action(...)` now returns `should_refresh=True` for any non-active auction to force card self-healing on button taps.
  - `refresh_auction_posts(...)` now handles additional transient Telegram exceptions:
    - `TelegramRetryAfter`
    - `TelegramNetworkError`
    - `TelegramServerError`
    - generic `TelegramAPIError`
  - Adds `_safe_refresh_auction_posts(...)` and uses it from `finalize_expired_auctions(...)` so one refresh failure does not break processing of other expired auctions.

## Why this helps
- Topic publishing becomes deterministic for forum chats (no dependency on inline chat picker behavior).
- Auction cards become much more resilient to temporary Telegram API instability and recover visually faster.
- User flow is cleaner and easier (`copy command` + auto command cleanup).

## Tests
Added:
- `tests/test_publish_auction_helpers.py`
  - parse `/publish` argument
  - invalid argument handling
  - keyboard contains copy button
  - photo chunking into batches of 10
- `tests/test_auction_service_resilience.py`
  - non-active auction returns `should_refresh=True`
  - safe refresh wrapper swallows refresh exceptions

Executed locally:
- `./.venv/bin/python -m ruff check app tests`
- `./.venv/bin/python -m pytest -q tests/test_auction_service_resilience.py tests/test_publish_auction_helpers.py tests/test_create_auction_handlers.py`

## Backward compatibility
- Inline publish flow remains available as fallback.
- Existing auction/bid logic remains intact; this PR extends behavior without schema changes.