### PR TITLE
[Sprint 41][S41-001] Upgrade My Auctions with filters and seller tools

### DIFF
--- a/app/bot/keyboards/auction.py
+++ b/app/bot/keyboards/auction.py
@@ -90,6 +90,129 @@ def start_private_keyboard(*, show_moderation_button: bool) -> InlineKeyboardMar
     return InlineKeyboardMarkup(inline_keyboard=rows)
 
 
+def _filter_button_text(*, filter_key: str, current_filter: str, label: str) -> str:
+    if filter_key == current_filter:
+        return f"[{label}]"
+    return label
+
+
+def my_auctions_list_keyboard(
+    *,
+    auctions: list[tuple[str, str]],
+    current_filter: str,
+    page: int,
+    has_prev: bool,
+    has_next: bool,
+) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = [
+        [
+            styled_button(
+                text=_filter_button_text(filter_key="a", current_filter=current_filter, label="Активные"),
+                callback_data="dash:my:list:a:0",
+            ),
+            styled_button(
+                text=_filter_button_text(filter_key="f", current_filter=current_filter, label="Завершенные"),
+                callback_data="dash:my:list:f:0",
+            ),
+        ],
+        [
+            styled_button(
+                text=_filter_button_text(filter_key="d", current_filter=current_filter, label="Черновики"),
+                callback_data="dash:my:list:d:0",
+            ),
+            styled_button(
+                text=_filter_button_text(filter_key="l", current_filter=current_filter, label="Все"),
+                callback_data="dash:my:list:l:0",
+            ),
+        ],
+    ]
+
+    for auction_id, label in auctions:
+        rows.append(
+            [
+                styled_button(
+                    text=label,
+                    callback_data=f"dash:my:view:{auction_id}:{current_filter}:{page}",
+                    style="primary",
+                )
+            ]
+        )
+
+    nav_row: list[InlineKeyboardButton] = []
+    if has_prev:
+        nav_row.append(styled_button(text="<-", callback_data=f"dash:my:list:{current_filter}:{page - 1}"))
+    nav_row.append(styled_button(text=f"Стр. {page + 1}", callback_data=f"dash:my:list:{current_filter}:{page}"))
+    if has_next:
+        nav_row.append(styled_button(text="->", callback_data=f"dash:my:list:{current_filter}:{page + 1}"))
+    rows.append(nav_row)
+
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def my_auction_detail_keyboard(
+    *,
+    auction_id: str,
+    filter_key: str,
+    page: int,
+    first_post_url: str | None,
+) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = [
+        [
+            styled_button(
+                text="Ставки",
+                callback_data=f"dash:my:bids:{auction_id}:{filter_key}:{page}",
+                style="primary",
+            ),
+            styled_button(
+                text="Посты",
+                callback_data=f"dash:my:posts:{auction_id}:{filter_key}:{page}",
+                style="primary",
+            ),
+        ],
+        [
+            styled_button(
+                text="Фото",
+                callback_data=f"gallery:{auction_id}",
+            ),
+            styled_button(
+                text="Назад к списку",
+                callback_data=f"dash:my:list:{filter_key}:{page}",
+            ),
+        ],
+    ]
+    if first_post_url:
+        rows.insert(
+            1,
+            [
+                styled_button(
+                    text="Открыть пост",
+                    url=first_post_url,
+                    style="success",
+                )
+            ],
+        )
+
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def my_auction_subview_keyboard(*, auction_id: str, filter_key: str, page: int) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                styled_button(
+                    text="Карточка лота",
+                    callback_data=f"dash:my:view:{auction_id}:{filter_key}:{page}",
+                    style="primary",
+                ),
+                styled_button(
+                    text="Назад к списку",
+                    callback_data=f"dash:my:list:{filter_key}:{page}",
+                ),
+            ]
+        ]
+    )
+
+
 def buyout_choice_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         inline_keyboard=[

--- a/app/services/seller_dashboard_service.py
+++ b/app/services/seller_dashboard_service.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.enums import AuctionStatus
+from app.db.models import Auction, AuctionPost, Bid, User
+
+
+@dataclass(slots=True)
+class SellerAuctionListItem:
+    auction_id: uuid.UUID
+    status: AuctionStatus
+    start_price: int
+    current_price: int
+    bid_count: int
+    ends_at: datetime | None
+    created_at: datetime
+
+
+@dataclass(slots=True)
+class SellerAuctionPostItem:
+    chat_id: int | None
+    message_id: int | None
+    inline_message_id: str | None
+
+
+@dataclass(slots=True)
+class SellerBidLogItem:
+    bid_id: uuid.UUID
+    amount: int
+    created_at: datetime
+    tg_user_id: int
+    username: str | None
+    is_removed: bool
+
+
+_FILTER_STATUSES: dict[str, tuple[AuctionStatus, ...] | None] = {
+    "a": (AuctionStatus.ACTIVE, AuctionStatus.FROZEN),
+    "f": (AuctionStatus.ENDED, AuctionStatus.BOUGHT_OUT, AuctionStatus.CANCELLED),
+    "d": (AuctionStatus.DRAFT,),
+    "l": None,
+}
+
+
+def is_valid_my_auctions_filter(filter_key: str) -> bool:
+    return filter_key in _FILTER_STATUSES
+
+
+async def list_seller_auctions(
+    session: AsyncSession,
+    *,
+    seller_user_id: int,
+    filter_key: str,
+    page: int,
+    page_size: int,
+) -> tuple[list[SellerAuctionListItem], int]:
+    statuses = _FILTER_STATUSES.get(filter_key)
+
+    bid_stats_subquery = (
+        select(
+            Bid.auction_id.label("auction_id"),
+            func.max(Bid.amount).label("max_bid"),
+            func.count(Bid.id).label("bid_count"),
+        )
+        .where(Bid.is_removed.is_(False))
+        .group_by(Bid.auction_id)
+        .subquery()
+    )
+
+    count_stmt = select(func.count(Auction.id)).where(Auction.seller_user_id == seller_user_id)
+    if statuses is not None:
+        count_stmt = count_stmt.where(Auction.status.in_(statuses))
+    total_items = int((await session.scalar(count_stmt)) or 0)
+
+    list_stmt = (
+        select(
+            Auction.id,
+            Auction.status,
+            Auction.start_price,
+            func.coalesce(bid_stats_subquery.c.max_bid, Auction.start_price),
+            func.coalesce(bid_stats_subquery.c.bid_count, 0),
+            Auction.ends_at,
+            Auction.created_at,
+        )
+        .outerjoin(bid_stats_subquery, bid_stats_subquery.c.auction_id == Auction.id)
+        .where(Auction.seller_user_id == seller_user_id)
+        .order_by(Auction.created_at.desc())
+        .limit(page_size)
+        .offset(page * page_size)
+    )
+    if statuses is not None:
+        list_stmt = list_stmt.where(Auction.status.in_(statuses))
+
+    rows = (await session.execute(list_stmt)).all()
+    items = [
+        SellerAuctionListItem(
+            auction_id=auction_id,
+            status=status,
+            start_price=start_price,
+            current_price=current_price,
+            bid_count=int(bid_count),
+            ends_at=ends_at,
+            created_at=created_at,
+        )
+        for auction_id, status, start_price, current_price, bid_count, ends_at, created_at in rows
+    ]
+    return items, total_items
+
+
+async def load_seller_auction(
+    session: AsyncSession,
+    *,
+    seller_user_id: int,
+    auction_id: uuid.UUID,
+) -> SellerAuctionListItem | None:
+    bid_stats_subquery = (
+        select(
+            Bid.auction_id.label("auction_id"),
+            func.max(Bid.amount).label("max_bid"),
+            func.count(Bid.id).label("bid_count"),
+        )
+        .where(Bid.is_removed.is_(False))
+        .group_by(Bid.auction_id)
+        .subquery()
+    )
+    stmt = (
+        select(
+            Auction.id,
+            Auction.status,
+            Auction.start_price,
+            func.coalesce(bid_stats_subquery.c.max_bid, Auction.start_price),
+            func.coalesce(bid_stats_subquery.c.bid_count, 0),
+            Auction.ends_at,
+            Auction.created_at,
+        )
+        .outerjoin(bid_stats_subquery, bid_stats_subquery.c.auction_id == Auction.id)
+        .where(Auction.id == auction_id, Auction.seller_user_id == seller_user_id)
+    )
+    row = (await session.execute(stmt)).first()
+    if row is None:
+        return None
+
+    (
+        loaded_auction_id,
+        status,
+        start_price,
+        current_price,
+        bid_count,
+        ends_at,
+        created_at,
+    ) = row
+    return SellerAuctionListItem(
+        auction_id=loaded_auction_id,
+        status=status,
+        start_price=start_price,
+        current_price=current_price,
+        bid_count=int(bid_count),
+        ends_at=ends_at,
+        created_at=created_at,
+    )
+
+
+async def list_seller_auction_posts(
+    session: AsyncSession,
+    *,
+    seller_user_id: int,
+    auction_id: uuid.UUID,
+) -> list[SellerAuctionPostItem]:
+    stmt = (
+        select(AuctionPost)
+        .join(Auction, Auction.id == AuctionPost.auction_id)
+        .where(Auction.id == auction_id, Auction.seller_user_id == seller_user_id)
+        .order_by(AuctionPost.id.desc())
+    )
+    rows = (await session.execute(stmt)).scalars().all()
+    return [
+        SellerAuctionPostItem(
+            chat_id=row.chat_id,
+            message_id=row.message_id,
+            inline_message_id=row.inline_message_id,
+        )
+        for row in rows
+    ]
+
+
+async def list_seller_auction_bid_logs(
+    session: AsyncSession,
+    *,
+    seller_user_id: int,
+    auction_id: uuid.UUID,
+    limit: int = 15,
+) -> list[SellerBidLogItem]:
+    seller_check = await session.scalar(
+        select(Auction.id).where(Auction.id == auction_id, Auction.seller_user_id == seller_user_id)
+    )
+    if seller_check is None:
+        return []
+
+    stmt = (
+        select(Bid, User)
+        .join(User, User.id == Bid.user_id)
+        .where(Bid.auction_id == auction_id)
+        .order_by(Bid.created_at.desc())
+        .limit(limit)
+    )
+    rows = (await session.execute(stmt)).all()
+    return [
+        SellerBidLogItem(
+            bid_id=bid.id,
+            amount=bid.amount,
+            created_at=bid.created_at,
+            tg_user_id=user.tg_user_id,
+            username=user.username,
+            is_removed=bid.is_removed,
+        )
+        for bid, user in rows
+    ]

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -1,11 +1,12 @@
 # Planning Status
 
-Last sync: 2026-02-16 03:22 UTC
-Active sprint: Sprint 40
+Last sync: 2026-02-16 03:44 UTC
+Active sprint: Sprint 41
 
 | Item | Title | Issue | PR |
 |---|---|---|---|
-| S40-001 | Redesign private dashboard menu and add callbacks | [#125](https://github.com/Nombah501/LiteAuction/issues/125) (open) | - |
+| S41-001 | Upgrade My Auctions with filters, bid logs, and post links | [#127](https://github.com/Nombah501/LiteAuction/issues/127) (open) | - |
+| S41-002 | Add seller productivity tools and analytics in My Auctions | [#128](https://github.com/Nombah501/LiteAuction/issues/128) (open) | - |
 
 ## Recovery Checklist
 

--- a/planning/sprints/sprint-41.toml
+++ b/planning/sprints/sprint-41.toml
@@ -1,0 +1,39 @@
+sprint = "Sprint 41"
+milestone = "Sprint 41"
+milestone_description = "Seller dashboard upgrades in private My Auctions section"
+base_branch = "main"
+status_file = "planning/STATUS.md"
+
+[[items]]
+id = "S41-001"
+title = "Upgrade My Auctions with filters, bid logs, and post links"
+description = "Turn private My Auctions into an interactive seller workspace with filters, pagination, per-auction bid logs, and publication links."
+priority = "P1"
+estimate = "L"
+tech_debt = false
+labels = ["type:feature", "area:bot", "area:ux", "priority:p1"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "My Auctions supports filters: active, finished, draft, all",
+  "List supports pagination and per-auction detail view",
+  "Per-auction actions include bid logs and publication link view",
+  "Publication list exposes clickable links where Telegram URL is derivable",
+]
+
+[[items]]
+id = "S41-002"
+title = "Add seller productivity tools and analytics in My Auctions"
+description = "Add sorting options, outcome analytics, and quick draft/active actions in My Auctions as a second implementation phase."
+priority = "P2"
+estimate = "M"
+tech_debt = false
+labels = ["type:feature", "area:bot", "area:ux", "priority:p2"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "Sorting options are available for My Auctions (newest, ending soon, most bids)",
+  "Auction detail includes seller-facing outcome metrics",
+  "Draft and active auctions expose quick action buttons",
+  "Feature is delivered in dedicated follow-up PR after S41-001",
+]

--- a/tests/test_keyboard_custom_emojis.py
+++ b/tests/test_keyboard_custom_emojis.py
@@ -5,6 +5,9 @@ from aiogram.types import InlineKeyboardButton
 from app.bot.keyboards.auction import (
     auction_active_keyboard,
     draft_publish_keyboard,
+    my_auction_detail_keyboard,
+    my_auction_subview_keyboard,
+    my_auctions_list_keyboard,
     photos_done_keyboard,
     start_private_keyboard,
 )
@@ -138,6 +141,58 @@ def test_start_private_keyboard_moderator_has_mod_button_last(monkeypatch) -> No
     mod_button = _button_by_callback(keyboard.inline_keyboard, "mod:panel")
     assert mod_button.style == "success"
     assert mod_button.icon_custom_emoji_id == "mod-panel"
+
+
+def test_my_auctions_list_keyboard_structure() -> None:
+    keyboard = my_auctions_list_keyboard(
+        auctions=[
+            ("12345678-1234-5678-1234-567812345678", "#12345678 · Активен · $95"),
+            ("87654321-4321-8765-4321-876543218765", "#87654321 · Черновик · $40"),
+        ],
+        current_filter="a",
+        page=1,
+        has_prev=True,
+        has_next=False,
+    )
+
+    assert _button_by_callback(keyboard.inline_keyboard, "dash:my:list:a:0").text == "[Активные]"
+    assert _button_by_callback(keyboard.inline_keyboard, "dash:my:list:f:0").text == "Завершенные"
+    assert _button_by_callback(
+        keyboard.inline_keyboard,
+        "dash:my:view:12345678-1234-5678-1234-567812345678:a:1",
+    ).text == "#12345678 · Активен · $95"
+    assert _button_by_callback(keyboard.inline_keyboard, "dash:my:list:a:0").text == "[Активные]"
+    assert _button_by_callback(keyboard.inline_keyboard, "dash:my:list:a:1").text == "Стр. 2"
+
+
+def test_my_auction_detail_and_subview_keyboards() -> None:
+    detail = my_auction_detail_keyboard(
+        auction_id="12345678-1234-5678-1234-567812345678",
+        filter_key="f",
+        page=2,
+        first_post_url="https://t.me/c/123/456",
+    )
+
+    assert _button_by_callback(
+        detail.inline_keyboard,
+        "dash:my:bids:12345678-1234-5678-1234-567812345678:f:2",
+    ).text == "Ставки"
+    assert _button_by_callback(
+        detail.inline_keyboard,
+        "dash:my:posts:12345678-1234-5678-1234-567812345678:f:2",
+    ).text == "Посты"
+    assert _button_by_callback(detail.inline_keyboard, "gallery:12345678-1234-5678-1234-567812345678").text == "Фото"
+    assert _button_by_url(detail.inline_keyboard, "https://t.me/c/123/456").text == "Открыть пост"
+
+    subview = my_auction_subview_keyboard(
+        auction_id="12345678-1234-5678-1234-567812345678",
+        filter_key="l",
+        page=0,
+    )
+    assert _button_by_callback(
+        subview.inline_keyboard,
+        "dash:my:view:12345678-1234-5678-1234-567812345678:l:0",
+    ).text == "Карточка лота"
 
 
 def test_moderation_keyboard_uses_granular_emoji_ids(monkeypatch) -> None:

--- a/tests/test_start_dashboard.py
+++ b/tests/test_start_dashboard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from typing import cast
 from uuid import UUID
 
@@ -7,11 +8,16 @@ import pytest
 from aiogram.types import CallbackQuery
 
 from app.bot.handlers.start import (
-    _render_my_auctions_text,
+    _parse_my_auctions_item_payload,
+    _parse_my_auctions_list_payload,
+    _render_bid_logs_text,
+    _render_my_auctions_list_text,
+    _resolve_post_link,
     callback_dashboard_balance,
     callback_dashboard_settings,
 )
 from app.db.enums import AuctionStatus
+from app.services.seller_dashboard_service import SellerAuctionListItem, SellerBidLogItem
 
 
 class _DummyCallback:
@@ -22,24 +28,83 @@ class _DummyCallback:
         self.answers.append((text, show_alert))
 
 
-def test_render_my_auctions_text_empty_state() -> None:
-    text = _render_my_auctions_text([])
+def test_parse_my_auctions_list_payload() -> None:
+    assert _parse_my_auctions_list_payload("dash:my:list:a:0") == ("a", 0)
+    assert _parse_my_auctions_list_payload("dash:my:list:f:3") == ("f", 3)
+    assert _parse_my_auctions_list_payload("dash:my:list:x:1") is None
+    assert _parse_my_auctions_list_payload("dash:my:list:a:-1") is None
 
-    assert "пока нет аукционов" in text
-    assert "Создать аукцион" in text
+
+def test_parse_my_auctions_item_payload() -> None:
+    payload = _parse_my_auctions_item_payload(
+        "dash:my:view:12345678-1234-5678-1234-567812345678:a:0",
+        action="view",
+    )
+    assert payload == (UUID("12345678-1234-5678-1234-567812345678"), "a", 0)
+    assert (
+        _parse_my_auctions_item_payload(
+            "dash:my:view:not-uuid:a:0",
+            action="view",
+        )
+        is None
+    )
 
 
-def test_render_my_auctions_text_with_rows() -> None:
-    rows = [
-        (UUID("12345678-1234-5678-1234-567812345678"), AuctionStatus.ACTIVE, 50, 95),
-        (UUID("87654321-4321-8765-4321-876543218765"), AuctionStatus.DRAFT, 40, None),
+def test_render_my_auctions_list_text_empty_state() -> None:
+    text = _render_my_auctions_list_text(items=[], filter_key="a", page=0, total_items=0)
+
+    assert "Мои аукционы" in text
+    assert "пока нет лотов" in text
+
+
+def test_render_my_auctions_list_text_with_items() -> None:
+    now = datetime.now(UTC)
+    items = [
+        SellerAuctionListItem(
+            auction_id=UUID("12345678-1234-5678-1234-567812345678"),
+            status=AuctionStatus.ACTIVE,
+            start_price=50,
+            current_price=95,
+            bid_count=5,
+            ends_at=now + timedelta(hours=1),
+            created_at=now,
+        )
     ]
 
-    text = _render_my_auctions_text(rows)
+    text = _render_my_auctions_list_text(items=items, filter_key="a", page=0, total_items=1)
 
-    assert "Мои аукционы (последние 10):" in text
-    assert "#12345678 | Активен | текущая цена: $95" in text
-    assert "#87654321 | Черновик | текущая цена: $40" in text
+    assert "#12345678" in text
+    assert "Активен" in text
+    assert "$95" in text
+    assert "ставок: 5" in text
+
+
+def test_render_bid_logs_text_contains_actor_and_amount() -> None:
+    rows = [
+        SellerBidLogItem(
+            bid_id=UUID("12345678-1234-5678-1234-567812345678"),
+            amount=100,
+            created_at=datetime.now(UTC),
+            tg_user_id=42,
+            username="anna",
+            is_removed=False,
+        )
+    ]
+
+    text = _render_bid_logs_text(
+        auction_id=UUID("87654321-4321-8765-4321-876543218765"),
+        rows=rows,
+    )
+
+    assert "#87654321" in text
+    assert "$100" in text
+    assert "@anna" in text
+
+
+def test_resolve_post_link_variants() -> None:
+    assert _resolve_post_link(-1001234567890, 17, None) == "https://t.me/c/1234567890/17"
+    assert _resolve_post_link(-1001234567890, 17, "publicchat") == "https://t.me/publicchat/17"
+    assert _resolve_post_link(-424242, 17, None) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- upgrade private `Мои аукционы` into an interactive seller workspace with filters (`Активные`, `Завершенные`, `Черновики`, `Все`) and pagination
- add per-lot views with quick actions for bid logs, publication links, and photos
- introduce seller dashboard data service to fetch scoped auctions, bid logs, and publication metadata safely for the current seller

## Linked Issue
Closes #127

## Follow-up Scope
- Planned as phase 2 in Sprint 41: #128

## Validation
- [x] .venv/bin/python -m ruff check app tests
- [x] .venv/bin/python -m pytest -q tests
- [x] RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test .venv/bin/python -m pytest -q tests/integration

## Telegram Smoke
- [ ] `/start` -> `Мои аукционы` opens filtered list and pagination controls
- [ ] Filter tabs switch between active/finished/draft/all
- [ ] Lot detail shows actions: `Ставки`, `Посты`, `Фото`
- [ ] `Ставки` shows recent bid logs with actor and amount
- [ ] `Посты` shows clickable links when URL can be derived

## Rollout Notes
- New callback namespace under `dash:my:*` for seller dashboard navigation.

## Rollback Notes
- Revert this PR to restore simple text-only My Auctions behavior.