### PR TITLE
[Sprint 43][S43-003] Add auction-level snooze controls for noisy lots

### DIFF
--- a/alembic/versions/0033_user_auction_notification_snoozes.py
+++ b/alembic/versions/0033_user_auction_notification_snoozes.py
@@ -1,0 +1,75 @@
+"""add user auction notification snoozes table
+
+Revision ID: 0033_user_auc_notif_snooze
+Revises: 0032_user_notif_prefs
+Create Date: 2026-02-17 20:25:00
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0033_user_auc_notif_snooze"
+down_revision: str | None = "0032_user_notif_prefs"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_auction_notification_snoozes",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("auction_id", sa.UUID(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("TIMEZONE('utc', NOW())"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("TIMEZONE('utc', NOW())"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="fk_user_auction_notification_snoozes_user_id_users",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_user_auction_notification_snoozes"),
+        sa.UniqueConstraint(
+            "user_id",
+            "auction_id",
+            name="uq_user_auction_notification_snoozes_user_auction",
+        ),
+    )
+    op.create_index(
+        "ix_user_auction_notification_snoozes_user_id",
+        "user_auction_notification_snoozes",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_user_auction_notification_snoozes_expires_at",
+        "user_auction_notification_snoozes",
+        ["expires_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_user_auction_notification_snoozes_expires_at",
+        table_name="user_auction_notification_snoozes",
+    )
+    op.drop_index(
+        "ix_user_auction_notification_snoozes_user_id",
+        table_name="user_auction_notification_snoozes",
+    )
+    op.drop_table("user_auction_notification_snoozes")

--- a/app/bot/handlers/bid_actions.py
+++ b/app/bot/handlers/bid_actions.py
@@ -293,6 +293,7 @@ async def _notify_outbid(
         reply_markup=reply_markup,
         message_effect_id=resolve_auction_message_effect_id(AuctionMessageEffectEvent.OUTBID),
         notification_event=NotificationEventType.AUCTION_OUTBID,
+        auction_id=auction_id,
     )
 
 
@@ -319,6 +320,7 @@ async def _notify_auction_finish(
                 AuctionMessageEffectEvent.BUYOUT_SELLER
             ),
             notification_event=NotificationEventType.AUCTION_FINISH,
+            auction_id=auction_id,
         )
     if winner_tg_id is not None:
         await send_user_topic_message(
@@ -331,6 +333,7 @@ async def _notify_auction_finish(
                 AuctionMessageEffectEvent.BUYOUT_WINNER
             ),
             notification_event=NotificationEventType.AUCTION_WIN,
+            auction_id=auction_id,
         )
 
 

--- a/app/bot/handlers/moderation.py
+++ b/app/bot/handlers/moderation.py
@@ -1253,6 +1253,7 @@ async def mod_freeze(message: Message, bot: Bot) -> None:
             text=f"Аукцион #{str(auction_id)[:8]} заморожен модератором",
             reply_markup=reply_markup,
             notification_event=NotificationEventType.AUCTION_MOD_ACTION,
+            auction_id=auction_id,
         )
 
 
@@ -1304,6 +1305,7 @@ async def mod_unfreeze(message: Message, bot: Bot) -> None:
             text=f"Аукцион #{str(auction_id)[:8]} разморожен модератором",
             reply_markup=reply_markup,
             notification_event=NotificationEventType.AUCTION_MOD_ACTION,
+            auction_id=auction_id,
         )
 
 
@@ -1355,6 +1357,7 @@ async def mod_end(message: Message, bot: Bot) -> None:
             text=f"Аукцион #{str(auction_id)[:8]} завершен модератором",
             reply_markup=reply_markup,
             notification_event=NotificationEventType.AUCTION_MOD_ACTION,
+            auction_id=auction_id,
         )
     if result.winner_tg_user_id:
         await send_user_topic_message(
@@ -1364,6 +1367,7 @@ async def mod_end(message: Message, bot: Bot) -> None:
             text=f"Вы победили в аукционе #{str(auction_id)[:8]}",
             reply_markup=reply_markup,
             notification_event=NotificationEventType.AUCTION_MOD_ACTION,
+            auction_id=auction_id,
         )
 
 
@@ -1450,6 +1454,7 @@ async def mod_remove_bid(message: Message, bot: Bot) -> None:
             text="Ваша ставка была снята модератором",
             reply_markup=reply_markup,
             notification_event=NotificationEventType.AUCTION_MOD_ACTION,
+            auction_id=result.auction_id,
         )
 
 
@@ -2147,6 +2152,7 @@ async def mod_panel_callbacks(callback: CallbackQuery, bot: Bot) -> None:
                 text=f"Аукцион #{str(auction_id)[:8]} разморожен модератором",
                 reply_markup=reply_markup,
                 notification_event=NotificationEventType.AUCTION_MOD_ACTION,
+                auction_id=auction_id,
             )
 
         text, keyboard = await _build_frozen_auctions_page(page)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -78,6 +78,24 @@ class UserNotificationPreference(Base, TimestampMixin):
     configured_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
+class UserAuctionNotificationSnooze(Base, TimestampMixin):
+    __tablename__ = "user_auction_notification_snoozes"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "auction_id",
+            name="uq_user_auction_notification_snoozes_user_auction",
+        ),
+        Index("ix_user_auction_notification_snoozes_user_id", "user_id"),
+        Index("ix_user_auction_notification_snoozes_expires_at", "expires_at"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    auction_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
 class TelegramUserVerification(Base):
     __tablename__ = "telegram_user_verifications"
     __table_args__ = (UniqueConstraint("tg_user_id", name="uq_telegram_user_verifications_tg_user_id"),)

--- a/app/services/auction_service.py
+++ b/app/services/auction_service.py
@@ -833,6 +833,7 @@ async def finalize_expired_auctions(bot: Bot) -> int:
                 AuctionMessageEffectEvent.ENDED_SELLER
             ),
             notification_event=NotificationEventType.AUCTION_FINISH,
+            auction_id=result.auction_id,
         )
 
         if result.winner_tg_user_id is not None:
@@ -846,6 +847,7 @@ async def finalize_expired_auctions(bot: Bot) -> int:
                     AuctionMessageEffectEvent.ENDED_WINNER
                 ),
                 notification_event=NotificationEventType.AUCTION_WIN,
+                auction_id=result.auction_id,
             )
 
     return len(finalized_results)

--- a/app/services/notification_policy_service.py
+++ b/app/services/notification_policy_service.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import StrEnum
+import uuid
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.models import User, UserNotificationPreference
+from app.db.models import User, UserAuctionNotificationSnooze, UserNotificationPreference
 
 
 class NotificationPreset(StrEnum):
@@ -37,6 +38,12 @@ class NotificationSettingsSnapshot:
     points_enabled: bool
     support_enabled: bool
     configured: bool
+
+
+@dataclass(slots=True)
+class AuctionNotificationSnoozeView:
+    auction_id: uuid.UUID
+    expires_at: datetime
 
 
 _PRESET_VALUES: dict[NotificationPreset, dict[str, bool]] = {
@@ -88,6 +95,16 @@ _ACTION_KEY_TO_EVENT: dict[str, NotificationEventType] = {
     value: key for key, value in _EVENT_TO_ACTION_KEY.items()
 }
 
+_AUCTION_SNOOZE_MINUTES_DEFAULT = 60
+_AUCTION_SNOOZE_MINUTES_MAX = 24 * 60
+
+_AUCTION_EVENT_TYPES: set[NotificationEventType] = {
+    NotificationEventType.AUCTION_OUTBID,
+    NotificationEventType.AUCTION_FINISH,
+    NotificationEventType.AUCTION_WIN,
+    NotificationEventType.AUCTION_MOD_ACTION,
+}
+
 
 def _normalize_preset(raw: str | None) -> NotificationPreset:
     if raw is None:
@@ -104,6 +121,35 @@ def notification_event_action_key(event_type: NotificationEventType) -> str:
 
 def notification_event_from_action_key(action_key: str) -> NotificationEventType | None:
     return _ACTION_KEY_TO_EVENT.get(action_key)
+
+
+def default_auction_snooze_minutes() -> int:
+    return _AUCTION_SNOOZE_MINUTES_DEFAULT
+
+
+def notification_snooze_callback_data(*, auction_id: uuid.UUID, duration_minutes: int) -> str:
+    duration = max(1, min(duration_minutes, _AUCTION_SNOOZE_MINUTES_MAX))
+    return f"notif:snooze:{auction_id}:{duration}"
+
+
+def parse_notification_snooze_callback_data(callback_data: str) -> tuple[uuid.UUID, int] | None:
+    parts = callback_data.split(":")
+    if len(parts) != 4:
+        return None
+    if parts[0] != "notif" or parts[1] != "snooze":
+        return None
+
+    try:
+        auction_id = uuid.UUID(parts[2])
+    except ValueError:
+        return None
+
+    if not parts[3].isdigit():
+        return None
+    duration = int(parts[3])
+    if duration < 1:
+        return None
+    return auction_id, min(duration, _AUCTION_SNOOZE_MINUTES_MAX)
 
 
 def _snapshot_from_row(*, user: User, row: UserNotificationPreference | None) -> NotificationSettingsSnapshot:
@@ -292,17 +338,154 @@ async def set_notification_event_enabled(
     return _snapshot_from_row(user=user, row=row)
 
 
+def _build_snooze_view(row: UserAuctionNotificationSnooze) -> AuctionNotificationSnoozeView:
+    return AuctionNotificationSnoozeView(
+        auction_id=row.auction_id,
+        expires_at=row.expires_at,
+    )
+
+
+async def _delete_expired_snoozes(session: AsyncSession, *, user_id: int) -> None:
+    await session.execute(
+        delete(UserAuctionNotificationSnooze).where(
+            UserAuctionNotificationSnooze.user_id == user_id,
+            UserAuctionNotificationSnooze.expires_at <= datetime.now(timezone.utc),
+        )
+    )
+
+
+async def list_active_auction_notification_snoozes(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    limit: int = 5,
+) -> list[AuctionNotificationSnoozeView]:
+    await _delete_expired_snoozes(session, user_id=user_id)
+
+    rows = await session.scalars(
+        select(UserAuctionNotificationSnooze)
+        .where(
+            UserAuctionNotificationSnooze.user_id == user_id,
+            UserAuctionNotificationSnooze.expires_at > datetime.now(timezone.utc),
+        )
+        .order_by(UserAuctionNotificationSnooze.expires_at.asc())
+        .limit(max(limit, 1))
+    )
+    return [_build_snooze_view(row) for row in rows]
+
+
+async def set_auction_notification_snooze(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    auction_id: uuid.UUID,
+    duration_minutes: int = 60,
+) -> AuctionNotificationSnoozeView:
+    await _delete_expired_snoozes(session, user_id=user_id)
+    now_utc = datetime.now(timezone.utc)
+    duration = max(1, min(duration_minutes, _AUCTION_SNOOZE_MINUTES_MAX))
+    expires_at = now_utc + timedelta(minutes=duration)
+
+    row = await session.scalar(
+        select(UserAuctionNotificationSnooze).where(
+            UserAuctionNotificationSnooze.user_id == user_id,
+            UserAuctionNotificationSnooze.auction_id == auction_id,
+        )
+    )
+    if row is None:
+        row = UserAuctionNotificationSnooze(
+            user_id=user_id,
+            auction_id=auction_id,
+            expires_at=expires_at,
+            updated_at=now_utc,
+        )
+        session.add(row)
+    else:
+        row.expires_at = expires_at
+        row.updated_at = now_utc
+
+    await session.flush()
+    return _build_snooze_view(row)
+
+
+async def set_auction_notification_snooze_by_tg_user_id(
+    session: AsyncSession,
+    *,
+    tg_user_id: int,
+    auction_id: uuid.UUID,
+    duration_minutes: int = 60,
+) -> AuctionNotificationSnoozeView | None:
+    user = await session.scalar(select(User).where(User.tg_user_id == tg_user_id))
+    if user is None:
+        return None
+    return await set_auction_notification_snooze(
+        session,
+        user_id=user.id,
+        auction_id=auction_id,
+        duration_minutes=duration_minutes,
+    )
+
+
+async def clear_auction_notification_snooze(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    auction_id: uuid.UUID,
+) -> bool:
+    row = await session.scalar(
+        select(UserAuctionNotificationSnooze).where(
+            UserAuctionNotificationSnooze.user_id == user_id,
+            UserAuctionNotificationSnooze.auction_id == auction_id,
+        )
+    )
+    if row is None:
+        return False
+    await session.delete(row)
+    await session.flush()
+    return True
+
+
+async def is_auction_notification_snoozed_by_tg_user_id(
+    session: AsyncSession,
+    *,
+    tg_user_id: int,
+    auction_id: uuid.UUID,
+) -> bool:
+    user = await session.scalar(select(User).where(User.tg_user_id == tg_user_id))
+    if user is None:
+        return False
+
+    await _delete_expired_snoozes(session, user_id=user.id)
+    row = await session.scalar(
+        select(UserAuctionNotificationSnooze.id).where(
+            UserAuctionNotificationSnooze.user_id == user.id,
+            UserAuctionNotificationSnooze.auction_id == auction_id,
+            UserAuctionNotificationSnooze.expires_at > datetime.now(timezone.utc),
+        )
+    )
+    return row is not None
+
+
 async def is_notification_allowed(
     session: AsyncSession,
     *,
     tg_user_id: int,
     event_type: NotificationEventType,
+    auction_id: uuid.UUID | None = None,
 ) -> bool:
     snapshot = await load_notification_settings_by_tg_user_id(session, tg_user_id=tg_user_id)
     if snapshot is None:
         return True
     if not snapshot.master_enabled:
         return False
+
+    if auction_id is not None and event_type in _AUCTION_EVENT_TYPES:
+        if await is_auction_notification_snoozed_by_tg_user_id(
+            session,
+            tg_user_id=tg_user_id,
+            auction_id=auction_id,
+        ):
+            return False
 
     if event_type == NotificationEventType.AUCTION_OUTBID:
         return snapshot.outbid_enabled

--- a/docs/release/sprint-43-notification-controls-readiness.md
+++ b/docs/release/sprint-43-notification-controls-readiness.md
@@ -1,0 +1,52 @@
+# Sprint 43 Notification Controls Readiness
+
+## Objective
+
+Ship actionable direct-notification controls that let users mute noisy categories and snooze specific auctions without leaving Telegram flows.
+
+## Scope
+
+- One-tap `Отключить этот тип` action in direct notifications
+- One-tap auction snooze action (`Пауза по лоту на 1ч`) for auction events
+- Per-auction snooze storage with automatic expiry (`user_auction_notification_snoozes`)
+- Settings panel visibility for active snoozes and one-tap remove actions
+- Settings polish: quick re-enable buttons for disabled notification types
+- Backward-safe callback parsing for stale/invalid snooze payloads
+
+## Validation Checklist
+
+- [x] `python -m compileall app tests`
+- [ ] `python -m ruff check app tests`
+- [ ] `python -m pytest -q tests`
+
+Notes:
+
+- Runtime image in this environment does not include `ruff`/`pytest`; syntax validation was completed with `compileall`.
+
+## Manual Smoke Checklist
+
+- [ ] Receive outbid/finish/win/mod notification and see buttons:
+  - `Открыть аукцион` (when link can be resolved)
+  - `Пауза по лоту на 1ч`
+  - `Отключить этот тип`
+- [ ] Tap `Пауза по лоту на 1ч` and verify next auction event is suppressed for ~1 hour
+- [ ] Open `/settings` and verify active snooze appears with expiry and `Снять паузу #...`
+- [ ] Tap `Снять паузу #...` and verify next auction event for the same lot is delivered
+- [ ] Disable a category from a notification, then verify `/settings` shows `Включить: ...` quick action
+- [ ] Tap `Включить: ...` and verify category resumes delivery
+
+## Rollout Plan
+
+1. Deploy migration `0033_user_auc_notif_snooze`.
+2. Deploy bot image with snooze callbacks and settings controls.
+3. Verify bot health and polling status.
+4. Execute manual smoke with two Telegram accounts across at least one active auction.
+
+## Rollback Plan
+
+If callback handling or suppression logic behaves unexpectedly:
+
+1. Roll back bot image to previous stable release.
+2. Keep migration in place (additive table, safe to keep unused).
+3. Re-check direct notifications for legacy behavior.
+4. Patch callback/action mapping in follow-up hotfix PR.

--- a/tests/test_notification_settings_render.py
+++ b/tests/test_notification_settings_render.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from uuid import UUID
+
 from app.bot.handlers.start import _preset_title, _render_settings_text
-from app.services.notification_policy_service import NotificationPreset, NotificationSettingsSnapshot
+from app.services.notification_policy_service import (
+    AuctionNotificationSnoozeView,
+    NotificationPreset,
+    NotificationSettingsSnapshot,
+)
 
 
 def test_preset_title_labels() -> None:
@@ -30,3 +37,50 @@ def test_render_settings_text_includes_state_markers() -> None:
     assert "Глобально: <b>отключены</b>" in text
     assert "Пресет: <b>Только важные</b>" in text
     assert "Статус первичной настройки: <b>настроены</b>" in text
+
+
+def test_render_settings_text_includes_active_snoozes() -> None:
+    snapshot = NotificationSettingsSnapshot(
+        master_enabled=True,
+        preset=NotificationPreset.RECOMMENDED,
+        outbid_enabled=True,
+        auction_finish_enabled=True,
+        auction_win_enabled=True,
+        auction_mod_actions_enabled=True,
+        points_enabled=True,
+        support_enabled=True,
+        configured=True,
+    )
+    snoozes = [
+        AuctionNotificationSnoozeView(
+            auction_id=UUID("12345678-1234-5678-1234-567812345678"),
+            expires_at=datetime(2026, 2, 18, 10, 30, tzinfo=UTC),
+        )
+    ]
+
+    text = _render_settings_text(snapshot, snoozes=snoozes)
+
+    assert "Пауза по отдельным лотам" in text
+    assert "#12345678" in text
+    assert "18.02 10:30 UTC" in text
+
+
+def test_render_settings_text_includes_disabled_types_block() -> None:
+    snapshot = NotificationSettingsSnapshot(
+        master_enabled=True,
+        preset=NotificationPreset.CUSTOM,
+        outbid_enabled=False,
+        auction_finish_enabled=True,
+        auction_win_enabled=False,
+        auction_mod_actions_enabled=True,
+        points_enabled=True,
+        support_enabled=False,
+        configured=True,
+    )
+
+    text = _render_settings_text(snapshot)
+
+    assert "Отключенные типы" in text
+    assert "Перебили ставку" in text
+    assert "Победа в аукционе" in text
+    assert "Поддержка и апелляции" in text

--- a/tests/test_private_topics_notification_markup.py
+++ b/tests/test_private_topics_notification_markup.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from uuid import UUID
+
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 from app.services.notification_policy_service import NotificationEventType
@@ -10,6 +12,7 @@ def test_notification_reply_markup_adds_mute_row_for_event() -> None:
     markup = _notification_reply_markup(
         reply_markup=None,
         notification_event=NotificationEventType.AUCTION_OUTBID,
+        auction_id=None,
     )
 
     assert isinstance(markup, InlineKeyboardMarkup)
@@ -27,9 +30,23 @@ def test_notification_reply_markup_appends_mute_row_to_existing_markup() -> None
     markup = _notification_reply_markup(
         reply_markup=existing,
         notification_event=NotificationEventType.AUCTION_FINISH,
+        auction_id=None,
     )
 
     assert isinstance(markup, InlineKeyboardMarkup)
     assert len(markup.inline_keyboard) == 2
     assert markup.inline_keyboard[0][0].text == "Open"
     assert markup.inline_keyboard[1][0].callback_data == "notif:mute:finish"
+
+
+def test_notification_reply_markup_adds_auction_snooze_row_when_auction_known() -> None:
+    markup = _notification_reply_markup(
+        reply_markup=None,
+        notification_event=NotificationEventType.AUCTION_WIN,
+        auction_id=UUID("12345678-1234-5678-1234-567812345678"),
+    )
+
+    assert isinstance(markup, InlineKeyboardMarkup)
+    assert len(markup.inline_keyboard) == 2
+    assert markup.inline_keyboard[0][0].callback_data == "notif:snooze:12345678-1234-5678-1234-567812345678:60"
+    assert markup.inline_keyboard[1][0].callback_data == "notif:mute:win"


### PR DESCRIPTION
## Summary
- add per-auction notification snooze storage, lifecycle helpers, and policy enforcement so auction events can be temporarily silenced per user
- add DM actions for `Пауза по лоту на 1ч` and wire `auction_id` through auction notification call sites (outbid/finish/win/mod actions)
- polish `/settings` with active snooze visibility/removal and one-tap re-enable buttons for disabled notification types
- include Sprint 43 readiness notes with rollout/rollback checklist

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests`
- `docker compose run --rm --no-deps -v /home/n501/VibeCoding/LiteAuction:/app bot sh -lc "pip install --no-cache-dir pytest pytest-asyncio >/tmp/pip-install.log && RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test python -m pytest -q tests/integration"`

## Rollout Notes
- Apply Alembic migration `0033_user_auc_notif_snooze` before or with bot deploy.
- Verify DM auction notifications now include snooze + mute controls and that `/settings` reflects active snoozes.

## Rollback Notes
- Roll back bot image to disable new callbacks/policy checks if needed.
- Keep migration in place (additive table) and ignore it until forward fix is deployed.

Closes #139