### PR TITLE
[Sprint 44][S44-003] Introduce quiet hours for non-critical notifications

### DIFF
--- a/alembic/versions/0034_notification_quiet_hours.py
+++ b/alembic/versions/0034_notification_quiet_hours.py
@@ -1,0 +1,58 @@
+"""add notification quiet hours columns
+
+Revision ID: 0034_notif_quiet_hours
+Revises: 0033_user_auc_notif_snooze
+Create Date: 2026-02-17 20:35:00
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0034_notif_quiet_hours"
+down_revision: str | None = "0033_user_auc_notif_snooze"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_notification_preferences",
+        sa.Column("quiet_hours_enabled", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+    op.add_column(
+        "user_notification_preferences",
+        sa.Column("quiet_hours_start_hour", sa.SmallInteger(), nullable=False, server_default=sa.text("23")),
+    )
+    op.add_column(
+        "user_notification_preferences",
+        sa.Column("quiet_hours_end_hour", sa.SmallInteger(), nullable=False, server_default=sa.text("8")),
+    )
+    op.create_check_constraint(
+        "ck_user_notification_preferences_quiet_start_hour",
+        "user_notification_preferences",
+        "quiet_hours_start_hour >= 0 AND quiet_hours_start_hour <= 23",
+    )
+    op.create_check_constraint(
+        "ck_user_notification_preferences_quiet_end_hour",
+        "user_notification_preferences",
+        "quiet_hours_end_hour >= 0 AND quiet_hours_end_hour <= 23",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_user_notification_preferences_quiet_end_hour",
+        "user_notification_preferences",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_user_notification_preferences_quiet_start_hour",
+        "user_notification_preferences",
+        type_="check",
+    )
+    op.drop_column("user_notification_preferences", "quiet_hours_end_hour")
+    op.drop_column("user_notification_preferences", "quiet_hours_start_hour")
+    op.drop_column("user_notification_preferences", "quiet_hours_enabled")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -60,6 +60,14 @@ class UserNotificationPreference(Base, TimestampMixin):
             "preset IN ('recommended', 'important', 'all', 'custom')",
             name="ck_user_notification_preferences_preset",
         ),
+        CheckConstraint(
+            "quiet_hours_start_hour >= 0 AND quiet_hours_start_hour <= 23",
+            name="ck_user_notification_preferences_quiet_start_hour",
+        ),
+        CheckConstraint(
+            "quiet_hours_end_hour >= 0 AND quiet_hours_end_hour <= 23",
+            name="ck_user_notification_preferences_quiet_end_hour",
+        ),
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
@@ -75,6 +83,21 @@ class UserNotificationPreference(Base, TimestampMixin):
     )
     points_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
     support_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
+    quiet_hours_enabled: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=text("false"),
+    )
+    quiet_hours_start_hour: Mapped[int] = mapped_column(
+        SmallInteger,
+        nullable=False,
+        server_default=text("23"),
+    )
+    quiet_hours_end_hour: Mapped[int] = mapped_column(
+        SmallInteger,
+        nullable=False,
+        server_default=text("8"),
+    )
     configured_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 

--- a/app/services/notification_quiet_hours_service.py
+++ b/app/services/notification_quiet_hours_service.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import logging
+
+from app.infra.redis_client import redis_client
+from app.services.notification_policy_service import NotificationEventType
+
+logger = logging.getLogger(__name__)
+
+
+def _quiet_hours_deferred_key(*, tg_user_id: int, event_type: NotificationEventType) -> str:
+    return f"notif:quiet:deferred:{tg_user_id}:{event_type.value}"
+
+
+async def defer_notification_event(
+    *,
+    tg_user_id: int,
+    event_type: NotificationEventType,
+) -> int:
+    key = _quiet_hours_deferred_key(tg_user_id=tg_user_id, event_type=event_type)
+    try:
+        deferred_count = int(await redis_client.incr(key))
+        await redis_client.expire(key, 172800)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "quiet_hours_defer_failed tg_user_id=%s event=%s error=%s",
+            tg_user_id,
+            event_type.value,
+            exc,
+        )
+        return 0
+    return deferred_count
+
+
+async def pop_deferred_notification_count(
+    *,
+    tg_user_id: int,
+    event_type: NotificationEventType,
+) -> int:
+    key = _quiet_hours_deferred_key(tg_user_id=tg_user_id, event_type=event_type)
+    try:
+        value = await redis_client.getdel(key)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "quiet_hours_pop_failed tg_user_id=%s event=%s error=%s",
+            tg_user_id,
+            event_type.value,
+            exc,
+        )
+        return 0
+    if value is None:
+        return 0
+    try:
+        return max(int(value), 0)
+    except (TypeError, ValueError):
+        return 0

--- a/docs/release/sprint-44-quiet-hours.md
+++ b/docs/release/sprint-44-quiet-hours.md
@@ -1,0 +1,36 @@
+# Sprint 44 Quiet Hours
+
+## Goal
+
+Allow users to defer non-critical notifications during configured quiet hours while keeping critical/high-priority events immediate.
+
+## User Controls
+
+Quiet-hours controls are available in `/settings`:
+
+- toggle quiet-hours on/off
+- quick presets:
+  - `23:00-08:00 UTC`
+  - `00:00-07:00 UTC`
+
+## Delivery Behavior
+
+- tier-aware policy is used:
+  - `critical/high` events are delivered immediately
+  - `normal/low` events are deferred during active quiet hours
+- deferred events are counted per user/event type and surfaced on next eligible notification outside quiet hours
+
+## Data Model
+
+`user_notification_preferences` now stores:
+
+- `quiet_hours_enabled` (`bool`)
+- `quiet_hours_start_hour` (`0..23`)
+- `quiet_hours_end_hour` (`0..23`)
+
+Migration: `0034_notif_quiet_hours`.
+
+## Ops Notes
+
+- suppression reason code: `quiet_hours_deferred`
+- deferred-flush aggregation reason code: `quiet_hours_flushed`

--- a/tests/test_notification_quiet_hours_service.py
+++ b/tests/test_notification_quiet_hours_service.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services import notification_quiet_hours_service
+from app.services.notification_policy_service import NotificationEventType
+
+
+class _RedisQuietHoursStub:
+    def __init__(self) -> None:
+        self.values: dict[str, int] = {}
+        self.expire_calls: list[tuple[str, int]] = []
+
+    async def incr(self, key: str) -> int:
+        current = self.values.get(key, 0) + 1
+        self.values[key] = current
+        return current
+
+    async def expire(self, key: str, seconds: int) -> bool:
+        self.expire_calls.append((key, seconds))
+        return True
+
+    async def getdel(self, key: str) -> str | None:
+        value = self.values.pop(key, None)
+        if value is None:
+            return None
+        return str(value)
+
+
+@pytest.mark.asyncio
+async def test_defer_notification_event_increments_and_sets_ttl(monkeypatch) -> None:
+    redis_stub = _RedisQuietHoursStub()
+    monkeypatch.setattr(notification_quiet_hours_service, "redis_client", redis_stub)
+
+    first = await notification_quiet_hours_service.defer_notification_event(
+        tg_user_id=123,
+        event_type=NotificationEventType.POINTS,
+    )
+    second = await notification_quiet_hours_service.defer_notification_event(
+        tg_user_id=123,
+        event_type=NotificationEventType.POINTS,
+    )
+
+    assert first == 1
+    assert second == 2
+    assert redis_stub.expire_calls
+
+
+@pytest.mark.asyncio
+async def test_pop_deferred_notification_count_returns_and_clears(monkeypatch) -> None:
+    redis_stub = _RedisQuietHoursStub()
+    monkeypatch.setattr(notification_quiet_hours_service, "redis_client", redis_stub)
+
+    await notification_quiet_hours_service.defer_notification_event(
+        tg_user_id=999,
+        event_type=NotificationEventType.AUCTION_OUTBID,
+    )
+    await notification_quiet_hours_service.defer_notification_event(
+        tg_user_id=999,
+        event_type=NotificationEventType.AUCTION_OUTBID,
+    )
+
+    count = await notification_quiet_hours_service.pop_deferred_notification_count(
+        tg_user_id=999,
+        event_type=NotificationEventType.AUCTION_OUTBID,
+    )
+    second = await notification_quiet_hours_service.pop_deferred_notification_count(
+        tg_user_id=999,
+        event_type=NotificationEventType.AUCTION_OUTBID,
+    )
+
+    assert count == 2
+    assert second == 0

--- a/tests/test_notification_settings_render.py
+++ b/tests/test_notification_settings_render.py
@@ -28,6 +28,9 @@ def test_render_settings_text_includes_state_markers() -> None:
         auction_mod_actions_enabled=True,
         points_enabled=False,
         support_enabled=True,
+        quiet_hours_enabled=False,
+        quiet_hours_start_hour=23,
+        quiet_hours_end_hour=8,
         configured=True,
     )
 
@@ -36,6 +39,7 @@ def test_render_settings_text_includes_state_markers() -> None:
     assert "Настройки уведомлений" in text
     assert "Глобально: <b>отключены</b>" in text
     assert "Пресет: <b>Только важные</b>" in text
+    assert "Тихие часы:" in text
     assert "Статус первичной настройки: <b>настроены</b>" in text
 
 
@@ -49,6 +53,9 @@ def test_render_settings_text_includes_active_snoozes() -> None:
         auction_mod_actions_enabled=True,
         points_enabled=True,
         support_enabled=True,
+        quiet_hours_enabled=False,
+        quiet_hours_start_hour=23,
+        quiet_hours_end_hour=8,
         configured=True,
     )
     snoozes = [
@@ -75,6 +82,9 @@ def test_render_settings_text_includes_disabled_types_block() -> None:
         auction_mod_actions_enabled=True,
         points_enabled=True,
         support_enabled=False,
+        quiet_hours_enabled=True,
+        quiet_hours_start_hour=23,
+        quiet_hours_end_hour=8,
         configured=True,
     )
 

--- a/tests/test_private_topics_notification_metrics.py
+++ b/tests/test_private_topics_notification_metrics.py
@@ -9,7 +9,10 @@ from aiogram.exceptions import TelegramBadRequest
 from aiogram.methods import SendMessage
 
 from app.services import private_topics_service
-from app.services.notification_policy_service import NotificationEventType
+from app.services.notification_policy_service import (
+    NotificationDeliveryDecision,
+    NotificationEventType,
+)
 
 
 class _SessionCtx:
@@ -25,8 +28,8 @@ async def test_send_user_topic_message_records_policy_suppression_metric(monkeyp
     monkeypatch.setattr(private_topics_service.settings, "private_topics_enabled", False)
     monkeypatch.setattr(private_topics_service, "SessionFactory", lambda: _SessionCtx())
 
-    async def _blocked(*_args, **_kwargs) -> bool:
-        return False
+    async def _blocked(*_args, **_kwargs) -> NotificationDeliveryDecision:
+        return NotificationDeliveryDecision(allowed=False, reason="blocked_master")
 
     sent_metrics: list[tuple[str, str]] = []
     suppressed_metrics: list[tuple[str, str]] = []
@@ -37,13 +40,19 @@ async def test_send_user_topic_message_records_policy_suppression_metric(monkeyp
     async def _record_suppressed(*, event_type: NotificationEventType, reason: str) -> None:
         suppressed_metrics.append((event_type.value, reason))
 
+    async def _record_aggregated(
+        *, event_type: NotificationEventType, reason: str, count: int = 1  # noqa: ARG001
+    ) -> None:
+        raise AssertionError(f"aggregated metric should not be emitted: {event_type.value}:{reason}")
+
     class _BotStub:
         async def send_message(self, **_kwargs):  # noqa: ANN201
             raise AssertionError("send_message should not be called for blocked policy")
 
-    monkeypatch.setattr(private_topics_service, "is_notification_allowed", _blocked)
+    monkeypatch.setattr(private_topics_service, "notification_delivery_decision", _blocked)
     monkeypatch.setattr(private_topics_service, "record_notification_sent", _record_sent)
     monkeypatch.setattr(private_topics_service, "record_notification_suppressed", _record_suppressed)
+    monkeypatch.setattr(private_topics_service, "record_notification_aggregated", _record_aggregated)
 
     delivered = await private_topics_service.send_user_topic_message(
         cast(Bot, _BotStub()),
@@ -55,7 +64,7 @@ async def test_send_user_topic_message_records_policy_suppression_metric(monkeyp
 
     assert delivered is False
     assert sent_metrics == []
-    assert suppressed_metrics == [(NotificationEventType.AUCTION_OUTBID.value, "policy_blocked")]
+    assert suppressed_metrics == [(NotificationEventType.AUCTION_OUTBID.value, "blocked_master")]
 
 
 @pytest.mark.asyncio
@@ -63,8 +72,8 @@ async def test_send_user_topic_message_records_sent_metric_on_delivery(monkeypat
     monkeypatch.setattr(private_topics_service.settings, "private_topics_enabled", False)
     monkeypatch.setattr(private_topics_service, "SessionFactory", lambda: _SessionCtx())
 
-    async def _allowed(*_args, **_kwargs) -> bool:
-        return True
+    async def _allowed(*_args, **_kwargs) -> NotificationDeliveryDecision:
+        return NotificationDeliveryDecision(allowed=True, reason="allowed")
 
     sent_metrics: list[tuple[str, str]] = []
 
@@ -74,13 +83,23 @@ async def test_send_user_topic_message_records_sent_metric_on_delivery(monkeypat
     async def _record_suppressed(*, event_type: NotificationEventType, reason: str) -> None:
         raise AssertionError(f"suppressed metric should not be emitted: {event_type.value}:{reason}")
 
+    async def _record_aggregated(
+        *, event_type: NotificationEventType, reason: str, count: int = 1  # noqa: ARG001
+    ) -> None:
+        return None
+
+    async def _pop_deferred(*, tg_user_id: int, event_type: NotificationEventType) -> int:  # noqa: ARG001
+        return 0
+
     class _BotStub:
         async def send_message(self, **kwargs):  # noqa: ANN201
             return SimpleNamespace(chat=SimpleNamespace(id=kwargs["chat_id"]), message_id=1)
 
-    monkeypatch.setattr(private_topics_service, "is_notification_allowed", _allowed)
+    monkeypatch.setattr(private_topics_service, "notification_delivery_decision", _allowed)
     monkeypatch.setattr(private_topics_service, "record_notification_sent", _record_sent)
     monkeypatch.setattr(private_topics_service, "record_notification_suppressed", _record_suppressed)
+    monkeypatch.setattr(private_topics_service, "record_notification_aggregated", _record_aggregated)
+    monkeypatch.setattr(private_topics_service, "pop_deferred_notification_count", _pop_deferred)
 
     delivered = await private_topics_service.send_user_topic_message(
         cast(Bot, _BotStub()),
@@ -99,8 +118,8 @@ async def test_send_user_topic_message_records_bad_request_suppression_metric(mo
     monkeypatch.setattr(private_topics_service.settings, "private_topics_enabled", False)
     monkeypatch.setattr(private_topics_service, "SessionFactory", lambda: _SessionCtx())
 
-    async def _allowed(*_args, **_kwargs) -> bool:
-        return True
+    async def _allowed(*_args, **_kwargs) -> NotificationDeliveryDecision:
+        return NotificationDeliveryDecision(allowed=True, reason="allowed")
 
     suppressed_metrics: list[tuple[str, str]] = []
 
@@ -110,6 +129,14 @@ async def test_send_user_topic_message_records_bad_request_suppression_metric(mo
     async def _record_suppressed(*, event_type: NotificationEventType, reason: str) -> None:
         suppressed_metrics.append((event_type.value, reason))
 
+    async def _record_aggregated(
+        *, event_type: NotificationEventType, reason: str, count: int = 1  # noqa: ARG001
+    ) -> None:
+        return None
+
+    async def _pop_deferred(*, tg_user_id: int, event_type: NotificationEventType) -> int:  # noqa: ARG001
+        return 0
+
     class _BotStub:
         async def send_message(self, **kwargs):  # noqa: ANN201
             raise TelegramBadRequest(
@@ -117,9 +144,11 @@ async def test_send_user_topic_message_records_bad_request_suppression_metric(mo
                 message="Bad Request: chat not found",
             )
 
-    monkeypatch.setattr(private_topics_service, "is_notification_allowed", _allowed)
+    monkeypatch.setattr(private_topics_service, "notification_delivery_decision", _allowed)
     monkeypatch.setattr(private_topics_service, "record_notification_sent", _record_sent)
     monkeypatch.setattr(private_topics_service, "record_notification_suppressed", _record_suppressed)
+    monkeypatch.setattr(private_topics_service, "record_notification_aggregated", _record_aggregated)
+    monkeypatch.setattr(private_topics_service, "pop_deferred_notification_count", _pop_deferred)
 
     delivered = await private_topics_service.send_user_topic_message(
         cast(Bot, _BotStub()),
@@ -131,3 +160,56 @@ async def test_send_user_topic_message_records_bad_request_suppression_metric(mo
 
     assert delivered is False
     assert suppressed_metrics == [(NotificationEventType.AUCTION_OUTBID.value, "bad_request")]
+
+
+@pytest.mark.asyncio
+async def test_send_user_topic_message_defers_quiet_hours_events(monkeypatch) -> None:
+    monkeypatch.setattr(private_topics_service.settings, "private_topics_enabled", False)
+    monkeypatch.setattr(private_topics_service, "SessionFactory", lambda: _SessionCtx())
+
+    async def _quiet_hours(*_args, **_kwargs) -> NotificationDeliveryDecision:
+        return NotificationDeliveryDecision(allowed=False, reason="quiet_hours_deferred")
+
+    suppressed_metrics: list[tuple[str, str]] = []
+    aggregated_metrics: list[tuple[str, str]] = []
+    deferred_calls: list[str] = []
+
+    async def _record_sent(*, event_type: NotificationEventType, reason: str = "delivered") -> None:
+        raise AssertionError(f"sent metric should not be emitted: {event_type.value}:{reason}")
+
+    async def _record_suppressed(*, event_type: NotificationEventType, reason: str) -> None:
+        suppressed_metrics.append((event_type.value, reason))
+
+    async def _record_aggregated(*, event_type: NotificationEventType, reason: str, count: int = 1) -> None:
+        aggregated_metrics.append((event_type.value, reason))
+
+    async def _defer(*, tg_user_id: int, event_type: NotificationEventType) -> int:  # noqa: ARG001
+        deferred_calls.append(event_type.value)
+        return 2
+
+    async def _pop_deferred(*, tg_user_id: int, event_type: NotificationEventType) -> int:  # noqa: ARG001
+        return 0
+
+    class _BotStub:
+        async def send_message(self, **_kwargs):  # noqa: ANN201
+            raise AssertionError("send_message should not be called during quiet-hours deferral")
+
+    monkeypatch.setattr(private_topics_service, "notification_delivery_decision", _quiet_hours)
+    monkeypatch.setattr(private_topics_service, "record_notification_sent", _record_sent)
+    monkeypatch.setattr(private_topics_service, "record_notification_suppressed", _record_suppressed)
+    monkeypatch.setattr(private_topics_service, "record_notification_aggregated", _record_aggregated)
+    monkeypatch.setattr(private_topics_service, "defer_notification_event", _defer)
+    monkeypatch.setattr(private_topics_service, "pop_deferred_notification_count", _pop_deferred)
+
+    delivered = await private_topics_service.send_user_topic_message(
+        cast(Bot, _BotStub()),
+        tg_user_id=321,
+        purpose=private_topics_service.PrivateTopicPurpose.AUCTIONS,
+        text="hello",
+        notification_event=NotificationEventType.AUCTION_OUTBID,
+    )
+
+    assert delivered is False
+    assert suppressed_metrics == [(NotificationEventType.AUCTION_OUTBID.value, "quiet_hours_deferred")]
+    assert aggregated_metrics == [(NotificationEventType.AUCTION_OUTBID.value, "quiet_hours_deferred")]
+    assert deferred_calls == [NotificationEventType.AUCTION_OUTBID.value]

--- a/tests/test_start_dashboard.py
+++ b/tests/test_start_dashboard.py
@@ -195,6 +195,9 @@ def test_settings_keyboard_contains_unsnooze_buttons() -> None:
         auction_mod_actions_enabled=True,
         points_enabled=True,
         support_enabled=True,
+        quiet_hours_enabled=False,
+        quiet_hours_start_hour=23,
+        quiet_hours_end_hour=8,
         configured=True,
     )
     snoozes = [
@@ -224,6 +227,9 @@ def test_settings_keyboard_contains_unmute_buttons_for_disabled_events() -> None
         auction_mod_actions_enabled=True,
         points_enabled=True,
         support_enabled=False,
+        quiet_hours_enabled=True,
+        quiet_hours_start_hour=23,
+        quiet_hours_end_hour=8,
         configured=True,
     )
 
@@ -237,6 +243,9 @@ def test_settings_keyboard_contains_unmute_buttons_for_disabled_events() -> None
     assert "dash:settings:unmute:outbid" in callback_data
     assert "dash:settings:unmute:win" in callback_data
     assert "dash:settings:unmute:support" in callback_data
+    assert "dash:settings:quiet:toggle" in callback_data
+    assert "dash:settings:quiet:23-8" in callback_data
+    assert "dash:settings:quiet:off" in callback_data
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add quiet-hours preferences to notification settings and persist them in `user_notification_preferences` (`quiet_hours_enabled`, start/end UTC hour)
- introduce quiet-hours delivery decision in notification policy so normal/low priority events are deferred while critical/high remain immediate
- add `/settings` controls for quiet-hours toggle and quick presets (`23:00-08:00 UTC`, `00:00-07:00 UTC`)
- implement lightweight deferred-count buffering per user/event and flush notice on next eligible notification after quiet hours
- document quiet-hours behavior, migration, and reason codes for operators/maintainers

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests/test_notification_policy_service.py tests/test_notification_settings_render.py tests/test_start_dashboard.py tests/test_private_topics_notification_metrics.py tests/test_notification_quiet_hours_service.py`
- `.venv/bin/python -m pytest -q tests`
- `docker compose run --rm --no-deps -v /home/n501/VibeCoding/LiteAuction:/app bot sh -lc "pip install --no-cache-dir pytest pytest-asyncio >/tmp/pip-install.log && RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test python -m pytest -q tests/integration"`

## Rollout Notes
- Apply Alembic migration `0034_notif_quiet_hours` before or with bot deploy.
- Quiet-hours rules are UTC-based in this iteration; presets and toggle are exposed in `/settings`.

## Rollback Notes
- Roll back bot image to disable quiet-hours decision/deferral behavior.
- Migration is additive and safe to keep if rollback is needed.

Closes #144