### PR TITLE
[Sprint 44][S44-005] Track anti-noise effectiveness metrics

### DIFF
--- a/app/services/notification_metrics_service.py
+++ b/app/services/notification_metrics_service.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import logging
+import re
+from enum import StrEnum
+
+from app.infra.redis_client import redis_client
+from app.services.notification_policy_service import NotificationEventType
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationMetricKind(StrEnum):
+    SENT = "sent"
+    SUPPRESSED = "suppressed"
+    AGGREGATED = "aggregated"
+
+
+def _normalize_reason(reason: str) -> str:
+    lowered = reason.strip().lower()
+    if not lowered:
+        return "unknown"
+    normalized = re.sub(r"[^a-z0-9_:-]+", "_", lowered)
+    return normalized.strip("_") or "unknown"
+
+
+def _metric_key(*, kind: NotificationMetricKind, event_type: NotificationEventType, reason: str) -> str:
+    return f"notif:metrics:{kind.value}:{event_type.value}:{reason}"
+
+
+async def _record_metric(
+    *,
+    kind: NotificationMetricKind,
+    event_type: NotificationEventType,
+    reason: str,
+    count: int = 1,
+) -> int | None:
+    safe_count = max(int(count), 1)
+    normalized_reason = _normalize_reason(reason)
+    key = _metric_key(kind=kind, event_type=event_type, reason=normalized_reason)
+
+    try:
+        total = await redis_client.incrby(key, safe_count)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "notification_metric_failed kind=%s event=%s reason=%s count=%s error=%s",
+            kind.value,
+            event_type.value,
+            normalized_reason,
+            safe_count,
+            exc,
+        )
+        return None
+
+    logger.info(
+        "notification_metric kind=%s event=%s reason=%s count=%s total=%s",
+        kind.value,
+        event_type.value,
+        normalized_reason,
+        safe_count,
+        total,
+    )
+    return int(total)
+
+
+async def record_notification_sent(
+    *,
+    event_type: NotificationEventType,
+    reason: str = "delivered",
+) -> int | None:
+    return await _record_metric(
+        kind=NotificationMetricKind.SENT,
+        event_type=event_type,
+        reason=reason,
+    )
+
+
+async def record_notification_suppressed(
+    *,
+    event_type: NotificationEventType,
+    reason: str,
+) -> int | None:
+    return await _record_metric(
+        kind=NotificationMetricKind.SUPPRESSED,
+        event_type=event_type,
+        reason=reason,
+    )
+
+
+async def record_notification_aggregated(
+    *,
+    event_type: NotificationEventType,
+    reason: str,
+    count: int = 1,
+) -> int | None:
+    return await _record_metric(
+        kind=NotificationMetricKind.AGGREGATED,
+        event_type=event_type,
+        reason=reason,
+        count=count,
+    )

--- a/docs/release/sprint-44-notification-metrics.md
+++ b/docs/release/sprint-44-notification-metrics.md
@@ -1,0 +1,32 @@
+# Sprint 44 Notification Metrics
+
+## Goal
+
+Add lightweight counters and structured log events for notification delivery outcomes so anti-noise impact can be observed directly from bot logs.
+
+## Metric Dimensions
+
+- `kind`: `sent`, `suppressed`, `aggregated`
+- `event`: notification event type (`auction_outbid`, `auction_finish`, `auction_win`, `auction_mod_action`, `points`, `support`)
+- `reason`: normalized reason code (`delivered`, `policy_blocked`, `bad_request`, `debounce_gate`, etc.)
+
+Redis key format:
+
+`notif:metrics:<kind>:<event>:<reason>`
+
+## Emission Points
+
+- `send_user_topic_message(...)`
+  - `sent`: when message is delivered
+  - `suppressed`: when blocked by policy or delivery fails (`bad_request`, `forbidden`, `telegram_api_error`, `unexpected_error`)
+- outbid debounce gate
+  - `suppressed` + `aggregated` with reason `debounce_gate` when duplicate outbid notification is throttled
+
+## Log Format
+
+Every increment logs one structured line:
+
+- success: `notification_metric kind=<...> event=<...> reason=<...> count=<...> total=<...>`
+- failure: `notification_metric_failed kind=<...> event=<...> reason=<...> count=<...> error=<...>`
+
+This allows operators to inspect notification outcomes using plain log search without extra metrics tooling.

