### PR TITLE
[Sprint 45][S45-005] Post-launch review and backlog follow-up

### DIFF
--- a/docs/release/sprint-45-post-launch-review.md
+++ b/docs/release/sprint-45-post-launch-review.md
@@ -1,0 +1,59 @@
+# Sprint 45 Post-Launch Review
+
+## Scope Reviewed
+
+Sprint 45 notification stabilization and operations hardening:
+
+- S45-001 delivery diagnostics and searchable failure logs
+- S45-002 copy/action-label UX polish
+- S45-003 migration + callback compatibility hardening
+- S45-004 support/moderation troubleshooting runbook
+
+## Key Metrics
+
+### Delivery Metrics
+
+- Sprint completion: `4/4` implementation items delivered before closeout.
+- GitHub issues closed in sprint scope: `#147`, `#148`, `#149`, `#150`.
+- Merged implementation PRs: `#163`, `#164`, `#165`, `#166`.
+
+### Quality/CI Signals
+
+- CI status for merged sprint PRs: all required checks passed (`ruff`, unit tests, integration DB, PR policy).
+- Local validation for each item included Ruff + targeted tests; code-changing items also included full unit + integration runs.
+
+### Observability Coverage
+
+- Structured decision logs available via `notification_delivery_decision`.
+- Structured failure logs available via `notification_delivery_failed` with `failure_class`.
+- Metrics counters available for `sent`, `suppressed`, `aggregated` outcomes with reason codes.
+
+## User Feedback Summary
+
+Observed product feedback trend during this delivery cycle:
+
+- Strong preference for compact notification copy and less chat noise.
+- Positive direction on explicit action labels and one-tap controls.
+- Importance of stale-button safety and clear fallback alerts confirmed in user flows.
+
+## Follow-Up Backlog (Prioritized)
+
+- P1: `#167` Add user timezone support for quiet hours.
+- P2: `#169` Improve pluralization in digest and deferred summaries.
+- P2: `#168` Add operator snapshot command for notification metrics.
+
+All follow-ups are logged with `tech-debt` and explicit priority labels.
+
+## Sprint Closeout Notes
+
+### Risks
+
+- Quiet-hours currently use UTC-only interpretation; timezone mismatch can reduce user trust.
+- Digest/deferred phrase pluralization is understandable but not fully natural for all counts.
+- Operators still rely on raw logs/Redis without a first-class summary command.
+
+### Next Actions
+
+1. Pull `#167` into next active sprint as first P1 notification task.
+2. Implement `#169` alongside copy updates to avoid further template drift.
+3. Implement `#168` and extend runbook with command output examples.


### PR DESCRIPTION
## Summary
- add Sprint 45 post-launch review covering delivered scope, quality signals, observability readiness, and user feedback themes
- log prioritized follow-up backlog items with explicit references and priorities (`#167`, `#169`, `#168`)
- include sprint closeout risk register and concrete next actions for transition into the next sprint

## Validation
- `.venv/bin/python -m ruff check app tests`

## Rollout Notes
- Documentation-only change.

## Rollback Notes
- Revert docs commit if closeout wording needs correction.

Closes #151