### PR TITLE
[Sprint 45][S45-001] Add delivery diagnostics and operator log views

### DIFF
--- a/docs/release/sprint-45-delivery-diagnostics.md
+++ b/docs/release/sprint-45-delivery-diagnostics.md
@@ -1,0 +1,41 @@
+# Sprint 45 Delivery Diagnostics
+
+## Goal
+
+Provide concise, searchable operator logs for notification delivery decisions and failure causes.
+
+## Structured Log Events
+
+- Decision log (INFO):
+  - prefix: `notification_delivery_decision`
+  - fields:
+    - `tg_user_id`
+    - `purpose`
+    - `event`
+    - `auction_id`
+    - `allowed`
+    - `reason`
+
+- Failure log (WARNING):
+  - prefix: `notification_delivery_failed`
+  - fields:
+    - `tg_user_id`
+    - `purpose`
+    - `event`
+    - `reason`
+    - `failure_class`
+    - `error`
+
+## Reason Codes
+
+- decision reasons: `allowed`, `blocked_master`, `blocked_event_toggle`, `blocked_auction_snooze`, `quiet_hours_deferred`, `allow_no_user`
+- failure reasons: `bad_request`, `forbidden`, `telegram_api_error`, `unexpected_error`
+
+## Operator Usage
+
+Recommended search queries in bot logs:
+
+- all blocked deliveries: `notification_delivery_decision allowed=False`
+- quiet-hours suppression: `notification_delivery_decision reason=quiet_hours_deferred`
+- transport failures: `notification_delivery_failed`
+- chat-level failures for a user: `notification_delivery_failed tg_user_id=<id>`

--- a/tests/test_private_topics_delivery_diagnostics.py
+++ b/tests/test_private_topics_delivery_diagnostics.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import logging
+from typing import cast
+
+import pytest
+from aiogram import Bot
+from aiogram.exceptions import TelegramBadRequest
+from aiogram.methods import SendMessage
+
+from app.services import private_topics_service
+from app.services.notification_policy_service import NotificationDeliveryDecision, NotificationEventType
+
+
+class _SessionCtx:
+    async def __aenter__(self):  # noqa: ANN204
+        return object()
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:  # noqa: ANN001, ANN204
+        return False
+
+
+@pytest.mark.asyncio
+async def test_delivery_decision_is_logged_with_reason_code(
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(private_topics_service.settings, "private_topics_enabled", False)
+    monkeypatch.setattr(private_topics_service, "SessionFactory", lambda: _SessionCtx())
+
+    async def _decision(*_args, **_kwargs) -> NotificationDeliveryDecision:
+        return NotificationDeliveryDecision(allowed=False, reason="blocked_event_toggle")
+
+    async def _record_suppressed(*, event_type: NotificationEventType, reason: str) -> None:  # noqa: ARG001
+        return None
+
+    async def _record_aggregated(*, event_type: NotificationEventType, reason: str, count: int = 1) -> None:  # noqa: ARG001
+        return None
+
+    caplog.set_level(logging.INFO)
+    monkeypatch.setattr(private_topics_service, "notification_delivery_decision", _decision)
+    monkeypatch.setattr(private_topics_service, "record_notification_suppressed", _record_suppressed)
+    monkeypatch.setattr(private_topics_service, "record_notification_aggregated", _record_aggregated)
+
+    class _BotStub:
+        async def send_message(self, **_kwargs):  # noqa: ANN201
+            raise AssertionError("send_message should not run for blocked decision")
+
+    delivered = await private_topics_service.send_user_topic_message(
+        cast(Bot, _BotStub()),
+        tg_user_id=321,
+        purpose=private_topics_service.PrivateTopicPurpose.AUCTIONS,
+        text="hello",
+        notification_event=NotificationEventType.POINTS,
+    )
+
+    assert delivered is False
+    assert "notification_delivery_decision" in caplog.text
+    assert "event=points" in caplog.text
+    assert "allowed=False" in caplog.text
+    assert "reason=blocked_event_toggle" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_delivery_failure_log_includes_event_and_failure_class(
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(private_topics_service.settings, "private_topics_enabled", False)
+    monkeypatch.setattr(private_topics_service, "SessionFactory", lambda: _SessionCtx())
+
+    async def _decision(*_args, **_kwargs) -> NotificationDeliveryDecision:
+        return NotificationDeliveryDecision(allowed=True, reason="allowed")
+
+    async def _record_sent(*, event_type: NotificationEventType, reason: str = "delivered") -> None:  # noqa: ARG001
+        return None
+
+    async def _record_suppressed(*, event_type: NotificationEventType, reason: str) -> None:  # noqa: ARG001
+        return None
+
+    async def _record_aggregated(*, event_type: NotificationEventType, reason: str, count: int = 1) -> None:  # noqa: ARG001
+        return None
+
+    async def _pop_deferred(*, tg_user_id: int, event_type: NotificationEventType) -> int:  # noqa: ARG001
+        return 0
+
+    caplog.set_level(logging.WARNING)
+    monkeypatch.setattr(private_topics_service, "notification_delivery_decision", _decision)
+    monkeypatch.setattr(private_topics_service, "record_notification_sent", _record_sent)
+    monkeypatch.setattr(private_topics_service, "record_notification_suppressed", _record_suppressed)
+    monkeypatch.setattr(private_topics_service, "record_notification_aggregated", _record_aggregated)
+    monkeypatch.setattr(private_topics_service, "pop_deferred_notification_count", _pop_deferred)
+
+    class _BotStub:
+        async def send_message(self, **kwargs):  # noqa: ANN201
+            raise TelegramBadRequest(
+                method=SendMessage(chat_id=kwargs["chat_id"], text=kwargs["text"]),
+                message="Bad Request: chat not found",
+            )
+
+    delivered = await private_topics_service.send_user_topic_message(
+        cast(Bot, _BotStub()),
+        tg_user_id=777,
+        purpose=private_topics_service.PrivateTopicPurpose.AUCTIONS,
+        text="hello",
+        notification_event=NotificationEventType.AUCTION_OUTBID,
+    )
+
+    assert delivered is False
+    assert "notification_delivery_failed" in caplog.text
+    assert "event=auction_outbid" in caplog.text
+    assert "reason=bad_request" in caplog.text
+    assert "failure_class=TelegramBadRequest" in caplog.text


### PR DESCRIPTION
## Summary
- add structured notification delivery decision logs with explicit reason codes for every event-driven send path
- add structured delivery failure diagnostics with `tg_user_id`, notification event, reason code, and exception class for support triage
- keep log format concise/searchable via stable prefixes (`notification_delivery_decision`, `notification_delivery_failed`)
- document operator-facing log fields, reason codes, and recommended log queries

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests/test_private_topics_delivery_diagnostics.py tests/test_private_topics_notification_metrics.py tests/test_notification_policy_service.py`
- `.venv/bin/python -m pytest -q tests`
- `docker compose run --rm --no-deps -v /home/n501/VibeCoding/LiteAuction:/app bot sh -lc "pip install --no-cache-dir pytest pytest-asyncio >/tmp/pip-install.log && RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test python -m pytest -q tests/integration"`

## Rollout Notes
- No migration required.
- Decision/failure diagnostics are additive logs only and do not alter delivery behavior.

## Rollback Notes
- Roll back bot image to revert diagnostics log format.

Closes #147