--- a/tests/test_notification_metrics_service.py
+++ b/tests/test_notification_metrics_service.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app.services import notification_metrics_service
+from app.services.notification_policy_service import NotificationEventType
+
+
+class _RedisIncrStub:
+    def __init__(self, *, total: int = 1, fail: bool = False) -> None:
+        self.total = total
+        self.fail = fail
+        self.calls: list[tuple[str, int]] = []
+
+    async def incrby(self, key: str, count: int) -> int:
+        self.calls.append((key, count))
+        if self.fail:
+            raise RuntimeError("boom")
+        return self.total
+
+
+@pytest.mark.asyncio
+async def test_record_notification_sent_increments_counter_with_normalized_reason(monkeypatch) -> None:
+    redis_stub = _RedisIncrStub(total=7)
+    monkeypatch.setattr(notification_metrics_service, "redis_client", redis_stub)
+
+    total = await notification_metrics_service.record_notification_sent(
+        event_type=NotificationEventType.AUCTION_OUTBID,
+        reason="Delivered OK",
+    )
+
+    assert total == 7
+    assert redis_stub.calls == [
+        ("notif:metrics:sent:auction_outbid:delivered_ok", 1),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_record_notification_aggregated_uses_count(monkeypatch) -> None:
+    redis_stub = _RedisIncrStub(total=9)
+    monkeypatch.setattr(notification_metrics_service, "redis_client", redis_stub)
+
+    total = await notification_metrics_service.record_notification_aggregated(
+        event_type=NotificationEventType.AUCTION_OUTBID,
+        reason="debounce_gate",
+        count=3,
+    )
+
+    assert total == 9
+    assert redis_stub.calls == [
+        ("notif:metrics:aggregated:auction_outbid:debounce_gate", 3),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_record_notification_metric_logs_warning_on_redis_failure(
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    redis_stub = _RedisIncrStub(fail=True)
+    monkeypatch.setattr(notification_metrics_service, "redis_client", redis_stub)
+    caplog.set_level(logging.WARNING)
+
+    total = await notification_metrics_service.record_notification_suppressed(
+        event_type=NotificationEventType.SUPPORT,
+        reason="policy blocked",
+    )
+
+    assert total is None
+    assert "notification_metric_failed" in caplog.text
+    assert "reason=policy_blocked" in caplog.text

--- a/tests/test_private_topics_notification_metrics.py
+++ b/tests/test_private_topics_notification_metrics.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from aiogram import Bot
+from aiogram.exceptions import TelegramBadRequest
+from aiogram.methods import SendMessage
+
+from app.services import private_topics_service
+from app.services.notification_policy_service import NotificationEventType
+
+
+class _SessionCtx:
+    async def __aenter__(self):  # noqa: ANN204
+        return object()
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:  # noqa: ANN001, ANN204
+        return False
+
+
+@pytest.mark.asyncio
+async def test_send_user_topic_message_records_policy_suppression_metric(monkeypatch) -> None:
+    monkeypatch.setattr(private_topics_service.settings, "private_topics_enabled", False)
+    monkeypatch.setattr(private_topics_service, "SessionFactory", lambda: _SessionCtx())
+
+    async def _blocked(*_args, **_kwargs) -> bool:
+        return False
+
+    sent_metrics: list[tuple[str, str]] = []
+    suppressed_metrics: list[tuple[str, str]] = []
+
+    async def _record_sent(*, event_type: NotificationEventType, reason: str = "delivered") -> None:
+        sent_metrics.append((event_type.value, reason))
+
+    async def _record_suppressed(*, event_type: NotificationEventType, reason: str) -> None:
+        suppressed_metrics.append((event_type.value, reason))
+
+    class _BotStub:
+        async def send_message(self, **_kwargs):  # noqa: ANN201
+            raise AssertionError("send_message should not be called for blocked policy")
+
+    monkeypatch.setattr(private_topics_service, "is_notification_allowed", _blocked)
+    monkeypatch.setattr(private_topics_service, "record_notification_sent", _record_sent)
+    monkeypatch.setattr(private_topics_service, "record_notification_suppressed", _record_suppressed)
+
+    delivered = await private_topics_service.send_user_topic_message(
+        cast(Bot, _BotStub()),
+        tg_user_id=321,
+        purpose=private_topics_service.PrivateTopicPurpose.AUCTIONS,
+        text="hello",
+        notification_event=NotificationEventType.AUCTION_OUTBID,
+    )
+
+    assert delivered is False
+    assert sent_metrics == []
+    assert suppressed_metrics == [(NotificationEventType.AUCTION_OUTBID.value, "policy_blocked")]
+
+
+@pytest.mark.asyncio
+async def test_send_user_topic_message_records_sent_metric_on_delivery(monkeypatch) -> None:
+    monkeypatch.setattr(private_topics_service.settings, "private_topics_enabled", False)
+    monkeypatch.setattr(private_topics_service, "SessionFactory", lambda: _SessionCtx())
+
+    async def _allowed(*_args, **_kwargs) -> bool:
+        return True
+
+    sent_metrics: list[tuple[str, str]] = []
+
+    async def _record_sent(*, event_type: NotificationEventType, reason: str = "delivered") -> None:
+        sent_metrics.append((event_type.value, reason))
+
+    async def _record_suppressed(*, event_type: NotificationEventType, reason: str) -> None:
+        raise AssertionError(f"suppressed metric should not be emitted: {event_type.value}:{reason}")
+
+    class _BotStub:
+        async def send_message(self, **kwargs):  # noqa: ANN201
+            return SimpleNamespace(chat=SimpleNamespace(id=kwargs["chat_id"]), message_id=1)
+
+    monkeypatch.setattr(private_topics_service, "is_notification_allowed", _allowed)
+    monkeypatch.setattr(private_topics_service, "record_notification_sent", _record_sent)
+    monkeypatch.setattr(private_topics_service, "record_notification_suppressed", _record_suppressed)
+
+    delivered = await private_topics_service.send_user_topic_message(
+        cast(Bot, _BotStub()),
+        tg_user_id=321,
+        purpose=private_topics_service.PrivateTopicPurpose.AUCTIONS,
+        text="hello",
+        notification_event=NotificationEventType.AUCTION_OUTBID,
+    )
+
+    assert delivered is True
+    assert sent_metrics == [(NotificationEventType.AUCTION_OUTBID.value, "delivered")]
+
+
+@pytest.mark.asyncio
+async def test_send_user_topic_message_records_bad_request_suppression_metric(monkeypatch) -> None:
+    monkeypatch.setattr(private_topics_service.settings, "private_topics_enabled", False)
+    monkeypatch.setattr(private_topics_service, "SessionFactory", lambda: _SessionCtx())
+
+    async def _allowed(*_args, **_kwargs) -> bool:
+        return True
+
+    suppressed_metrics: list[tuple[str, str]] = []
+
+    async def _record_sent(*, event_type: NotificationEventType, reason: str = "delivered") -> None:
+        raise AssertionError(f"sent metric should not be emitted: {event_type.value}:{reason}")
+
+    async def _record_suppressed(*, event_type: NotificationEventType, reason: str) -> None:
+        suppressed_metrics.append((event_type.value, reason))
+
+    class _BotStub:
+        async def send_message(self, **kwargs):  # noqa: ANN201
+            raise TelegramBadRequest(
+                method=SendMessage(chat_id=kwargs["chat_id"], text=kwargs["text"]),
+                message="Bad Request: chat not found",
+            )
+
+    monkeypatch.setattr(private_topics_service, "is_notification_allowed", _allowed)
+    monkeypatch.setattr(private_topics_service, "record_notification_sent", _record_sent)
+    monkeypatch.setattr(private_topics_service, "record_notification_suppressed", _record_suppressed)
+
+    delivered = await private_topics_service.send_user_topic_message(
+        cast(Bot, _BotStub()),
+        tg_user_id=321,
+        purpose=private_topics_service.PrivateTopicPurpose.AUCTIONS,
+        text="hello",
+        notification_event=NotificationEventType.AUCTION_OUTBID,
+    )
+
+    assert delivered is False
+    assert suppressed_metrics == [(NotificationEventType.AUCTION_OUTBID.value, "bad_request")]


### PR DESCRIPTION
## Summary
- add notification metrics service with Redis-backed counters for `sent`, `suppressed`, and `aggregated` outcomes
- emit structured metric logs with reason codes so operators can inspect anti-noise behavior directly from logs
- instrument direct notification delivery flow with suppression reasons (`policy_blocked`, `bad_request`, `forbidden`, `telegram_api_error`, `unexpected_error`)
- instrument outbid debounce suppression to increment both `suppressed` and `aggregated` counters with reason `debounce_gate`
- add maintainer-facing metrics doc for key format, reason dimensions, and log format

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests/test_notification_metrics_service.py tests/test_private_topics_notification_metrics.py tests/test_bid_actions_outbid_notifications.py`
- `.venv/bin/python -m pytest -q tests`
- `docker compose run --rm --no-deps -v /home/n501/VibeCoding/LiteAuction:/app bot sh -lc "pip install --no-cache-dir pytest pytest-asyncio >/tmp/pip-install.log && RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test python -m pytest -q tests/integration"`

## Rollout Notes
- No migration required.
- Metrics keys are additive in Redis and can be purged safely if needed.

## Rollback Notes
- Roll back bot image to disable metrics emission paths.

Closes #146