### PR TITLE
[Sprint 44][S44-001] Implement per-auction debounce for outbid notifications

### DIFF
--- a/app/bot/handlers/bid_actions.py
+++ b/app/bot/handlers/bid_actions.py
@@ -15,6 +15,7 @@ from app.db.session import SessionFactory
 from app.services.anti_fool_service import (
     acquire_bid_cooldown,
     acquire_complaint_cooldown,
+    acquire_outbid_notification_debounce,
     arm_or_confirm_action,
 )
 from app.services.auction_service import (
@@ -280,6 +281,9 @@ async def _notify_outbid(
     post_url: str | None,
 ) -> None:
     if outbid_user_tg_id is None or outbid_user_tg_id == actor_tg_id:
+        return
+
+    if not await acquire_outbid_notification_debounce(auction_id, outbid_user_tg_id):
         return
 
     resolved_post_url = post_url or await resolve_auction_post_url(bot, auction_id=auction_id)

--- a/app/config.py
+++ b/app/config.py
@@ -91,6 +91,7 @@ class Settings(BaseSettings):
     anti_sniper_extend_minutes: int = 3
     anti_sniper_max_extensions: int = 3
     bid_cooldown_seconds: int = 2
+    outbid_notification_debounce_seconds: int = 60
     duplicate_bid_window_seconds: int = 15
     confirmation_ttl_seconds: int = 5
     complaint_cooldown_seconds: int = 60

--- a/config/defaults.toml
+++ b/config/defaults.toml
@@ -58,6 +58,7 @@ anti_sniper_window_minutes = 2
 anti_sniper_extend_minutes = 3
 anti_sniper_max_extensions = 3
 bid_cooldown_seconds = 2
+outbid_notification_debounce_seconds = 60
 duplicate_bid_window_seconds = 15
 confirmation_ttl_seconds = 5
 complaint_cooldown_seconds = 60

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -1,15 +1,15 @@
 # Planning Status
 
-Last sync: 2026-02-17 14:59 UTC
-Active sprint: Sprint 43
+Last sync: 2026-02-17 19:15 UTC
+Active sprint: Sprint 44
 
 | Item | Title | Issue | PR |
 |---|---|---|---|
-| S43-001 | Unify open-auction deep links in direct notifications | [#137](https://github.com/Nombah501/LiteAuction/issues/137) (closed) | - |
-| S43-002 | Add quick action to mute notification type from message | [#138](https://github.com/Nombah501/LiteAuction/issues/138) (open) | - |
-| S43-003 | Add auction-level snooze controls for noisy lots | [#139](https://github.com/Nombah501/LiteAuction/issues/139) (open) | - |
-| S43-004 | Add direct notification control panel | [#140](https://github.com/Nombah501/LiteAuction/issues/140) (open) | - |
-| S43-005 | Stabilize callback payload compatibility for notification actions | [#141](https://github.com/Nombah501/LiteAuction/issues/141) (open) | - |
+| S44-001 | Implement per-auction debounce for outbid notifications | [#142](https://github.com/Nombah501/LiteAuction/issues/142) (open) | - |
+| S44-002 | Add notification batching and digest mode | [#143](https://github.com/Nombah501/LiteAuction/issues/143) (open) | - |
+| S44-003 | Introduce quiet hours for non-critical notifications | [#144](https://github.com/Nombah501/LiteAuction/issues/144) (open) | - |
+| S44-004 | Add notification priority model and delivery rules | [#145](https://github.com/Nombah501/LiteAuction/issues/145) (open) | - |
+| S44-005 | Track anti-noise effectiveness metrics | [#146](https://github.com/Nombah501/LiteAuction/issues/146) (open) | - |
 
 ## Recovery Checklist
 

--- a/tests/test_anti_fool_service.py
+++ b/tests/test_anti_fool_service.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from app.services import anti_fool_service
+
+
+class _RedisSetStub:
+    def __init__(self, result: object) -> None:
+        self.result = result
+        self.calls: list[tuple[str, str, int, bool]] = []
+
+    async def set(self, key: str, value: str, *, ex: int, nx: bool) -> object:
+        self.calls.append((key, value, ex, nx))
+        return self.result
+
+
+@pytest.mark.asyncio
+async def test_outbid_notification_debounce_disabled_bypasses_redis(monkeypatch) -> None:
+    stub = _RedisSetStub(result=True)
+    monkeypatch.setattr(anti_fool_service, "redis_client", stub)
+    monkeypatch.setattr(anti_fool_service.settings, "outbid_notification_debounce_seconds", 0)
+
+    allowed = await anti_fool_service.acquire_outbid_notification_debounce(
+        UUID("12345678-1234-5678-1234-567812345678"),
+        42,
+    )
+
+    assert allowed is True
+    assert stub.calls == []
+
+
+@pytest.mark.asyncio
+async def test_outbid_notification_debounce_uses_user_and_auction_key(monkeypatch) -> None:
+    stub = _RedisSetStub(result=True)
+    monkeypatch.setattr(anti_fool_service, "redis_client", stub)
+    monkeypatch.setattr(anti_fool_service.settings, "outbid_notification_debounce_seconds", 75)
+
+    allowed = await anti_fool_service.acquire_outbid_notification_debounce(
+        UUID("12345678-1234-5678-1234-567812345678"),
+        55,
+    )
+
+    assert allowed is True
+    assert stub.calls == [
+        ("notif:outbid:debounce:12345678-1234-5678-1234-567812345678:55", "1", 75, True)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_outbid_notification_debounce_denies_when_key_exists(monkeypatch) -> None:
+    stub = _RedisSetStub(result=None)
+    monkeypatch.setattr(anti_fool_service, "redis_client", stub)
+    monkeypatch.setattr(anti_fool_service.settings, "outbid_notification_debounce_seconds", 60)
+
+    allowed = await anti_fool_service.acquire_outbid_notification_debounce(
+        UUID("12345678-1234-5678-1234-567812345678"),
+        99,
+    )
+
+    assert allowed is False

--- a/tests/test_bid_actions_outbid_notifications.py
+++ b/tests/test_bid_actions_outbid_notifications.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from app.bot.handlers import bid_actions
+from app.services.notification_policy_service import NotificationEventType
+
+
+class _BotStub:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_notify_outbid_skips_message_when_debounce_denies(monkeypatch) -> None:
+    sent_calls: list[dict[str, object]] = []
+
+    async def _deny_debounce(_auction_id: UUID, _tg_user_id: int) -> bool:
+        return False
+
+    async def _capture_send(*_args, **kwargs):
+        sent_calls.append(kwargs)
+        return True
+
+    monkeypatch.setattr(bid_actions, "acquire_outbid_notification_debounce", _deny_debounce)
+    monkeypatch.setattr(bid_actions, "send_user_topic_message", _capture_send)
+
+    await bid_actions._notify_outbid(
+        _BotStub(),
+        outbid_user_tg_id=10,
+        actor_tg_id=20,
+        auction_id=UUID("12345678-1234-5678-1234-567812345678"),
+        post_url="https://t.me/example/10",
+    )
+
+    assert sent_calls == []
+
+
+@pytest.mark.asyncio
+async def test_notify_outbid_sends_message_when_debounce_allows(monkeypatch) -> None:
+    sent_calls: list[dict[str, object]] = []
+
+    async def _allow_debounce(_auction_id: UUID, _tg_user_id: int) -> bool:
+        return True
+
+    async def _capture_send(*_args, **kwargs):
+        sent_calls.append(kwargs)
+        return True
+
+    monkeypatch.setattr(bid_actions, "acquire_outbid_notification_debounce", _allow_debounce)
+    monkeypatch.setattr(bid_actions, "send_user_topic_message", _capture_send)
+
+    auction_id = UUID("12345678-1234-5678-1234-567812345678")
+    await bid_actions._notify_outbid(
+        _BotStub(),
+        outbid_user_tg_id=10,
+        actor_tg_id=20,
+        auction_id=auction_id,
+        post_url="https://t.me/example/10",
+    )
+
+    assert len(sent_calls) == 1
+    assert sent_calls[0]["notification_event"] == NotificationEventType.AUCTION_OUTBID
+    assert sent_calls[0]["auction_id"] == auction_id


### PR DESCRIPTION
## Summary
- add per-user/per-auction outbid debounce gate in Redis and apply it before sending outbid DM notifications
- introduce configurable `outbid_notification_debounce_seconds` setting (defaults to 60s) in app settings and defaults config
- add targeted tests for debounce gate semantics and outbid notification handler behavior
- sync planning status to Sprint 44 as active sprint

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests/test_anti_fool_service.py tests/test_bid_actions_outbid_notifications.py tests/test_bid_actions_alerts.py`
- `.venv/bin/python -m pytest -q tests`
- `docker compose run --rm --no-deps -v /home/n501/VibeCoding/LiteAuction:/app bot sh -lc "pip install --no-cache-dir pytest pytest-asyncio >/tmp/pip-install.log && RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test python -m pytest -q tests/integration"`

## Rollout Notes
- No migration required.
- Set `OUTBID_NOTIFICATION_DEBOUNCE_SECONDS` via env/config if non-default behavior is desired.
- Finish/win/mod/support/points notifications are unaffected; only outbid DM events are throttled.

## Rollback Notes
- Roll back bot image or set `OUTBID_NOTIFICATION_DEBOUNCE_SECONDS=0` to disable debounce immediately.

Closes #142