### PR TITLE
[Sprint 50][S50-002] Add /notifstats window selector for focused triage output

### DIFF
--- a/docs/quality/notification-troubleshooting-runbook.md
+++ b/docs/quality/notification-troubleshooting-runbook.md
@@ -90,6 +90,12 @@ When escalating to engineering, include:
 
 Use `/notifstats` in private moderation topic for a compact Redis-based snapshot.
 
+Useful selector forms:
+
+- `/notifstats 24h` or `/notifstats window=24h`: only 24h totals/delta and 24h top suppression reasons
+- `/notifstats 7d` or `/notifstats window=7d`: only 7d totals and 7d top suppression reasons
+- `/notifstats all` or `/notifstats window=all`: only all-time totals and all-time top suppression reasons
+
 Output blocks:
 
 - `All-time totals`: cumulative counters since last metrics reset/Redis flush


### PR DESCRIPTION
## Summary
- add `/notifstats` window selector support (`24h`, `7d`, `all` via shorthand or `window=<...>`) with validation and help text updates
- make selected-window rendering concise: only relevant totals and top suppression section for the chosen window (with 24h delta for `24h`)
- keep backward compatibility: existing `/notifstats` and `compact` behavior remains unchanged when no window selector is provided
- update runbook with practical `window` selector command forms for operators

## Linked Issue
Closes #193

## Validation
- [x] `.venv/bin/python -m ruff check app tests`
- [x] `.venv/bin/python -m pytest -q tests`
- [x] `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@localhost:5432/auction_test .venv/bin/python -m pytest -q tests/integration`

## Rollout / Rollback
- Rollout: deploy bot workers; no schema migration required.
- Rollback: revert application commit; change affects `/notifstats` parsing/rendering only.