### PR TITLE
[Sprint 43][S43-005] Stabilize callback payload compatibility for notification actions

### DIFF
--- a/docs/release/sprint-43-notification-controls-readiness.md
+++ b/docs/release/sprint-43-notification-controls-readiness.md
@@ -11,7 +11,7 @@ Ship actionable direct-notification controls that let users mute noisy categorie
 - Per-auction snooze storage with automatic expiry (`user_auction_notification_snoozes`)
 - Settings panel visibility for active snoozes and one-tap remove actions
 - Settings polish: quick re-enable buttons for disabled notification types
-- Backward-safe callback parsing for stale/invalid snooze payloads
+- Backward-safe callback parsing for stale/invalid mute and snooze payloads
 
 ## Validation Checklist
 
@@ -34,6 +34,7 @@ Notes:
 - [ ] Tap `Снять паузу #...` and verify next auction event for the same lot is delivered
 - [ ] Disable a category from a notification, then verify `/settings` shows `Включить: ...` quick action
 - [ ] Tap `Включить: ...` and verify category resumes delivery
+- [ ] Tap an outdated notification action payload and verify user sees a clear alert without traceback/noise in logs
 
 ## Rollout Plan
 


### PR DESCRIPTION
## Summary
- harden notification callback parsing to support legacy payload variants for mute/snooze actions (`notif:disable:*`, `notif:off:*`, and legacy snooze payload without duration)
- add clear stale-button alerts in handlers so outdated notification messages fail safely for users without traceback-prone paths
- document stale callback smoke scenario in Sprint 43 readiness notes

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests/test_notification_policy_service.py tests/test_start_dashboard.py tests/test_private_topics_notification_markup.py tests/test_notification_settings_render.py`
- `.venv/bin/python -m pytest -q tests`
- `docker compose run --rm --no-deps -v /home/n501/VibeCoding/LiteAuction:/app bot sh -lc "pip install --no-cache-dir pytest pytest-asyncio >/tmp/pip-install.log && RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test python -m pytest -q tests/integration"`

## Rollout Notes
- No schema/config changes.
- Verify that tapping old notification buttons now shows a clear alert and no handler errors.

## Rollback Notes
- Roll back bot image to previous release to restore old callback parsing behavior if needed.

Closes #141