### PR TITLE
[Sprint 44][S44-004] Add notification priority model and delivery rules

### DIFF
--- a/docs/release/sprint-44-notification-priority-model.md
+++ b/docs/release/sprint-44-notification-priority-model.md
@@ -1,0 +1,44 @@
+# Sprint 44 Notification Priority Model
+
+## Goal
+
+Define stable notification priority tiers and delivery rules so anti-noise features (debounce, digest, quiet hours) use one shared policy contract.
+
+## Event Priority Mapping
+
+| Event type | Priority tier | Rationale |
+|---|---|---|
+| `auction_win` | `critical` | Winning outcome must be delivered immediately. |
+| `auction_finish` | `high` | Auction closure for sellers is time-sensitive. |
+| `auction_mod_action` | `high` | Moderation actions should not be delayed/suppressed by anti-noise controls. |
+| `support` | `high` | Support and appeals updates are operationally important. |
+| `auction_outbid` | `normal` | High-frequency candidate, safe for anti-noise controls. |
+| `points` | `low` | Informational updates, suitable for aggregation/deferral. |
+
+## Tier Delivery Rules
+
+- `critical` / `high`:
+  - `debounce_enabled = false`
+  - `digest_enabled = false`
+  - `defer_during_quiet_hours = false`
+- `normal` / `low`:
+  - `debounce_enabled = true`
+  - `digest_enabled = true`
+  - `defer_during_quiet_hours = true`
+
+## Current Enforcement
+
+- Outbid DM notifications check tier policy before applying Redis debounce gate.
+- If policy disables debounce for an event, debounce key acquisition is skipped.
+
+## Maintainer Notes
+
+- Source of truth lives in `app/services/notification_policy_service.py`:
+  - `NotificationPriorityTier`
+  - `NotificationDeliveryPolicy`
+  - `notification_priority_tier(...)`
+  - `notification_delivery_policy(...)`
+- Feature-specific code should call policy helpers instead of duplicating tier logic:
+  - `should_apply_notification_debounce(...)`
+  - `should_include_notification_in_digest(...)`
+  - `should_defer_notification_during_quiet_hours(...)`

--- a/tests/test_bid_actions_outbid_notifications.py
+++ b/tests/test_bid_actions_outbid_notifications.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from typing import cast
 from uuid import UUID
 
 import pytest
+from aiogram import Bot
 
 from app.bot.handlers import bid_actions
 from app.services.notification_policy_service import NotificationEventType
@@ -27,7 +29,7 @@ async def test_notify_outbid_skips_message_when_debounce_denies(monkeypatch) -> 
     monkeypatch.setattr(bid_actions, "send_user_topic_message", _capture_send)
 
     await bid_actions._notify_outbid(
-        _BotStub(),
+        cast(Bot, _BotStub()),
         outbid_user_tg_id=10,
         actor_tg_id=20,
         auction_id=UUID("12345678-1234-5678-1234-567812345678"),
@@ -53,7 +55,7 @@ async def test_notify_outbid_sends_message_when_debounce_allows(monkeypatch) -> 
 
     auction_id = UUID("12345678-1234-5678-1234-567812345678")
     await bid_actions._notify_outbid(
-        _BotStub(),
+        cast(Bot, _BotStub()),
         outbid_user_tg_id=10,
         actor_tg_id=20,
         auction_id=auction_id,
@@ -63,3 +65,32 @@ async def test_notify_outbid_sends_message_when_debounce_allows(monkeypatch) -> 
     assert len(sent_calls) == 1
     assert sent_calls[0]["notification_event"] == NotificationEventType.AUCTION_OUTBID
     assert sent_calls[0]["auction_id"] == auction_id
+
+
+@pytest.mark.asyncio
+async def test_notify_outbid_skips_debounce_gate_when_policy_disables_it(monkeypatch) -> None:
+    sent_calls: list[dict[str, object]] = []
+
+    def _disable_debounce_policy(_event_type: NotificationEventType) -> bool:
+        return False
+
+    async def _raise_if_called(_auction_id: UUID, _tg_user_id: int) -> bool:
+        raise AssertionError("debounce gate should not run when policy disables it")
+
+    async def _capture_send(*_args, **kwargs):
+        sent_calls.append(kwargs)
+        return True
+
+    monkeypatch.setattr(bid_actions, "should_apply_notification_debounce", _disable_debounce_policy)
+    monkeypatch.setattr(bid_actions, "acquire_outbid_notification_debounce", _raise_if_called)
+    monkeypatch.setattr(bid_actions, "send_user_topic_message", _capture_send)
+
+    await bid_actions._notify_outbid(
+        cast(Bot, _BotStub()),
+        outbid_user_tg_id=10,
+        actor_tg_id=20,
+        auction_id=UUID("12345678-1234-5678-1234-567812345678"),
+        post_url="https://t.me/example/10",
+    )
+
+    assert len(sent_calls) == 1


### PR DESCRIPTION
## Summary
- add explicit notification priority tiers (`critical/high/normal/low`) and map all notification event types to tiers in policy service
- introduce shared `NotificationDeliveryPolicy` helpers for debounce, digest, and quiet-hours behavior so anti-noise features use one source of truth
- enforce tier-aware behavior in outbid notifications by checking policy before applying debounce gate
- document tier mapping and delivery rules for maintainers in Sprint 44 policy doc

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests/test_notification_policy_service.py tests/test_bid_actions_outbid_notifications.py tests/test_anti_fool_service.py`
- `.venv/bin/python -m pytest -q tests`
- `docker compose run --rm --no-deps -v /home/n501/VibeCoding/LiteAuction:/app bot sh -lc "pip install --no-cache-dir pytest pytest-asyncio >/tmp/pip-install.log && RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test python -m pytest -q tests/integration"`

## Rollout Notes
- No migration required.
- This change introduces policy helpers and one integration point (outbid debounce gate).
- Future digest/quiet-hours implementations should call the new policy helpers instead of hardcoding event checks.

## Rollback Notes
- Roll back bot image to remove priority policy helpers and restore previous outbid debounce check path.

Closes #145