### PR TITLE
[Sprint 37][S37-004] Refresh planning status and sprint manifest docs

### DIFF
--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -1,13 +1,14 @@
 # Planning Status
 
-Last sync: 2026-02-15 21:31 UTC
+Last sync: 2026-02-15 22:11 UTC
 Active sprint: Sprint 37
 
 | Item | Title | Issue | PR |
 |---|---|---|---|
-| S37-001 | Split minimal and full environment examples | [#107](https://github.com/Nombah501/LiteAuction/issues/107) (open) | - |
-| S37-002 | Add TOML config source for non-secret defaults | [#108](https://github.com/Nombah501/LiteAuction/issues/108) (open) | - |
-| S37-003 | Implement owner-only runtime settings overrides | [#109](https://github.com/Nombah501/LiteAuction/issues/109) (open) | - |
+| S37-001 | Split minimal and full environment examples | [#107](https://github.com/Nombah501/LiteAuction/issues/107) (closed) | - |
+| S37-002 | Add TOML config source for non-secret defaults | [#108](https://github.com/Nombah501/LiteAuction/issues/108) (closed) | - |
+| S37-003 | Implement owner-only runtime settings overrides | [#109](https://github.com/Nombah501/LiteAuction/issues/109) (closed) | - |
+| S37-004 | Refresh planning status and sprint manifest docs | [#113](https://github.com/Nombah501/LiteAuction/issues/113) (open) | - |
 
 ## Recovery Checklist
 

--- a/planning/sprints/README.md
+++ b/planning/sprints/README.md
@@ -9,25 +9,25 @@ Session bootstrap: read `AGENTS.md` and `planning/STATUS.md` before editing any 
 1. Copy template:
 
 ```bash
-cp planning/sprints/sprint-template.toml planning/sprints/sprint-33.toml
+cp planning/sprints/sprint-template.toml planning/sprints/sprint-<number>.toml
 ```
 
-2. Edit `planning/sprints/sprint-33.toml` and fill items.
+2. Edit `planning/sprints/sprint-<number>.toml` and fill items.
 
 3. Sync issues + milestone:
 
 ```bash
-python scripts/sprint_sync.py --manifest planning/sprints/sprint-33.toml
+python scripts/sprint_sync.py --manifest planning/sprints/sprint-<number>.toml
 ```
 
 4. Also create draft PR scaffolds:
 
 ```bash
-python scripts/sprint_sync.py --manifest planning/sprints/sprint-33.toml --create-draft-prs
+python scripts/sprint_sync.py --manifest planning/sprints/sprint-<number>.toml --create-draft-prs
 ```
 
 ## Notes
 
-- Every item should have a stable `id` (for example, `S33-001`) to allow idempotent re-sync.
+- Every item should have a stable `id` (for example, `S37-001`) to allow idempotent re-sync.
 - The sync updates `planning/STATUS.md` by default so context is recoverable after chat/session resets.
 - PR policy workflow requires a sprint label and linked issue in PR body (`Closes #<id>`).

--- a/planning/sprints/sprint-37.toml
+++ b/planning/sprints/sprint-37.toml
@@ -54,3 +54,19 @@ acceptance = [
   "Invalid override values are rejected with clear feedback",
   "Runtime changes are visible in admin UI and audited",
 ]
+
+[[items]]
+id = "S37-004"
+title = "Refresh planning status and sprint manifest docs"
+description = "Update planning status snapshot after merged Sprint 37 work and replace Sprint 33-specific sprint-manifest examples with reusable placeholders."
+priority = "P2"
+estimate = "S"
+tech_debt = true
+labels = ["type:chore", "area:process", "priority:p2", "tech-debt"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "Planning status reflects closed Sprint 37 issues/PRs",
+  "Sprint manifest README examples use generic sprint placeholders",
+  "Changes are delivered through issue-linked PR workflow",
+]


### PR DESCRIPTION
## Summary
- Synced Sprint 37 manifest with a follow-up docs task (`S37-004`) and updated `planning/STATUS.md` to reflect current issue states.
- Updated sprint-manifest README quick-start commands to use reusable `sprint-<number>` placeholders instead of Sprint 33-specific examples.
- Kept planning traceability flow aligned with issue-first policy for post-merge housekeeping.

## Linked Issue
Closes #113

## Validation
- [x] .venv/bin/python -m ruff check app tests
- [x] .venv/bin/python -m pytest -q tests
- [x] RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@localhost:5432/auction_test .venv/bin/python -m pytest -q tests/integration

## Rollout / Rollback
- Rollout: no runtime impact; docs/planning metadata only.
- Rollback: revert this PR to restore previous planning docs wording.