### PR TITLE
[Sprint 44][S44-002] Add notification batching and digest mode

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -92,6 +92,7 @@ class Settings(BaseSettings):
     anti_sniper_max_extensions: int = 3
     bid_cooldown_seconds: int = 2
     outbid_notification_debounce_seconds: int = 60
+    outbid_notification_digest_window_seconds: int = 180
     duplicate_bid_window_seconds: int = 15
     confirmation_ttl_seconds: int = 5
     complaint_cooldown_seconds: int = 60

--- a/app/services/notification_digest_service.py
+++ b/app/services/notification_digest_service.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+
+from app.config import settings
+from app.infra.redis_client import redis_client
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class OutbidDigestDecision:
+    suppressed_count: int
+    window_seconds: int
+    should_emit_digest: bool
+
+
+def _outbid_digest_count_key(*, tg_user_id: int, auction_id: uuid.UUID) -> str:
+    return f"notif:digest:outbid:{tg_user_id}:{auction_id}:count"
+
+
+def _outbid_digest_emit_key(*, tg_user_id: int, auction_id: uuid.UUID) -> str:
+    return f"notif:digest:outbid:{tg_user_id}:{auction_id}:emit"
+
+
+async def register_outbid_notification_suppression(
+    *,
+    tg_user_id: int,
+    auction_id: uuid.UUID,
+) -> OutbidDigestDecision:
+    window_seconds = max(settings.outbid_notification_digest_window_seconds, 1)
+    count_key = _outbid_digest_count_key(tg_user_id=tg_user_id, auction_id=auction_id)
+    emit_key = _outbid_digest_emit_key(tg_user_id=tg_user_id, auction_id=auction_id)
+
+    try:
+        suppressed_count = int(await redis_client.incr(count_key))
+        if suppressed_count == 1:
+            await redis_client.expire(count_key, window_seconds)
+
+        should_emit_digest = False
+        if suppressed_count >= 2:
+            should_emit_digest = bool(
+                await redis_client.set(emit_key, "1", ex=window_seconds, nx=True)
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "notification_digest_register_failed tg_user_id=%s auction_id=%s error=%s",
+            tg_user_id,
+            auction_id,
+            exc,
+        )
+        return OutbidDigestDecision(
+            suppressed_count=0,
+            window_seconds=window_seconds,
+            should_emit_digest=False,
+        )
+
+    return OutbidDigestDecision(
+        suppressed_count=suppressed_count,
+        window_seconds=window_seconds,
+        should_emit_digest=should_emit_digest,
+    )

--- a/config/defaults.toml
+++ b/config/defaults.toml
@@ -59,6 +59,7 @@ anti_sniper_extend_minutes = 3
 anti_sniper_max_extensions = 3
 bid_cooldown_seconds = 2
 outbid_notification_debounce_seconds = 60
+outbid_notification_digest_window_seconds = 180
 duplicate_bid_window_seconds = 15
 confirmation_ttl_seconds = 5
 complaint_cooldown_seconds = 60

--- a/docs/release/sprint-44-notification-digest-mode.md
+++ b/docs/release/sprint-44-notification-digest-mode.md
@@ -1,0 +1,33 @@
+# Sprint 44 Notification Digest Mode
+
+## Goal
+
+Reduce repetitive direct messages by grouping repeated outbid events into a compact digest message.
+
+## Behavior
+
+- Normal outbid notifications still use the regular immediate message path.
+- When outbid notifications are suppressed by debounce in the same window:
+  - suppressed events are accumulated per `(tg_user_id, auction_id)`
+  - once repeated suppressions are detected, the user receives one digest message for that window
+
+Digest example:
+
+`Дайджест по лоту #abcd1234: за 3 мин ставку перебивали 4 раз.`
+
+## Config
+
+- `outbid_notification_digest_window_seconds` (default: `180`)
+  - controls accumulation/emit window for outbid digest grouping
+
+## Actionability
+
+- Digest messages include the same open-auction action link (when available), so users can jump directly to the post.
+
+## Notes for Maintainers
+
+- Digest state is Redis-backed:
+  - count key: `notif:digest:outbid:<tg_user_id>:<auction_id>:count`
+  - emit lock key: `notif:digest:outbid:<tg_user_id>:<auction_id>:emit`
+- Delivery policy remains tier-aware:
+  - digest applies only if `should_include_notification_in_digest(event_type)` is `true`.

--- a/tests/test_bid_actions_outbid_notifications.py
+++ b/tests/test_bid_actions_outbid_notifications.py
@@ -7,6 +7,7 @@ import pytest
 from aiogram import Bot
 
 from app.bot.handlers import bid_actions
