### PR TITLE
[Sprint 39][S39-001] Fix album photo progress feedback in create flow

### DIFF
--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -1,15 +1,11 @@
 # Planning Status
 
-Last sync: 2026-02-16 02:25 UTC
-Active sprint: Sprint 38
+Last sync: 2026-02-16 02:45 UTC
+Active sprint: Sprint 39
 
 | Item | Title | Issue | PR |
 |---|---|---|---|
-| S38-001 | Redesign auction caption copy and structure | [#117](https://github.com/Nombah501/LiteAuction/issues/117) (open) | - |
-| S38-002 | Compact active auction keyboard and unify bid button style | [#118](https://github.com/Nombah501/LiteAuction/issues/118) (open) | - |
-| S38-003 | Enable one-tap bids and show exact bid amount in alerts | [#119](https://github.com/Nombah501/LiteAuction/issues/119) (open) | - |
-| S38-004 | Add regression tests for keyboard and bid feedback | [#120](https://github.com/Nombah501/LiteAuction/issues/120) (open) | - |
-| S38-005 | Refresh docs and rollout checklist for auction UX changes | [#121](https://github.com/Nombah501/LiteAuction/issues/121) (open) | - |
+| S39-001 | Fix misleading album photo progress message in create flow | [#123](https://github.com/Nombah501/LiteAuction/issues/123) (open) | - |
 
 ## Recovery Checklist
 

--- a/planning/sprints/sprint-39.toml
+++ b/planning/sprints/sprint-39.toml
@@ -1,0 +1,21 @@
+sprint = "Sprint 39"
+milestone = "Sprint 39"
+milestone_description = "Create flow UX fixes: correct album photo progress feedback"
+base_branch = "main"
+status_file = "planning/STATUS.md"
+
+[[items]]
+id = "S39-001"
+title = "Fix misleading album photo progress message in create flow"
+description = "When users upload multiple photos as a media group, avoid showing a stale '1/10' progress message and provide accurate feedback for album intake."
+priority = "P1"
+estimate = "S"
+tech_debt = false
+labels = ["type:bug", "area:bot", "area:ux", "priority:p1"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "Album upload no longer shows misleading 'Фото добавлено (1/10)' feedback",
+  "Single-photo upload keeps exact progress counter (N/10)",
+  "Create-flow tests cover album feedback behavior",
+]

--- a/tests/test_create_auction_handlers.py
+++ b/tests/test_create_auction_handlers.py
@@ -94,3 +94,31 @@ async def test_done_without_photos_shows_alert() -> None:
 
     assert done_callback.answers == [("Сначала добавьте хотя бы одно фото", True)]
     assert state.state == AuctionCreateStates.waiting_photo
+
+
+@pytest.mark.asyncio
+async def test_album_feedback_does_not_show_stale_single_count() -> None:
+    state = _DummyState()
+    await state.set_state(AuctionCreateStates.waiting_photo)
+
+    first_photo = _DummyMessage(photo_file_id="photo-1", media_group_id="album-1")
+    second_photo = _DummyMessage(photo_file_id="photo-2", media_group_id="album-1")
+
+    await create_photo_step(first_photo, state)
+    await create_photo_step(second_photo, state)
+
+    assert first_photo.answers == [
+        "Альбом принят. После отправки всех фото нажмите 'Готово'."
+    ]
+    assert second_photo.answers == []
+
+
+@pytest.mark.asyncio
+async def test_single_photo_feedback_keeps_exact_counter() -> None:
+    state = _DummyState()
+    await state.set_state(AuctionCreateStates.waiting_photo)
+
+    single_photo = _DummyMessage(photo_file_id="photo-1")
+    await create_photo_step(single_photo, state)
+
+    assert single_photo.answers == ["Фото добавлено (1/10). Отправьте еще или нажмите 'Готово'."]


### PR DESCRIPTION
## Summary
- fix create-auction photo intake feedback so media-group uploads do not show stale `Фото добавлено (1/10)` text
- send one album-specific hint per media group and keep exact `N/10` progress for single-photo uploads
- add regression tests for album feedback and single-photo counter behavior

## Linked Issue
Closes #123

## Validation
- [x] .venv/bin/python -m ruff check app tests
- [x] .venv/bin/python -m pytest -q tests
- [x] RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test .venv/bin/python -m pytest -q tests/integration

## Telegram Smoke
- [ ] Start `/newauction`, send album with 3+ photos, verify no stale `1/10` progress text appears
- [ ] Send one single photo, verify exact progress text `Фото добавлено (1/10)`
- [ ] Complete flow with `Готово`, verify all uploaded photos are preserved

## Rollback Notes
- Revert this PR to restore previous feedback behavior for media-group uploads.