### PR TITLE
[Sprint 40][S40-001] Refresh private dashboard menu and callbacks

### DIFF
--- a/app/bot/handlers/start.py
+++ b/app/bot/handlers/start.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 from aiogram import Bot, F, Router
 from aiogram.enums import ChatType
 from aiogram.filters import Command, CommandStart
-from aiogram.types import Message
+from aiogram.types import CallbackQuery, Message
+from sqlalchemy import func, select
 
 from app.bot.keyboards.auction import start_private_keyboard
 from app.config import settings
+from app.db.enums import AuctionStatus
+from app.db.models import Auction, Bid
 from app.db.session import SessionFactory
 from app.services.appeal_service import create_appeal_from_ref, redeem_appeal_priority_boost
+from app.services.moderation_service import has_moderator_access, is_moderator_tg_user
 from app.services.moderation_topic_router import ModerationTopicSection, send_section_message
 from app.services.private_topics_service import (
     PrivateTopicPurpose,
@@ -49,6 +53,68 @@ def _extract_boost_appeal_id(text: str | None) -> int | None:
     if not candidate.isdigit():
         return None
     return int(candidate)
+
+
+def _auction_status_label(status: AuctionStatus) -> str:
+    labels = {
+        AuctionStatus.DRAFT: "Черновик",
+        AuctionStatus.ACTIVE: "Активен",
+        AuctionStatus.ENDED: "Завершен",
+        AuctionStatus.BOUGHT_OUT: "Выкуплен",
+        AuctionStatus.CANCELLED: "Отменен",
+        AuctionStatus.FROZEN: "Заморожен",
+    }
+    return labels[status]
+
+
+def _render_my_auctions_text(
+    rows: list[tuple[object, AuctionStatus, int, int | None]],
+) -> str:
+    if not rows:
+        return "У вас пока нет аукционов. Нажмите «Создать аукцион», чтобы добавить первый лот."
+
+    lines = ["Мои аукционы (последние 10):", ""]
+    for idx, (auction_id, status, start_price, top_bid_amount) in enumerate(rows, start=1):
+        current_price = top_bid_amount if top_bid_amount is not None else start_price
+        lines.append(
+            f"{idx}) #{str(auction_id)[:8]} | {_auction_status_label(status)} | текущая цена: ${current_price}"
+        )
+    return "\n".join(lines)
+
+
+async def _load_my_auctions_rows(
+    *,
+    session,
+    seller_user_id: int,
+    limit: int = 10,
+) -> list[tuple[object, AuctionStatus, int, int | None]]:
+    top_bid_amount = (
+        select(func.max(Bid.amount))
+        .where(Bid.auction_id == Auction.id, Bid.is_removed.is_(False))
+        .correlate(Auction)
+        .scalar_subquery()
+    )
+    stmt = (
+        select(
+            Auction.id,
+            Auction.status,
+            Auction.start_price,
+            top_bid_amount.label("top_bid_amount"),
+        )
+        .where(Auction.seller_user_id == seller_user_id)
+        .order_by(Auction.created_at.desc())
+        .limit(limit)
+    )
+    return [
+        (auction_id, status, start_price, top_bid)
+        for auction_id, status, start_price, top_bid in (await session.execute(stmt)).all()
+    ]
+
+
+async def _can_show_moderation_button(*, session, tg_user_id: int) -> bool:
+    if is_moderator_tg_user(tg_user_id):
+        return True
+    return await has_moderator_access(session, tg_user_id)
 
 
 async def _notify_moderators_about_appeal(
@@ -145,10 +211,15 @@ async def handle_start_private(message: Message, bot: Bot) -> None:
     appeal_id: int | None = None
     topics_overview: str | None = None
     auctions_thread_id: int | None = None
+    show_moderation_button = False
 
     async with SessionFactory() as session:
         async with session.begin():
             user = await upsert_user(session, message.from_user, mark_private_started=True)
+            show_moderation_button = await _can_show_moderation_button(
+                session=session,
+                tg_user_id=message.from_user.id,
+            )
             if settings.private_topics_enabled and settings.private_topics_autocreate_on_start:
                 topics_overview = await render_user_topics_overview(
                     session,
@@ -172,6 +243,8 @@ async def handle_start_private(message: Message, bot: Bot) -> None:
                 )
                 appeal_id = appeal.id
 
+    dashboard_keyboard = start_private_keyboard(show_moderation_button=show_moderation_button)
+
     if payload is not None and payload.startswith("appeal_") and appeal_id is not None:
         appeal_ref = payload[len("appeal_") :] or "manual"
         await _notify_moderators_about_appeal(
@@ -182,7 +255,7 @@ async def handle_start_private(message: Message, bot: Bot) -> None:
         )
         await message.answer(
             _appeal_acceptance_text(appeal_id),
-            reply_markup=start_private_keyboard(),
+            reply_markup=dashboard_keyboard,
         )
         return
 
@@ -199,11 +272,11 @@ async def handle_start_private(message: Message, bot: Bot) -> None:
             tg_user_id=message.from_user.id,
             purpose=PrivateTopicPurpose.AUCTIONS,
             text=start_text,
-            reply_markup=start_private_keyboard(),
+            reply_markup=dashboard_keyboard,
         )
 
     if not sent_to_auctions:
-        await message.answer(start_text, reply_markup=start_private_keyboard())
+        await message.answer(start_text, reply_markup=dashboard_keyboard)
     elif (
         auctions_thread_id is not None
         and getattr(message, "message_thread_id", None) != auctions_thread_id
@@ -237,3 +310,29 @@ async def command_topics(message: Message, bot: Bot) -> None:
 @router.message(CommandStart())
 async def handle_start_non_private(message: Message) -> None:
     await message.answer("Для настройки и уведомлений откройте бота в личных сообщениях.")
+
+
+@router.callback_query(F.data == "dash:my_auctions")
+async def callback_my_auctions(callback: CallbackQuery) -> None:
+    if callback.from_user is None:
+        return
+
+    rows: list[tuple[object, AuctionStatus, int, int | None]] = []
+    async with SessionFactory() as session:
+        async with session.begin():
+            user = await upsert_user(session, callback.from_user, mark_private_started=True)
+            rows = await _load_my_auctions_rows(session=session, seller_user_id=user.id, limit=10)
+
+    await callback.answer()
+    if callback.message is not None and isinstance(callback.message, Message):
+        await callback.message.answer(_render_my_auctions_text(rows))
+
+
+@router.callback_query(F.data == "dash:settings")
+async def callback_dashboard_settings(callback: CallbackQuery) -> None:
+    await callback.answer("Раздел «Настройки» в разработке.", show_alert=True)
+
+
+@router.callback_query(F.data == "dash:balance")
+async def callback_dashboard_balance(callback: CallbackQuery) -> None:
+    await callback.answer("Раздел «Баланс» в разработке.", show_alert=True)

--- a/app/bot/keyboards/auction.py
+++ b/app/bot/keyboards/auction.py
@@ -44,17 +44,39 @@ def styled_button(
     return InlineKeyboardButton.model_validate(payload)
 
 
-def start_private_keyboard() -> InlineKeyboardMarkup:
-    return InlineKeyboardMarkup(
-        inline_keyboard=[
-            [
-                styled_button(
-                    text="Создать аукцион",
-                    callback_data="create:new",
-                    style="primary",
-                    icon_custom_emoji_id=_icon(settings.ui_emoji_create_auction_id),
-                )
-            ],
+def start_private_keyboard(*, show_moderation_button: bool) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = [
+        [
+            styled_button(
+                text="Создать аукцион",
+                callback_data="create:new",
+                style="primary",
+                icon_custom_emoji_id=_icon(settings.ui_emoji_create_auction_id),
+            )
+        ],
+        [
+            styled_button(
+                text="Мои аукционы",
+                callback_data="dash:my_auctions",
+                style="primary",
+            )
+        ],
+        [
+            styled_button(
+                text="Настройки",
+                callback_data="dash:settings",
+            )
+        ],
+        [
+            styled_button(
+                text="Баланс",
+                callback_data="dash:balance",
+            )
+        ],
+    ]
+
+    if show_moderation_button:
+        rows.append(
             [
                 styled_button(
                     text="Мод-панель",
@@ -62,9 +84,10 @@ def start_private_keyboard() -> InlineKeyboardMarkup:
                     style="success",
                     icon_custom_emoji_id=_icon(settings.ui_emoji_mod_panel_id),
                 )
-            ],
-        ]
-    )
+            ]
+        )
+
+    return InlineKeyboardMarkup(inline_keyboard=rows)
 
 
 def buyout_choice_keyboard() -> InlineKeyboardMarkup:

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -1,11 +1,11 @@
 # Planning Status
 
-Last sync: 2026-02-16 02:45 UTC
-Active sprint: Sprint 39
+Last sync: 2026-02-16 03:22 UTC
+Active sprint: Sprint 40
 
 | Item | Title | Issue | PR |
 |---|---|---|---|
-| S39-001 | Fix misleading album photo progress message in create flow | [#123](https://github.com/Nombah501/LiteAuction/issues/123) (open) | - |
+| S40-001 | Redesign private dashboard menu and add callbacks | [#125](https://github.com/Nombah501/LiteAuction/issues/125) (open) | - |
 
 ## Recovery Checklist
 

--- a/planning/sprints/sprint-40.toml
+++ b/planning/sprints/sprint-40.toml
@@ -1,0 +1,22 @@
+sprint = "Sprint 40"
+milestone = "Sprint 40"
+milestone_description = "Private dashboard refresh with role-aware moderation entry"
+base_branch = "main"
+status_file = "planning/STATUS.md"
+
+[[items]]
+id = "S40-001"
+title = "Redesign private dashboard menu and add callbacks"
+description = "Rework private /start dashboard order, show moderation button only to moderators/admins, implement My Auctions listing, and keep Settings/Balance as in-development alerts."
+priority = "P1"
+estimate = "M"
+tech_debt = false
+labels = ["type:feature", "area:bot", "area:ux", "priority:p1"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "Private dashboard buttons are ordered: Создать аукцион, Мои аукционы, Настройки, Баланс",
+  "Мод-панель is visible only to users with moderator/admin access and is rendered last",
+  "Настройки and Баланс callbacks return alert that section is in development",
+  "Мои аукционы callback returns recent user auctions with status and current price",
+]

--- a/tests/test_keyboard_custom_emojis.py
+++ b/tests/test_keyboard_custom_emojis.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from aiogram.types import InlineKeyboardButton
 
-from app.bot.keyboards.auction import auction_active_keyboard, draft_publish_keyboard, photos_done_keyboard
+from app.bot.keyboards.auction import (
+    auction_active_keyboard,
+    draft_publish_keyboard,
+    photos_done_keyboard,
+    start_private_keyboard,
+)
 from app.bot.keyboards.moderation import (
     complaint_actions_keyboard,
     moderation_complaints_list_keyboard,
@@ -105,6 +110,34 @@ def test_auction_keyboard_emoji_fallbacks(monkeypatch) -> None:
 
     done = photos_done_keyboard()
     assert _button_by_text(done.inline_keyboard, "Готово").icon_custom_emoji_id == "create-base"
+
+
+def test_start_private_keyboard_regular_user_order() -> None:
+    keyboard = start_private_keyboard(show_moderation_button=False)
+
+    assert [row[0].text for row in keyboard.inline_keyboard] == [
+        "Создать аукцион",
+        "Мои аукционы",
+        "Настройки",
+        "Баланс",
+    ]
+    assert all(button.callback_data != "mod:panel" for button in _all_buttons(keyboard.inline_keyboard))
+
+
+def test_start_private_keyboard_moderator_has_mod_button_last(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "ui_emoji_mod_panel_id", "mod-panel")
+    keyboard = start_private_keyboard(show_moderation_button=True)
+
+    assert [row[0].text for row in keyboard.inline_keyboard] == [
+        "Создать аукцион",
+        "Мои аукционы",
+        "Настройки",
+        "Баланс",
+        "Мод-панель",
+    ]
+    mod_button = _button_by_callback(keyboard.inline_keyboard, "mod:panel")
+    assert mod_button.style == "success"
+    assert mod_button.icon_custom_emoji_id == "mod-panel"
 
 
 def test_moderation_keyboard_uses_granular_emoji_ids(monkeypatch) -> None:

--- a/tests/test_start_dashboard.py
+++ b/tests/test_start_dashboard.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import cast
+from uuid import UUID
+
+import pytest
+from aiogram.types import CallbackQuery
+
+from app.bot.handlers.start import (
+    _render_my_auctions_text,
+    callback_dashboard_balance,
+    callback_dashboard_settings,
+)
+from app.db.enums import AuctionStatus
+
+
+class _DummyCallback:
+    def __init__(self) -> None:
+        self.answers: list[tuple[str, bool]] = []
+
+    async def answer(self, text: str = "", show_alert: bool = False, **_kwargs) -> None:
+        self.answers.append((text, show_alert))
+
+
+def test_render_my_auctions_text_empty_state() -> None:
+    text = _render_my_auctions_text([])
+
+    assert "пока нет аукционов" in text
+    assert "Создать аукцион" in text
+
+
+def test_render_my_auctions_text_with_rows() -> None:
+    rows = [
+        (UUID("12345678-1234-5678-1234-567812345678"), AuctionStatus.ACTIVE, 50, 95),
+        (UUID("87654321-4321-8765-4321-876543218765"), AuctionStatus.DRAFT, 40, None),
+    ]
+
+    text = _render_my_auctions_text(rows)
+
+    assert "Мои аукционы (последние 10):" in text
+    assert "#12345678 | Активен | текущая цена: $95" in text
+    assert "#87654321 | Черновик | текущая цена: $40" in text
+
+
+@pytest.mark.asyncio
+async def test_dashboard_settings_callback_returns_in_development_alert() -> None:
+    callback = _DummyCallback()
+
+    await callback_dashboard_settings(cast(CallbackQuery, callback))
+
+    assert callback.answers == [("Раздел «Настройки» в разработке.", True)]
+
+
+@pytest.mark.asyncio
+async def test_dashboard_balance_callback_returns_in_development_alert() -> None:
+    callback = _DummyCallback()
+
+    await callback_dashboard_balance(cast(CallbackQuery, callback))
+
+    assert callback.answers == [("Раздел «Баланс» в разработке.", True)]


### PR DESCRIPTION
## Summary
- redesign private `/start` dashboard order to: `Создать аукцион`, `Мои аукционы`, `Настройки`, `Баланс`
- show `Мод-панель` only for users with moderator/admin access and keep it as the last button
- add dashboard callbacks: `Мои аукционы` (recent seller auctions with status + current price), `Настройки`/`Баланс` in-development alerts

## Linked Issue
Closes #125

## Validation
- [x] .venv/bin/python -m ruff check app tests
- [x] .venv/bin/python -m pytest -q tests
- [x] RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test .venv/bin/python -m pytest -q tests/integration

## Telegram Smoke
- [ ] Open bot in private chat and run `/start` as regular user: `Мод-панель` hidden, button order matches spec
- [ ] Run `/start` as moderator/admin: `Мод-панель` is visible and rendered last
- [ ] Tap `Настройки` and `Баланс`: alert says section is in development
- [ ] Tap `Мои аукционы`: receive list of recent auctions with statuses and current prices

## Rollout Notes
- Dashboard callbacks are additive and do not alter existing moderation command entrypoints.

## Rollback Notes
- Revert this PR to restore previous `/start` keyboard and remove dashboard callbacks.