### PR TITLE
[Sprint 34][S34-005] add private topic capability fallback cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Private DM topics (Bot API 9.3/9.4):
 - `PRIVATE_TOPICS_STRICT_ROUTING` - when enabled, commands are processed only in their assigned topic.
 - `PRIVATE_TOPICS_AUTOCREATE_ON_START` - bootstrap all personal topics on `/start`.
 - `PRIVATE_TOPIC_TITLE_*` - topic names for `auctions/support/points/trades/moderation`.
+- When Telegram reports `has_topics_enabled=false` for a user, bot falls back to regular private-chat flow.
 
 Examples:
 

--- a/app/bot/handlers/start.py
+++ b/app/bot/handlers/start.py
@@ -147,7 +147,12 @@ async def handle_start_private(message: Message, bot: Bot) -> None:
         async with session.begin():
             user = await upsert_user(session, message.from_user, mark_private_started=True)
             if settings.private_topics_enabled and settings.private_topics_autocreate_on_start:
-                topics_overview = await render_user_topics_overview(session, bot, user=user)
+                topics_overview = await render_user_topics_overview(
+                    session,
+                    bot,
+                    user=user,
+                    telegram_user=message.from_user,
+                )
             if payload is not None and payload.startswith("appeal_"):
                 appeal_ref = payload[len("appeal_") :] or "manual"
                 appeal = await create_appeal_from_ref(
@@ -190,7 +195,12 @@ async def command_topics(message: Message, bot: Bot) -> None:
     async with SessionFactory() as session:
         async with session.begin():
             user = await upsert_user(session, message.from_user, mark_private_started=True)
-            overview = await render_user_topics_overview(session, bot, user=user)
+            overview = await render_user_topics_overview(
+                session,
+                bot,
+                user=user,
+                telegram_user=message.from_user,
+            )
 
     await message.answer(overview)
 

--- a/app/services/private_topics_service.py
+++ b/app/services/private_topics_service.py
@@ -8,7 +8,7 @@ from enum import StrEnum
 from aiogram import Bot
 from aiogram.enums import ChatType
 from aiogram.exceptions import TelegramAPIError, TelegramBadRequest, TelegramForbiddenError
-from aiogram.types import CallbackQuery, InlineKeyboardMarkup, Message
+from aiogram.types import CallbackQuery, InlineKeyboardMarkup, Message, User as TgUser
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -17,6 +17,7 @@ from app.db.models import User, UserPrivateTopic
 from app.db.session import SessionFactory
 
 logger = logging.getLogger(__name__)
+_TOPICS_CAPABILITY_CACHE: dict[int, bool] = {}
 
 
 class PrivateTopicPurpose(StrEnum):
@@ -54,6 +55,18 @@ def topic_title(purpose: PrivateTopicPurpose) -> str:
     return settings.private_topic_title_moderation.strip() or "Модерация"
 
 
+def _resolve_cached_topics_capability(
+    *,
+    tg_user_id: int,
+    telegram_user: TgUser | None,
+) -> bool | None:
+    has_topics_enabled = getattr(telegram_user, "has_topics_enabled", None)
+    if isinstance(has_topics_enabled, bool):
+        _TOPICS_CAPABILITY_CACHE[tg_user_id] = has_topics_enabled
+        return has_topics_enabled
+    return _TOPICS_CAPABILITY_CACHE.get(tg_user_id)
+
+
 async def _load_user_topics_map(session: AsyncSession, user_id: int) -> dict[PrivateTopicPurpose, int]:
     rows = (
         await session.execute(
@@ -79,8 +92,12 @@ async def ensure_user_private_topics(
     bot: Bot | None,
     *,
     user: User,
+    telegram_user: TgUser | None = None,
 ) -> EnsureTopicsResult:
     existing = await _load_user_topics_map(session, user.id)
+    capability = _resolve_cached_topics_capability(tg_user_id=user.tg_user_id, telegram_user=telegram_user)
+    if capability is False:
+        return EnsureTopicsResult(mapping=existing, created=[])
     if not settings.private_topics_enabled or bot is None:
         return EnsureTopicsResult(mapping=existing, created=[])
 
@@ -130,8 +147,9 @@ async def resolve_user_topic_thread_id(
     *,
     user: User,
     purpose: PrivateTopicPurpose,
+    telegram_user: TgUser | None = None,
 ) -> int | None:
-    result = await ensure_user_private_topics(session, bot, user=user)
+    result = await ensure_user_private_topics(session, bot, user=user, telegram_user=telegram_user)
     return result.mapping.get(purpose)
 
 
@@ -150,7 +168,17 @@ async def enforce_message_topic(
     if chat is None or getattr(chat, "type", None) != ChatType.PRIVATE:
         return True
 
-    target_thread_id = await resolve_user_topic_thread_id(session, bot, user=user, purpose=purpose)
+    capability = _resolve_cached_topics_capability(tg_user_id=user.tg_user_id, telegram_user=message.from_user)
+    if capability is False:
+        return True
+
+    target_thread_id = await resolve_user_topic_thread_id(
+        session,
+        bot,
+        user=user,
+        purpose=purpose,
+        telegram_user=message.from_user,
+    )
     if target_thread_id is None or not settings.private_topics_strict_routing:
         return True
     if getattr(message, "message_thread_id", None) == target_thread_id:
@@ -195,7 +223,17 @@ async def enforce_callback_topic(
     if getattr(chat, "type", None) != ChatType.PRIVATE:
         return True
 
-    target_thread_id = await resolve_user_topic_thread_id(session, bot, user=user, purpose=purpose)
+    capability = _resolve_cached_topics_capability(tg_user_id=user.tg_user_id, telegram_user=callback.from_user)
+    if capability is False:
+        return True
+
+    target_thread_id = await resolve_user_topic_thread_id(
+        session,
+        bot,
+        user=user,
+        purpose=purpose,
+        telegram_user=callback.from_user,
+    )
     if target_thread_id is None or not settings.private_topics_strict_routing:
         return True
     if getattr(message, "message_thread_id", None) == target_thread_id:
@@ -230,14 +268,17 @@ async def send_user_topic_message(
     thread_id: int | None = None
 
     if settings.private_topics_enabled:
-        try:
-            async with SessionFactory() as session:
-                async with session.begin():
-                    user = await session.scalar(select(User).where(User.tg_user_id == tg_user_id))
-                    if user is not None:
-                        thread_id = await resolve_user_topic_thread_id(session, bot, user=user, purpose=purpose)
-        except Exception:
+        if _TOPICS_CAPABILITY_CACHE.get(tg_user_id) is False:
             thread_id = None
+        else:
+            try:
+                async with SessionFactory() as session:
+                    async with session.begin():
+                        user = await session.scalar(select(User).where(User.tg_user_id == tg_user_id))
+                        if user is not None:
+                            thread_id = await resolve_user_topic_thread_id(session, bot, user=user, purpose=purpose)
+            except Exception:
+                thread_id = None
 
     try:
         if thread_id is not None:
@@ -259,8 +300,16 @@ async def render_user_topics_overview(
     bot: Bot | None,
     *,
     user: User,
+    telegram_user: TgUser | None = None,
 ) -> str:
-    result = await ensure_user_private_topics(session, bot, user=user)
+    capability = _resolve_cached_topics_capability(tg_user_id=user.tg_user_id, telegram_user=telegram_user)
+    if capability is False:
+        return (
+            "Разделы-топики отключены для этого диалога в настройках Telegram. "
+            "Команды продолжают работать в обычном режиме лички."
+        )
+
+    result = await ensure_user_private_topics(session, bot, user=user, telegram_user=telegram_user)
     if not result.mapping:
         return (
             "Разделы в личке пока недоступны для этого диалога. "

--- a/planning/pr-scaffolds/s34-005.md
+++ b/planning/pr-scaffolds/s34-005.md
@@ -1,6 +1,0 @@
-# Draft PR Scaffold
-
-This branch was auto-created for sprint task `S34-005`.
-Linked issue: #89
-
-Replace or remove this file while implementing the task.

--- a/tests/test_private_topics_service.py
+++ b/tests/test_private_topics_service.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services import private_topics_service
+
+
+def test_topics_capability_cache_uses_telegram_hint() -> None:
+    private_topics_service._TOPICS_CAPABILITY_CACHE.clear()  # noqa: SLF001
+
+    hint_user = SimpleNamespace(has_topics_enabled=False)
+    result = private_topics_service._resolve_cached_topics_capability(  # noqa: SLF001
+        tg_user_id=501,
+        telegram_user=hint_user,
+    )
+
+    assert result is False
+    assert private_topics_service._TOPICS_CAPABILITY_CACHE.get(501) is False  # noqa: SLF001
+
+
+def test_topics_capability_cache_reuses_previous_value() -> None:
+    private_topics_service._TOPICS_CAPABILITY_CACHE.clear()  # noqa: SLF001
+    private_topics_service._TOPICS_CAPABILITY_CACHE[777] = True  # noqa: SLF001
+
+    result = private_topics_service._resolve_cached_topics_capability(  # noqa: SLF001
+        tg_user_id=777,
+        telegram_user=None,
+    )
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_topics_overview_falls_back_when_topics_disabled() -> None:
+    private_topics_service._TOPICS_CAPABILITY_CACHE.clear()  # noqa: SLF001
+
+    text = await private_topics_service.render_user_topics_overview(
+        session=None,  # type: ignore[arg-type]
+        bot=None,
+        user=SimpleNamespace(tg_user_id=909),
+        telegram_user=SimpleNamespace(has_topics_enabled=False),
+    )
+
+    assert "топики отключены" in text


### PR DESCRIPTION
## Summary
- add private-topic capability cache keyed by Telegram user id and consume `has_topics_enabled` hints from incoming updates
- skip strict topic routing/topic creation when Telegram reports topics are disabled for a user, with graceful fallback to standard private chat behavior
- update `/start` and `/topics` overview output to reflect fallback mode and add regression tests for capability cache behavior

## Linked Issue
Closes #89

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://.../auction_test .venv/bin/python -m pytest -q tests/integration`

## Rollout / Rollback
- Rollout: no additional env flags; feature activates automatically when Telegram sends `has_topics_enabled=false`.
- Rollback: revert this PR to restore previous strict topic creation/routing behavior.