### PR TITLE
[Sprint 48][S48-002] Add per-window top suppression reasons for /notifstats

### DIFF
--- a/app/bot/handlers/moderation.py
+++ b/app/bot/handlers/moderation.py
@@ -808,6 +808,17 @@ async def _render_notification_metrics_snapshot_text(
     )
     event_filter_label = event_type_filter.value if event_type_filter is not None else "all"
     reason_filter_label = reason_filter or "all"
+    def _top_section(title: str, items: tuple) -> list[str]:
+        lines = [title]
+        if not items:
+            lines.append("- пока нет данных")
+            return lines
+        for item in items:
+            lines.append(
+                f"- {_notification_event_label(item.event_type)} / {item.reason}: {item.total}"
+            )
+        return lines
+
     lines = [
         "Notification metrics snapshot",
         f"Filters: event={event_filter_label}, reason={reason_filter_label}",
@@ -831,15 +842,12 @@ async def _render_notification_metrics_snapshot_text(
         f"- suppressed total (7d): {snapshot.last_7d.suppressed_total}",
         f"- aggregated total (7d): {snapshot.last_7d.aggregated_total}",
         "",
-        "Top suppression reasons (event/reason, all-time):",
     ]
-    if not snapshot.top_suppressed:
-        lines.append("- пока нет данных")
-    else:
-        for item in snapshot.top_suppressed:
-            lines.append(
-                f"- {_notification_event_label(item.event_type)} / {item.reason}: {item.total}"
-            )
+    lines.extend(_top_section("Top suppression reasons (24h):", snapshot.top_suppressed_24h))
+    lines.append("")
+    lines.extend(_top_section("Top suppression reasons (7d):", snapshot.top_suppressed_7d))
+    lines.append("")
+    lines.extend(_top_section("Top suppression reasons (event/reason, all-time):", snapshot.top_suppressed))
     return "\n".join(lines)
 
 

--- a/tests/test_moderation_notifstats_command.py
+++ b/tests/test_moderation_notifstats_command.py
@@ -67,6 +67,25 @@ async def test_render_notification_metrics_snapshot_text_includes_top_reasons(mo
                 aggregated_delta=0,
             ),
             last_7d=NotificationMetricTotals(sent_total=9, suppressed_total=5, aggregated_total=3),
+            top_suppressed_24h=(
+                NotificationMetricBucket(
+                    event_type=NotificationEventType.AUCTION_OUTBID,
+                    reason="blocked_master",
+                    total=2,
+                ),
+            ),
+            top_suppressed_7d=(
+                NotificationMetricBucket(
+                    event_type=NotificationEventType.AUCTION_OUTBID,
+                    reason="blocked_master",
+                    total=4,
+                ),
+                NotificationMetricBucket(
+                    event_type=NotificationEventType.SUPPORT,
+                    reason="forbidden",
+                    total=3,
+                ),
+            ),
             top_suppressed=(
                 NotificationMetricBucket(
                     event_type=NotificationEventType.AUCTION_OUTBID,
@@ -98,6 +117,8 @@ async def test_render_notification_metrics_snapshot_text_includes_top_reasons(mo
     assert "sent total (7d): 9" in text
     assert "suppressed total (7d): 5" in text
     assert "aggregated total (7d): 3" in text
+    assert "Top suppression reasons (24h):" in text
+    assert "Top suppression reasons (7d):" in text
     assert "Перебили ставку / blocked_master: 4" in text
     assert "Поддержка / forbidden: 3" in text
     assert captured_filters == [(None, None)]


### PR DESCRIPTION
## Summary
- extend notification snapshot model with top suppression groups for 24h and 7d windows in addition to all-time
- update `/notifstats` output to render separate top suppression sections for 24h, 7d, and all-time windows
- keep ranking deterministic (count desc, event asc, reason asc) and add tests for deterministic ordering and filtered window tops

## Linked Issue
Closes #181

## Validation
- [x] `.venv/bin/python -m ruff check app tests`
- [x] `.venv/bin/python -m pytest -q tests`
- [x] `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@<db-ip>:5432/auction_test .venv/bin/python -m pytest -q tests/integration`

## Rollout / Rollback
- Rollout: deploy bot workers; no schema migration required.
- Rollback: revert application commit; output/model changes are runtime-only.