### PR TITLE
[Sprint 34][S34-002] add suggested post moderation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - Outbox-driven automation for approved feedback -> GitHub issue creation with retry/backoff
 - Full private-chat topic routing for bot DM (`Лоты`, `Поддержка`, `Баллы`, `Сделки`, `Модерация`) with strict command/topic enforcement and `/topics`
 - Channel DM lot intake foundation (Bot API 9.2) via `direct_messages_topic_id` for `/newauction`
+- Suggested post moderation pipeline for channel DM topics (approve/decline + persisted review audit)
 - Sprint planning automation via TOML manifests + GitHub issue/draft-PR sync + PR policy gate (`Closes #...` + `sprint:*` label)
 
 ## Sprint 0 Checklist
@@ -525,6 +526,7 @@ Channel DM lot intake (Bot API 9.2):
 
 - `CHANNEL_DM_INTAKE_ENABLED` - enables `/newauction` intake in channel DM topics.
 - `CHANNEL_DM_INTAKE_CHAT_ID` - optional chat allowlist; `0` allows any direct-messages chat.
+- Incoming `suggested_post_info` events from enabled channel DM chats are routed to moderation with approve/decline actions.
 
 Examples:
 

--- a/alembic/versions/0025_add_suggested_post_reviews.py
+++ b/alembic/versions/0025_add_suggested_post_reviews.py
@@ -1,0 +1,79 @@
+"""add suggested post reviews table
+
+Revision ID: 0025_add_suggested_post_reviews
+Revises: 0024_add_user_private_topics
+Create Date: 2026-02-15 23:05:00
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0025_add_suggested_post_reviews"
+down_revision: str | None = "0024_add_user_private_topics"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "suggested_post_reviews",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("source_chat_id", sa.BigInteger(), nullable=False),
+        sa.Column("source_message_id", sa.BigInteger(), nullable=False),
+        sa.Column("source_direct_messages_topic_id", sa.BigInteger(), nullable=True),
+        sa.Column("submitter_user_id", sa.BigInteger(), nullable=True),
+        sa.Column("submitter_tg_user_id", sa.BigInteger(), nullable=True),
+        sa.Column("queue_chat_id", sa.BigInteger(), nullable=True),
+        sa.Column("queue_message_id", sa.BigInteger(), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False, server_default=sa.text("'PENDING'")),
+        sa.Column("decision_note", sa.Text(), nullable=True),
+        sa.Column("decided_by_user_id", sa.BigInteger(), nullable=True),
+        sa.Column("decided_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("TIMEZONE('utc', NOW())"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("TIMEZONE('utc', NOW())"),
+        ),
+        sa.CheckConstraint(
+            "status IN ('PENDING', 'APPROVED', 'DECLINED', 'FAILED')",
+            name="suggested_post_reviews_status_values",
+        ),
+        sa.ForeignKeyConstraint(["decided_by_user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["submitter_user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "source_chat_id",
+            "source_message_id",
+            name="uq_suggested_post_reviews_source",
+        ),
+    )
+    op.create_index(
+        "ix_suggested_post_reviews_status",
+        "suggested_post_reviews",
+        ["status"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_suggested_post_reviews_status_created_at",
+        "suggested_post_reviews",
+        ["status", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_suggested_post_reviews_status_created_at", table_name="suggested_post_reviews")
+    op.drop_index("ix_suggested_post_reviews_status", table_name="suggested_post_reviews")
+    op.drop_table("suggested_post_reviews")

--- a/app/bot/handlers/__init__.py
+++ b/app/bot/handlers/__init__.py
@@ -10,6 +10,7 @@ from .moderation import router as moderation_router
 from .points import router as points_router
 from .publish_auction import router as publish_auction_router
 from .start import router as start_router
+from .suggested_posts import router as suggested_posts_router
 from .trade_feedback import router as trade_feedback_router
 
 router = Router(name="root")
@@ -23,6 +24,7 @@ router.include_router(guarantor_router)
 router.include_router(points_router)
 router.include_router(publish_auction_router)
 router.include_router(trade_feedback_router)
+router.include_router(suggested_posts_router)
 router.include_router(moderation_router)
 
 __all__ = ["router"]

--- a/app/bot/handlers/suggested_posts.py
+++ b/app/bot/handlers/suggested_posts.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from aiogram import Bot, F, Router
+from aiogram.enums import ChatType
+from aiogram.exceptions import TelegramAPIError
+from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
+from sqlalchemy import select
+
+from app.db.models import SuggestedPostReview
+from app.db.session import SessionFactory
+from app.services.channel_dm_intake_service import (
+    AuctionIntakeKind,
+    resolve_auction_intake_actor,
+    resolve_auction_intake_context,
+)
+from app.services.moderation_topic_router import ModerationTopicSection, send_section_message
+from app.services.rbac_service import SCOPE_AUCTION_MANAGE, resolve_tg_user_scopes
+from app.services.user_service import upsert_user
+
+router = Router(name="suggested_posts")
+
+_CALLBACK_PREFIX = "spp"
+_CALLBACK_ACTION_APPROVE = "ap"
+_CALLBACK_ACTION_DECLINE = "dc"
+
+_DECLINE_REASON_MAP: dict[str, str] = {
+    "rules": "Нарушение правил площадки",
+    "spam": "Спам или реклама",
+}
+
+
+@dataclass(slots=True)
+class SuggestedPostDecision:
+    review_id: int
+    approve: bool
+    decline_reason_code: str | None = None
+
+
+def _build_review_keyboard(review_id: int) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="Одобрить",
+                    callback_data=f"{_CALLBACK_PREFIX}:{_CALLBACK_ACTION_APPROVE}:{review_id}",
+                ),
+            ],
+            [
+                InlineKeyboardButton(
+                    text="Отклонить: правила",
+                    callback_data=(
+                        f"{_CALLBACK_PREFIX}:{_CALLBACK_ACTION_DECLINE}:{review_id}:rules"
+                    ),
+                ),
+                InlineKeyboardButton(
+                    text="Отклонить: спам",
+                    callback_data=f"{_CALLBACK_PREFIX}:{_CALLBACK_ACTION_DECLINE}:{review_id}:spam",
+                ),
+            ],
+        ]
+    )
+
+
+def _parse_decision_callback(data: str | None) -> SuggestedPostDecision | None:
+    if not data:
+        return None
+    parts = data.split(":")
+    if len(parts) < 3 or parts[0] != _CALLBACK_PREFIX:
+        return None
+
+    action = parts[1]
+    review_raw = parts[2]
+    if not review_raw.isdigit():
+        return None
+    review_id = int(review_raw)
+
+    if action == _CALLBACK_ACTION_APPROVE:
+        return SuggestedPostDecision(review_id=review_id, approve=True)
+
+    if action == _CALLBACK_ACTION_DECLINE:
+        if len(parts) < 4:
+            return None
+        decline_reason_code = parts[3].strip().lower()
+        if decline_reason_code not in _DECLINE_REASON_MAP:
+            return None
+        return SuggestedPostDecision(
+            review_id=review_id,
+            approve=False,
+            decline_reason_code=decline_reason_code,
+        )
+
+    return None
+
+
+def _source_author_line(message: Message) -> str:
+    actor = resolve_auction_intake_actor(message)
+    if actor is None:
+        return "Источник: неизвестный пользователь"
+    if actor.username:
+        return f"Источник: @{actor.username} (tg:{actor.id})"
+    return f"Источник: tg:{actor.id}"
+
+
+def _review_intro_text(*, review_id: int, message: Message) -> str:
+    topic_id = getattr(getattr(message, "direct_messages_topic", None), "topic_id", None)
+    topic_segment = f" | topic:{topic_id}" if isinstance(topic_id, int) else ""
+    return (
+        "🧩 Новый suggested post в DM канала\n"
+        f"review_id: <code>{review_id}</code>\n"
+        f"source_chat: <code>{message.chat.id}</code>\n"
+        f"source_message: <code>{message.message_id}</code>{topic_segment}\n"
+        f"{_source_author_line(message)}\n"
+        "\n"
+        "Выберите решение модерации:"
+    )
+
+
+@router.message(F.chat.type == ChatType.SUPERGROUP)
+async def capture_suggested_post(message: Message, bot: Bot) -> None:
+    if getattr(message, "suggested_post_info", None) is None:
+        return
+
+    context = resolve_auction_intake_context(message)
+    if context.kind != AuctionIntakeKind.CHANNEL_DM:
+        return
+    if context.chat_id is None:
+        return
+
+    existing_review_id: int | None = None
+    actor = resolve_auction_intake_actor(message)
+    async with SessionFactory() as session:
+        async with session.begin():
+            existing = await session.scalar(
+                select(SuggestedPostReview).where(
+                    SuggestedPostReview.source_chat_id == context.chat_id,
+                    SuggestedPostReview.source_message_id == message.message_id,
+                )
+            )
+            if existing is not None and existing.queue_message_id is not None:
+                return
+            if existing is not None:
+                existing_review_id = existing.id
+            else:
+                submitter_user_id: int | None = None
+                submitter_tg_user_id: int | None = None
+                if actor is not None:
+                    submitter = await upsert_user(session, actor)
+                    submitter_user_id = submitter.id
+                    submitter_tg_user_id = submitter.tg_user_id
+
+                review = SuggestedPostReview(
+                    source_chat_id=context.chat_id,
+                    source_message_id=message.message_id,
+                    source_direct_messages_topic_id=context.direct_messages_topic_id,
+                    submitter_user_id=submitter_user_id,
+                    submitter_tg_user_id=submitter_tg_user_id,
+                    status="PENDING",
+                    payload={
+                        "has_caption": bool(message.caption),
+                        "has_media": any(
+                            getattr(message, key, None) is not None
+                            for key in (
+                                "photo",
+                                "video",
+                                "animation",
+                                "document",
+                            )
+                        ),
+                    },
+                )
+                session.add(review)
+                await session.flush()
+                existing_review_id = review.id
+
+    if existing_review_id is None:
+        return
+
+    moderation_ref = await send_section_message(
+        bot,
+        section=ModerationTopicSection.SUGGESTIONS,
+        text=_review_intro_text(review_id=existing_review_id, message=message),
+        reply_markup=_build_review_keyboard(existing_review_id),
+    )
+
+    if moderation_ref is None:
+        return
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            review = await session.get(SuggestedPostReview, existing_review_id)
+            if review is None:
+                return
+            if review.queue_message_id is None:
+                review.queue_chat_id, review.queue_message_id = moderation_ref
+                review.updated_at = datetime.now(UTC)
+
+
+@router.callback_query(F.data.startswith(f"{_CALLBACK_PREFIX}:"))
+async def handle_suggested_post_decision(callback: CallbackQuery, bot: Bot) -> None:
+    decision = _parse_decision_callback(callback.data)
+    if decision is None:
+        await callback.answer("Некорректное действие", show_alert=True)
+        return
+
+    moderator = callback.from_user
+    if moderator is None:
+        await callback.answer("Не удалось определить модератора", show_alert=True)
+        return
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            scopes = await resolve_tg_user_scopes(session, moderator.id)
+            if SCOPE_AUCTION_MANAGE not in scopes:
+                await callback.answer("Недостаточно прав", show_alert=True)
+                return
+
+            moderator_user = await upsert_user(session, moderator)
+            review = await session.scalar(
+                select(SuggestedPostReview)
+                .where(SuggestedPostReview.id == decision.review_id)
+                .with_for_update()
+            )
+            if review is None:
+                await callback.answer("review не найден", show_alert=True)
+                return
+
+            if review.status != "PENDING":
+                await callback.answer("Решение уже принято", show_alert=True)
+                return
+
+            try:
+                if decision.approve:
+                    await bot.approve_suggested_post(
+                        chat_id=review.source_chat_id,
+                        message_id=review.source_message_id,
+                    )
+                    review.status = "APPROVED"
+                    review.decision_note = "Одобрено модерацией"
+                    ui_note = "✅ Suggested post одобрен"
+                else:
+                    decline_reason = _DECLINE_REASON_MAP.get(
+                        decision.decline_reason_code or "",
+                        "Отклонено модерацией",
+                    )
+                    await bot.decline_suggested_post(
+                        chat_id=review.source_chat_id,
+                        message_id=review.source_message_id,
+                        comment=decline_reason,
+                    )
+                    review.status = "DECLINED"
+                    review.decision_note = decline_reason
+                    ui_note = f"⛔ Suggested post отклонен: {decline_reason}"
+            except TelegramAPIError as exc:
+                review.status = "FAILED"
+                review.decision_note = str(exc)
+                review.decided_by_user_id = moderator_user.id
+                review.decided_at = datetime.now(UTC)
+                review.updated_at = datetime.now(UTC)
+                await callback.answer("API ошибка при обработке suggested post", show_alert=True)
+                return
+
+            review.decided_by_user_id = moderator_user.id
+            review.decided_at = datetime.now(UTC)
+            review.updated_at = datetime.now(UTC)
+
+    await callback.answer("Решение сохранено")
+
+    message = callback.message
+    if message is not None and hasattr(message, "edit_text"):
+        original_text = getattr(message, "text", None) or "Suggested post review"
+        try:
+            await message.edit_text(f"{original_text}\n\n{ui_note}", reply_markup=None)
+        except Exception:
+            pass

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -224,6 +224,38 @@ class ModerationLog(Base):
     )
 
 
+class SuggestedPostReview(Base, TimestampMixin):
+    __tablename__ = "suggested_post_reviews"
+    __table_args__ = (
+        UniqueConstraint("source_chat_id", "source_message_id", name="uq_suggested_post_reviews_source"),
+        CheckConstraint(
+            "status IN ('PENDING', 'APPROVED', 'DECLINED', 'FAILED')",
+            name="suggested_post_reviews_status_values",
+        ),
+        Index("ix_suggested_post_reviews_status_created_at", "status", "created_at"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    source_chat_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    source_message_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    source_direct_messages_topic_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    submitter_user_id: Mapped[int | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    submitter_tg_user_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    queue_chat_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    queue_message_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, server_default=text("'PENDING'"), index=True)
+    decision_note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    decided_by_user_id: Mapped[int | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    decided_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+
 class Complaint(Base):
     __tablename__ = "complaints"
     __table_args__ = (

--- a/planning/pr-scaffolds/s34-002.md
+++ b/planning/pr-scaffolds/s34-002.md
@@ -1,6 +1,0 @@
-# Draft PR Scaffold
-
-This branch was auto-created for sprint task `S34-002`.
-Linked issue: #83
-
-Replace or remove this file while implementing the task.

--- a/tests/test_suggested_posts_handler.py
+++ b/tests/test_suggested_posts_handler.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from app.bot.handlers.suggested_posts import _parse_decision_callback
+
+
+def test_parse_suggested_post_approve_callback() -> None:
+    parsed = _parse_decision_callback("spp:ap:42")
+
+    assert parsed is not None
+    assert parsed.review_id == 42
+    assert parsed.approve is True
+    assert parsed.decline_reason_code is None
+
+
+def test_parse_suggested_post_decline_callback() -> None:
+    parsed = _parse_decision_callback("spp:dc:11:rules")
+
+    assert parsed is not None
+    assert parsed.review_id == 11
+    assert parsed.approve is False
+    assert parsed.decline_reason_code == "rules"
+
+
+def test_parse_suggested_post_callback_rejects_malformed_payload() -> None:
+    assert _parse_decision_callback(None) is None
+    assert _parse_decision_callback("spp:dc:11") is None
+    assert _parse_decision_callback("spp:dc:abc:rules") is None
+    assert _parse_decision_callback("spp:dc:11:unknown") is None


### PR DESCRIPTION
## Summary
- add suggested-post intake handler for channel DM chats: captures `suggested_post_info`, routes to moderation suggestions section, and stores review records in DB
- add moderation decision callbacks (approve / decline with reason), RBAC scope checks, and API execution via `approveSuggestedPost` / `declineSuggestedPost`
- add `suggested_post_reviews` persistence model + Alembic migration and parser tests for callback payload validation

## Linked Issue
Closes #83

## Validation
- `.venv/bin/python -m ruff check app tests alembic`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://.../auction_test .venv/bin/python -m pytest -q tests/integration`

## Rollout / Rollback
- Rollout: ensure `CHANNEL_DM_INTAKE_ENABLED=true` and moderation section topics are configured; run migration `alembic upgrade head`.
- Rollback: disable intake with `CHANNEL_DM_INTAKE_ENABLED=false`; if required, revert migration/handler commit.