+from app.services.notification_digest_service import OutbidDigestDecision
 from app.services.notification_policy_service import NotificationEventType
 
 
@@ -33,10 +34,14 @@ async def test_notify_outbid_skips_message_when_debounce_denies(monkeypatch) -> 
     async def _capture_aggregated(*, event_type: NotificationEventType, reason: str, count: int = 1) -> None:
         aggregated_metrics.append((event_type.value, reason))
 
+    async def _digest_no_emit(*, tg_user_id: int, auction_id: UUID) -> OutbidDigestDecision:  # noqa: ARG001
+        return OutbidDigestDecision(suppressed_count=1, window_seconds=180, should_emit_digest=False)
+
     monkeypatch.setattr(bid_actions, "acquire_outbid_notification_debounce", _deny_debounce)
     monkeypatch.setattr(bid_actions, "send_user_topic_message", _capture_send)
     monkeypatch.setattr(bid_actions, "record_notification_suppressed", _capture_suppressed)
     monkeypatch.setattr(bid_actions, "record_notification_aggregated", _capture_aggregated)
+    monkeypatch.setattr(bid_actions, "register_outbid_notification_suppression", _digest_no_emit)
 
     await bid_actions._notify_outbid(
         cast(Bot, _BotStub()),
@@ -70,10 +75,14 @@ async def test_notify_outbid_sends_message_when_debounce_allows(monkeypatch) -> 
     ) -> None:
         return None
 
+    async def _raise_if_called(*, tg_user_id: int, auction_id: UUID) -> OutbidDigestDecision:  # noqa: ARG001
+        raise AssertionError("digest register should not run when debounce allows")
+
     monkeypatch.setattr(bid_actions, "acquire_outbid_notification_debounce", _allow_debounce)
     monkeypatch.setattr(bid_actions, "send_user_topic_message", _capture_send)
     monkeypatch.setattr(bid_actions, "record_notification_suppressed", _noop_suppressed)
     monkeypatch.setattr(bid_actions, "record_notification_aggregated", _noop_aggregated)
