### PR TITLE
[Sprint 38][S38-001] Refresh auction post UX and one-tap bid feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ This repository currently contains **Sprint 0 + Sprint 1 + Sprint 2 + Sprint 3 +
 - [x] Create auction wizard: photo, description, start price, buyout/skip, min step, duration, anti-sniper
 - [x] Publish draft via inline flow (`switch_inline_query` -> inline card)
 - [x] Activate auction on publish and store `inline_message_id`
-- [x] Bid buttons (`x1`, `x3`, `x5`) and buyout button
+- [x] Bid buttons with fast presets (`+step`, `+3step`, `+5step`) and buyout button
 - [x] Live post refresh after each accepted action
-- [x] Anti-mistake: no self-overbid, cooldown, duplicate guard, confirm for `x3/x5` and buyout
+- [x] Anti-mistake: no self-overbid, cooldown, duplicate guard, confirm for buyout
+- [x] Bid callbacks return alert with exact accepted amount
 - [x] Auction auto-finish watcher and winner/seller notifications
 
 ## Sprint 2 Checklist (Moderation)
@@ -650,6 +651,14 @@ FRAUD_HISTORICAL_SPIKE_SCORE=20
 FRAUD_HISTORICAL_START_RATIO_LOW=0.5
 FRAUD_HISTORICAL_START_RATIO_HIGH=2.0
 ```
+
+## Telegram Smoke Checklist (Auction UX)
+
+- Publish a draft auction and verify caption shows expressive status block, timer, and `Топ-3` with medals.
+- In an active lot, verify bid buttons are green and display only amounts (`+$N`, `+$3N`, `+$5N`).
+- Tap any bid button once and verify a Telegram alert appears with exact accepted amount (`$N`).
+- Verify compact secondary actions are shown as short buttons (`Фото N`, `Жалоба`, `Бот`).
+- Verify buyout and complaint still require confirmation and keep existing anti-spam cooldown behavior.
 
 ## Next (Post-Sprint)
 

--- a/app/bot/keyboards/auction.py
+++ b/app/bot/keyboards/auction.py
@@ -175,27 +175,16 @@ def auction_active_keyboard(
     rows: list[list[InlineKeyboardButton]] = [
         [
             styled_button(
-                text=f"Все фото ({photo_count})",
-                callback_data=f"gallery:{auction_id}",
-                style="primary",
-                icon_custom_emoji_id=_first_icon(
-                    settings.ui_emoji_gallery_id,
-                    settings.ui_emoji_publish_id,
-                ),
-            )
-        ],
-        [
-            styled_button(
-                text=f"+ ${min_step} x1",
+                text=f"+${min_step}",
                 callback_data=f"bid:{auction_id}:1",
-                style="primary",
+                style="success",
                 icon_custom_emoji_id=_first_icon(
                     settings.ui_emoji_bid_x1_id,
                     settings.ui_emoji_bid_id,
                 ),
             ),
             styled_button(
-                text=f"+ ${min_step * 3} x3",
+                text=f"+${min_step * 3}",
                 callback_data=f"bid:{auction_id}:3",
                 style="success",
                 icon_custom_emoji_id=_first_icon(
@@ -204,7 +193,7 @@ def auction_active_keyboard(
                 ),
             ),
             styled_button(
-                text=f"+ ${min_step * 5} x5",
+                text=f"+${min_step * 5}",
                 callback_data=f"bid:{auction_id}:5",
                 style="success",
                 icon_custom_emoji_id=_first_icon(
@@ -219,7 +208,7 @@ def auction_active_keyboard(
         rows.append(
             [
                 styled_button(
-                    text="Выкупить",
+                    text="Выкуп",
                     callback_data=f"buy:{auction_id}",
                     style="danger",
                     icon_custom_emoji_id=_icon(settings.ui_emoji_buyout_id),
@@ -227,27 +216,34 @@ def auction_active_keyboard(
             ]
         )
 
-    rows.append(
-        [
-            styled_button(
-                text="Пожаловаться",
-                callback_data=f"report:{auction_id}",
-                style="danger",
-                icon_custom_emoji_id=_icon(settings.ui_emoji_report_id),
-            )
-        ]
-    )
+    utility_row: list[InlineKeyboardButton] = [
+        styled_button(
+            text=f"Фото {photo_count}",
+            callback_data=f"gallery:{auction_id}",
+            style="primary",
+            icon_custom_emoji_id=_first_icon(
+                settings.ui_emoji_gallery_id,
+                settings.ui_emoji_publish_id,
+            ),
+        ),
+        styled_button(
+            text="Жалоба",
+            callback_data=f"report:{auction_id}",
+            style="danger",
+            icon_custom_emoji_id=_icon(settings.ui_emoji_report_id),
+        ),
+    ]
 
     username = settings.bot_username.strip().lstrip("@")
     if username:
-        rows.append(
-            [
-                styled_button(
-                    text="Открыть бота",
-                    url=f"https://t.me/{username}?start=auction_gate",
-                    style="primary",
-                )
-            ]
+        utility_row.append(
+            styled_button(
+                text="Бот",
+                url=f"https://t.me/{username}?start=auction_gate",
+                style="primary",
+            )
         )
+
+    rows.append(utility_row)
 
     return InlineKeyboardMarkup(inline_keyboard=rows)

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -1,14 +1,15 @@
 # Planning Status
 
-Last sync: 2026-02-15 22:11 UTC
-Active sprint: Sprint 37
+Last sync: 2026-02-16 02:25 UTC
+Active sprint: Sprint 38
 
 | Item | Title | Issue | PR |
 |---|---|---|---|
-| S37-001 | Split minimal and full environment examples | [#107](https://github.com/Nombah501/LiteAuction/issues/107) (closed) | - |
-| S37-002 | Add TOML config source for non-secret defaults | [#108](https://github.com/Nombah501/LiteAuction/issues/108) (closed) | - |
-| S37-003 | Implement owner-only runtime settings overrides | [#109](https://github.com/Nombah501/LiteAuction/issues/109) (closed) | - |
-| S37-004 | Refresh planning status and sprint manifest docs | [#113](https://github.com/Nombah501/LiteAuction/issues/113) (open) | - |
+| S38-001 | Redesign auction caption copy and structure | [#117](https://github.com/Nombah501/LiteAuction/issues/117) (open) | - |
+| S38-002 | Compact active auction keyboard and unify bid button style | [#118](https://github.com/Nombah501/LiteAuction/issues/118) (open) | - |
+| S38-003 | Enable one-tap bids and show exact bid amount in alerts | [#119](https://github.com/Nombah501/LiteAuction/issues/119) (open) | - |
+| S38-004 | Add regression tests for keyboard and bid feedback | [#120](https://github.com/Nombah501/LiteAuction/issues/120) (open) | - |
+| S38-005 | Refresh docs and rollout checklist for auction UX changes | [#121](https://github.com/Nombah501/LiteAuction/issues/121) (open) | - |
 
 ## Recovery Checklist
 

--- a/planning/sprints/sprint-38.toml
+++ b/planning/sprints/sprint-38.toml
@@ -1,0 +1,89 @@
+sprint = "Sprint 38"
+milestone = "Sprint 38"
+milestone_description = "Auction post UX refresh: compact keyboard, expressive copy, one-tap bids, precise bid alerts"
+base_branch = "main"
+status_file = "planning/STATUS.md"
+
+[[items]]
+id = "S38-001"
+title = "Redesign auction caption copy and structure"
+description = "Refresh auction caption with more expressive, compact, and readable layout while preserving all critical auction data."
+priority = "P1"
+estimate = "M"
+tech_debt = false
+labels = ["type:feature", "area:bot", "area:ux", "priority:p1"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "Caption has a clearer visual hierarchy and more emotional tone",
+  "Core fields remain present: status, seller, current price, next minimum, timer, anti-sniper, top bids",
+  "Top bids block remains stable and readable for empty, partial, and full states",
+  "Caption always fits Telegram 1024-char limit without truncating critical fields",
+]
+
+[[items]]
+id = "S38-002"
+title = "Compact active auction keyboard and unify bid button style"
+description = "Rework active auction keyboard layout: compact secondary actions, remove x1/x3/x5 suffixes from bid labels, and set all bid buttons to green style."
+priority = "P1"
+estimate = "M"
+tech_debt = false
+labels = ["type:feature", "area:bot", "area:ux", "priority:p1"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "Bid button labels display only amounts (+$N) without x1/x3/x5",
+  "All bid buttons use green style",
+  "Secondary actions (photos, report, open bot) are shorter and more compact",
+  "Existing callback payloads for bid, buy, report, and gallery remain backward-compatible",
+]
+
+[[items]]
+id = "S38-003"
+title = "Enable one-tap bids and show exact bid amount in alerts"
+description = "Remove bid-only double-tap confirmation and ensure callback alert always includes the exact placed amount, including soft-gate hint scenarios."
+priority = "P1"
+estimate = "M"
+tech_debt = false
+labels = ["type:feature", "area:bot", "area:bidding", "priority:p1"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "Bid actions are accepted on first tap without arm/confirm step",
+  "Successful bid alert always includes the exact final amount (for example, $95)",
+  "Soft-gate hint flow preserves the exact amount text in the same alert",
+  "Buyout and report confirmation behavior remains unchanged",
+]
+
+[[items]]
+id = "S38-004"
+title = "Add regression tests for keyboard and bid feedback"
+description = "Extend tests to cover new keyboard labels/styles/layout and precise bid alert behavior with and without soft-gate hints."
+priority = "P1"
+estimate = "M"
+tech_debt = true
+labels = ["type:test", "area:bot", "area:ux", "priority:p1", "tech-debt"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "Keyboard tests assert amount-only labels and green style for all bid buttons",
+  "Tests assert compact secondary action texts and layout",
+  "Tests assert bid success alert includes exact amount in normal and soft-gate-hint paths",
+  "Existing custom emoji fallback tests remain green",
+]
+
+[[items]]
+id = "S38-005"
+title = "Refresh docs and rollout checklist for auction UX changes"
+description = "Update README behavior notes and add concise Telegram smoke checklist for one-tap bids and updated keyboard and caption UX."
+priority = "P2"
+estimate = "S"
+tech_debt = true
+labels = ["type:chore", "area:docs", "area:process", "priority:p2", "tech-debt"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "README reflects one-tap bid behavior and exact-amount bid alerts",
+  "README no longer states confirmation for x3/x5 bids",
+  "PR checklist includes Telegram smoke steps for updated auction post UX",
+]

--- a/tests/test_auction_caption_render.py
+++ b/tests/test_auction_caption_render.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from app.db.enums import AuctionStatus
+from app.services.auction_service import AuctionView, TopBidView, render_auction_caption
+
+
+def _build_view(*, top_bids: list[TopBidView]) -> AuctionView:
+    now = datetime.now(UTC)
+    auction = SimpleNamespace(
+        id=uuid.UUID("12345678-1234-5678-1234-567812345678"),
+        status=AuctionStatus.ACTIVE,
+        description="Легендарный нож в отличном состоянии",
+        start_price=50,
+        buyout_price=150,
+        min_step=5,
+        anti_sniper_enabled=True,
+        anti_sniper_max_extensions=3,
+        anti_sniper_extensions_used=1,
+        ends_at=now + timedelta(hours=2),
+    )
+    seller = SimpleNamespace(username="sellername", first_name="Seller", tg_user_id=101)
+
+    return AuctionView(
+        auction=auction,
+        seller=seller,
+        winner=None,
+        top_bids=top_bids,
+        current_price=95,
+        minimum_next_bid=100,
+        open_complaints=2,
+        photo_count=4,
+    )
+
+
+def test_render_auction_caption_contains_compact_emotional_sections() -> None:
+    view = _build_view(
+        top_bids=[
+            TopBidView(
+                amount=95,
+                user_id=1,
+                tg_user_id=11,
+                username="anna",
+                first_name="Anna",
+                created_at=datetime.now(UTC),
+            ),
+            TopBidView(
+                amount=90,
+                user_id=2,
+                tg_user_id=22,
+                username=None,
+                first_name="Vlad",
+                created_at=datetime.now(UTC),
+            ),
+        ]
+    )
+
+    caption = render_auction_caption(view)
+
+    assert "🔥 Аукцион #12345678" in caption
+    assert "⚡ Торги в разгаре" in caption
+    assert "💸 Текущая ставка: <b>$95</b>" in caption
+    assert "⏭ Следующая ставка: <b>$100</b>" in caption
+    assert "🖼 Фото: 4 | 🚨 Жалобы: 2" in caption
+    assert "🏆 <b>Топ-3 ставок</b>" in caption
+    assert "🥇 $95 — @anna" in caption
+    assert "🥈 $90" in caption
+    assert "🥉 —" in caption
+
+
+def test_render_auction_caption_shows_empty_top_with_medals() -> None:
+    view = _build_view(top_bids=[])
+
+    caption = render_auction_caption(view)
+
+    assert "🥇 —" in caption
+    assert "🥈 —" in caption
+    assert "🥉 —" in caption

--- a/tests/test_bid_actions_alerts.py
+++ b/tests/test_bid_actions_alerts.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from app.bot.handlers.bid_actions import _compose_bid_success_alert, _extract_amount_from_alert_text
+
+
+def test_extract_amount_from_alert_text_returns_integer() -> None:
+    assert _extract_amount_from_alert_text("Ставка принята: $95") == 95
+
+
+def test_extract_amount_from_alert_text_returns_none_when_absent() -> None:
+    assert _extract_amount_from_alert_text("Ставка принята") is None
+
+
+def test_compose_bid_success_alert_prefers_explicit_amount() -> None:
+    text = _compose_bid_success_alert(
+        alert_text="Ставка принята",
+        placed_bid_amount=120,
+        include_soft_gate_hint=False,
+    )
+
+    assert text == "✅ Ставка зафиксирована: $120"
+
+
+def test_compose_bid_success_alert_uses_amount_from_alert_text() -> None:
+    text = _compose_bid_success_alert(
+        alert_text="Ставка принята: $77",
+        placed_bid_amount=None,
+        include_soft_gate_hint=False,
+    )
+
+    assert text == "✅ Ставка зафиксирована: $77"
+
+
+def test_compose_bid_success_alert_keeps_amount_with_soft_gate_hint(monkeypatch) -> None:
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "bot_username", "liteauctionbot")
+    text = _compose_bid_success_alert(
+        alert_text="Ставка принята: $88",
+        placed_bid_amount=None,
+        include_soft_gate_hint=True,
+    )
+
+    assert "✅ Ставка зафиксирована: $88" in text
+    assert "@liteauctionbot" in text
+
+
+def test_compose_bid_success_alert_marks_buyout_when_present() -> None:
+    text = _compose_bid_success_alert(
+        alert_text="Выкуп оформлен за $150",
+        placed_bid_amount=150,
+        include_soft_gate_hint=False,
+    )
+
+    assert text == "✅ Выкуп оформлен: $150"


### PR DESCRIPTION
## Summary
- refresh active auction caption structure with stronger visual hierarchy, compact fields, and top-bid medal formatting
- redesign active auction keyboard for compact secondary actions and green amount-only bid buttons
- remove bid double-confirmation and always show exact accepted amount in callback alerts, including soft-gate hint path

## Linked Issue
Closes #117
Closes #118
Closes #119
Closes #120
Closes #121

## Validation
- [x] .venv/bin/python -m ruff check app tests
- [x] .venv/bin/python -m pytest -q tests
- [x] RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test .venv/bin/python -m pytest -q tests/integration

## Rollout Notes
- Telegram post keyboard labels changed to compact variants (`Фото N`, `Жалоба`, `Бот`; bid buttons `+$N`)
- bid callbacks are now one-tap; buyout/report confirmation remains unchanged

## Rollback Notes
- revert this PR to restore previous caption format, keyboard labels, and bid confirmation behavior