### PR TITLE
[Sprint 41][S41-002] Add seller productivity tools to My Auctions

### DIFF
--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -1,11 +1,11 @@
 # Planning Status
 
-Last sync: 2026-02-16 03:44 UTC
+Last sync: 2026-02-16 14:30 UTC
 Active sprint: Sprint 41
 
 | Item | Title | Issue | PR |
 |---|---|---|---|
-| S41-001 | Upgrade My Auctions with filters, bid logs, and post links | [#127](https://github.com/Nombah501/LiteAuction/issues/127) (open) | - |
+| S41-001 | Upgrade My Auctions with filters, bid logs, and post links | [#127](https://github.com/Nombah501/LiteAuction/issues/127) (closed) | - |
 | S41-002 | Add seller productivity tools and analytics in My Auctions | [#128](https://github.com/Nombah501/LiteAuction/issues/128) (open) | - |
 
 ## Recovery Checklist


### PR DESCRIPTION
## Summary
- add sorting controls for My Auctions (`Новые`, `Скоро финиш`, `Больше ставок`) and preserve sort in callback navigation
- extend lot detail with seller-facing outcome metrics (growth vs start and average growth per bid)
- add quick actions by lot state: draft publish helpers (`Inline пост`, `Скопировать /publish`) and active/frozen `Обновить посты`

## Linked Issue
Closes #128

## Validation
- [x] .venv/bin/python -m ruff check app tests
- [x] .venv/bin/python -m pytest -q tests
- [x] RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test .venv/bin/python -m pytest -q tests/integration

## Telegram Smoke
- [ ] Open `Мои аукционы` and switch sort modes (`Новые`, `Скоро финиш`, `Больше ставок`)
- [ ] Open a draft lot and verify quick actions: `Inline пост`, `Скопировать /publish`
- [ ] Open an active lot and verify `Обновить посты` refreshes publication card
- [ ] Verify detail metrics include growth vs start and average growth per bid

## Rollout Notes
- Callback payloads now include sort key but remain backward-compatible with previously sent dashboard messages.

## Rollback Notes
- Revert this PR to remove sorting and quick-action controls from My Auctions.