+    monkeypatch.setattr(bid_actions, "register_outbid_notification_suppression", _raise_if_called)
 
     auction_id = UUID("12345678-1234-5678-1234-567812345678")
     await bid_actions._notify_outbid(
@@ -111,8 +120,51 @@ async def test_notify_outbid_skips_debounce_gate_when_policy_disables_it(monkeyp
     ) -> None:
         return None
 
+    async def _raise_if_called(*, tg_user_id: int, auction_id: UUID) -> OutbidDigestDecision:  # noqa: ARG001
+        raise AssertionError("digest register should not run when suppression does not happen")
+
     monkeypatch.setattr(bid_actions, "should_apply_notification_debounce", _disable_debounce_policy)
     monkeypatch.setattr(bid_actions, "acquire_outbid_notification_debounce", _raise_if_called)
+    monkeypatch.setattr(bid_actions, "send_user_topic_message", _capture_send)
+    monkeypatch.setattr(bid_actions, "record_notification_suppressed", _noop_suppressed)
+    monkeypatch.setattr(bid_actions, "record_notification_aggregated", _noop_aggregated)
+    monkeypatch.setattr(bid_actions, "register_outbid_notification_suppression", _raise_if_called)
+
+    await bid_actions._notify_outbid(
+        cast(Bot, _BotStub()),
+        outbid_user_tg_id=10,
+        actor_tg_id=20,
+        auction_id=UUID("12345678-1234-5678-1234-567812345678"),
+        post_url="https://t.me/example/10",
+    )
+
+    assert len(sent_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_notify_outbid_sends_digest_message_when_suppression_threshold_reached(monkeypatch) -> None:
+    sent_calls: list[dict[str, object]] = []
+
+    async def _deny_debounce(_auction_id: UUID, _tg_user_id: int) -> bool:
+        return False
+
+    async def _digest_emit(*, tg_user_id: int, auction_id: UUID) -> OutbidDigestDecision:  # noqa: ARG001
+        return OutbidDigestDecision(suppressed_count=3, window_seconds=180, should_emit_digest=True)
+
+    async def _capture_send(*_args, **kwargs):
+        sent_calls.append(kwargs)
+        return True
+
+    async def _noop_suppressed(*, event_type: NotificationEventType, reason: str) -> None:  # noqa: ARG001
+        return None
+
+    async def _noop_aggregated(
+        *, event_type: NotificationEventType, reason: str, count: int = 1  # noqa: ARG001
+    ) -> None:
+        return None
+
+    monkeypatch.setattr(bid_actions, "acquire_outbid_notification_debounce", _deny_debounce)
+    monkeypatch.setattr(bid_actions, "register_outbid_notification_suppression", _digest_emit)
     monkeypatch.setattr(bid_actions, "send_user_topic_message", _capture_send)
     monkeypatch.setattr(bid_actions, "record_notification_suppressed", _noop_suppressed)
     monkeypatch.setattr(bid_actions, "record_notification_aggregated", _noop_aggregated)
@@ -126,3 +178,6 @@ async def test_notify_outbid_skips_debounce_gate_when_policy_disables_it(monkeyp
     )
 
     assert len(sent_calls) == 1
+    assert "Дайджест по лоту #12345678" in str(sent_calls[0]["text"])
+    assert "перебивали 3 раз" in str(sent_calls[0]["text"])
+    assert sent_calls[0]["reply_markup"] is not None

--- a/tests/test_notification_digest_service.py
+++ b/tests/test_notification_digest_service.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from app.services import notification_digest_service
+
+
+class _RedisDigestStub:
+    def __init__(self) -> None:
+        self._counts: dict[str, int] = {}
+        self._locks: set[str] = set()
+        self.expire_calls: list[tuple[str, int]] = []
+
+    async def incr(self, key: str) -> int:
+        current = self._counts.get(key, 0) + 1
+        self._counts[key] = current
+        return current
+
+    async def expire(self, key: str, seconds: int) -> bool:
+        self.expire_calls.append((key, seconds))
+        return True
+
+    async def set(self, key: str, value: str, *, ex: int, nx: bool) -> bool | None:  # noqa: ARG002
+        if nx and key in self._locks:
+            return None
+        self._locks.add(key)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_register_outbid_suppression_first_event_does_not_emit(monkeypatch) -> None:
+    redis_stub = _RedisDigestStub()
+    monkeypatch.setattr(notification_digest_service, "redis_client", redis_stub)
+    monkeypatch.setattr(notification_digest_service.settings, "outbid_notification_digest_window_seconds", 180)
+
+    decision = await notification_digest_service.register_outbid_notification_suppression(
+        tg_user_id=42,
+        auction_id=UUID("12345678-1234-5678-1234-567812345678"),
+    )
+
+    assert decision.suppressed_count == 1
+    assert decision.window_seconds == 180
+    assert decision.should_emit_digest is False
+    assert redis_stub.expire_calls == [
+        ("notif:digest:outbid:42:12345678-1234-5678-1234-567812345678:count", 180)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_register_outbid_suppression_second_event_emits_digest_once(monkeypatch) -> None:
+    redis_stub = _RedisDigestStub()
+    monkeypatch.setattr(notification_digest_service, "redis_client", redis_stub)
+    monkeypatch.setattr(notification_digest_service.settings, "outbid_notification_digest_window_seconds", 120)
+
+    first = await notification_digest_service.register_outbid_notification_suppression(
+        tg_user_id=7,
+        auction_id=UUID("12345678-1234-5678-1234-567812345678"),
+    )
+    second = await notification_digest_service.register_outbid_notification_suppression(
+        tg_user_id=7,
+        auction_id=UUID("12345678-1234-5678-1234-567812345678"),
+    )
+    third = await notification_digest_service.register_outbid_notification_suppression(
+        tg_user_id=7,
+        auction_id=UUID("12345678-1234-5678-1234-567812345678"),
+    )
+
+    assert first.should_emit_digest is False
+    assert second.should_emit_digest is True
+    assert third.should_emit_digest is False


### PR DESCRIPTION
## Summary
- add Redis-backed outbid digest batching state so repeated suppressed outbid events are grouped into one compact digest message per user+auction window
- make digest window configurable via `outbid_notification_digest_window_seconds` (default `180`)
- keep digest actionable by attaching open-auction link keyboard when a post URL is available
- integrate digest flow with existing tier-aware policy (`should_include_notification_in_digest`) and keep existing debounce/metrics behavior
- add maintainer docs for digest keys, behavior, and policy integration

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests/test_notification_digest_service.py tests/test_bid_actions_outbid_notifications.py tests/test_notification_policy_service.py`
- `.venv/bin/python -m pytest -q tests`
- `docker compose run --rm --no-deps -v /home/n501/VibeCoding/LiteAuction:/app bot sh -lc "pip install --no-cache-dir pytest pytest-asyncio >/tmp/pip-install.log && RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test python -m pytest -q tests/integration"`

## Rollout Notes
- No DB migration required.
- Tune `outbid_notification_digest_window_seconds` if product wants shorter/longer digest grouping.

## Rollback Notes
- Roll back bot image or set `outbid_notification_digest_window_seconds` to a minimal window and disable outbid debounce if digest behavior needs immediate rollback.

Closes #143