### PR TITLE
[Sprint 51][S51-005] Add in-place triage interactions for moderation queues

### DIFF
--- a/.planning/phases/03-in-place-triage-interactions/03-01-PLAN.md
+++ b/.planning/phases/03-in-place-triage-interactions/03-01-PLAN.md
@@ -1,0 +1,102 @@
+---
+phase: 03-in-place-triage-interactions
+plan: "01"
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - app/web/main.py
+  - app/web/dense_list.py
+  - tests/test_web_dense_list_contract.py
+  - tests/integration/test_web_triage_interactions.py
+autonomous: true
+requirements:
+  - DISC-01
+  - DISC-03
+must_haves:
+  truths:
+    - "Operators can open and close inline row details without leaving queue page context or losing active filters."
+    - "Multiple rows can stay expanded simultaneously and remain within a strict two-level disclosure model (list + details only)."
+    - "Closing details restores focus and preserves scroll position for continued triage."
+  artifacts:
+    - path: app/web/main.py
+      provides: "Queue row/detail markup and route wiring for inline disclosure state."
+      contains: "data-triage-row|data-triage-detail|expanded"
+    - path: app/web/dense_list.py
+      provides: "Dense-list script behavior for inline open/close, dimming, and focus return."
+      contains: "triage|expandedRows|focus"
+    - path: tests/integration/test_web_triage_interactions.py
+      provides: "DB-backed assertions for in-place disclosure and context retention."
+      contains: "inline detail|context preserve|two-level"
+  key_links:
+    - from: app/web/main.py
+      to: app/web/dense_list.py
+      via: "Route markup emits triage data hooks consumed by dense-list interaction script."
+      pattern: "data-triage-"
+    - from: tests/integration/test_web_triage_interactions.py
+      to: app/web/main.py
+      via: "Integration tests verify queue routes keep disclosure state in-place without navigation depth growth."
+      pattern: "complaints|signals|appeals|trade_feedback"
+---
+
+<objective>
+Lay down the in-place disclosure foundation so operators can inspect rows inline and continue triage without context loss.
+
+Purpose: Implement stable list+detail structure first, before progressive loading and advanced interaction layers.
+Output: Queue markup + dense-list behavior + integration tests proving DISC-01 and DISC-03 baseline contracts.
+</objective>
+
+<execution_context>
+@/home/n501/.config/opencode/get-shit-done/workflows/execute-plan.md
+@/home/n501/.config/opencode/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/03-in-place-triage-interactions/03-CONTEXT.md
+@.planning/phases/03-in-place-triage-interactions/03-RESEARCH.md
+@app/web/main.py
+@app/web/dense_list.py
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add inline detail-row structure on triage queues</name>
+  <files>app/web/main.py</files>
+  <action>Extend `complaints`, `signals`, `appeals`, and `trade_feedback` table rendering so each data row has an adjacent inline details container row (`data-triage-detail`) bound by stable row ids. Keep details inside the same table context, avoid nested navigation links for details-only exploration, and preserve existing queue filters/page/density query behavior.</action>
+  <verify>python -m pytest -q tests/integration/test_web_triage_interactions.py -k "inline and structure"</verify>
+  <done>Queue pages render list+detail as one in-place interaction model and no third disclosure level exists.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Implement open/close behavior with focus and scroll preservation</name>
+  <files>app/web/dense_list.py</files>
+  <action>Add triage controls to dense-list script so operators can expand/collapse rows inline, keep multiple expanded rows, visually dim non-active rows when any detail is open, and return focus to the invoking row control on close. Preserve active filter text, row visibility, and list scroll offset during toggles.</action>
+  <verify>python -m pytest -q tests/test_web_dense_list_contract.py -k "triage and focus"</verify>
+  <done>Inline detail interactions are stable, keyboard-focus-safe, and do not reset list context.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add disclosure baseline integration coverage</name>
+  <files>tests/test_web_dense_list_contract.py, tests/integration/test_web_triage_interactions.py</files>
+  <action>Create contract and DB-backed tests asserting: inline detail rows render for all four queue contexts, expanded state is independent per row, close returns focus to trigger, and disclosure depth remains exactly two levels (list and details). Include regression for preserving active quick filter while opening/closing rows.</action>
+  <verify>RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://.../auction_test python -m pytest -q tests/test_web_dense_list_contract.py tests/integration/test_web_triage_interactions.py -k "triage or disclosure"</verify>
+  <done>Automated evidence locks DISC-01 and DISC-03 baseline behavior for in-place triage.</done>
+</task>
+
+</tasks>
+
+<verification>
+Run dense-list contract tests and triage integration tests to prove inline disclosure and context retention behavior.
+</verification>
+
+<success_criteria>
+In-place disclosure foundation is in place: operators open multiple inline details, keep queue context intact, and stay within two-level disclosure limits.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03-in-place-triage-interactions/03-in-place-triage-interactions-01-SUMMARY.md`
+</output>

--- a/.planning/phases/03-in-place-triage-interactions/03-02-PLAN.md
+++ b/.planning/phases/03-in-place-triage-interactions/03-02-PLAN.md
@@ -1,0 +1,104 @@
+---
+phase: 03-in-place-triage-interactions
+plan: "02"
+type: execute
+wave: 2
+depends_on:
+  - 03-01
+files_modified:
+  - app/web/main.py
+  - app/web/dense_list.py
+  - tests/test_web_dense_list_contract.py
+  - tests/integration/test_web_triage_interactions.py
+autonomous: true
+requirements:
+  - DISC-02
+  - KEYB-01
+must_haves:
+  truths:
+    - "Detail panels show immediate skeleton and key fields, then progressively hydrate higher-priority sections first."
+    - "Section-level failures keep successful sections visible and provide inline retry for failed sections."
+    - "Keyboard shortcuts let operators focus quick search, move row focus, and toggle active row details without leaving queue context."
+  artifacts:
+    - path: app/web/main.py
+      provides: "Detail-section JSON endpoints and priority section payload contract per queue context."
+      contains: "triage detail sections|retry"
+    - path: app/web/dense_list.py
+      provides: "Progressive section loader, error/retry rendering, and keyboard interaction map."
+      contains: "loading skeleton|retry section|keydown"
+    - path: tests/integration/test_web_triage_interactions.py
+      provides: "Integration checks for progressive loading behavior and keyboard shortcut outcomes."
+      contains: "progressive|partial failure|keyboard"
+  key_links:
+    - from: app/web/dense_list.py
+      to: app/web/main.py
+      via: "Client requests per-section payloads and retries failed sections against JSON endpoints."
+      pattern: "fetch|section|retry"
+    - from: tests/test_web_dense_list_contract.py
+      to: app/web/dense_list.py
+      via: "Contract tests lock shortcut identifiers and progressive detail state hooks."
+      pattern: "data-shortcut|data-detail-state"
+---
+
+<objective>
+Add progressive detail loading and keyboard-first triage controls so in-place review remains fast under heavy queues.
+
+Purpose: Complete DISC-02 and KEYB-01 after inline disclosure foundation exists.
+Output: Section-based progressive loading with retry semantics plus deterministic shortcut behavior and tests.
+</objective>
+
+<execution_context>
+@/home/n501/.config/opencode/get-shit-done/workflows/execute-plan.md
+@/home/n501/.config/opencode/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/03-in-place-triage-interactions/03-CONTEXT.md
+@.planning/phases/03-in-place-triage-interactions/03-RESEARCH.md
+@.planning/phases/03-in-place-triage-interactions/03-01-PLAN.md
+@app/web/main.py
+@app/web/dense_list.py
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Implement progressive detail section API and initial skeleton state</name>
+  <files>app/web/main.py, app/web/dense_list.py</files>
+  <action>Define a detail payload contract with prioritized sections (top triage fields first). On row open, render skeleton placeholders and initial high-priority values immediately, then asynchronously load remaining sections by priority. Keep list interactions responsive and avoid locking scroll or row navigation while sections load.</action>
+  <verify>python -m pytest -q tests/integration/test_web_triage_interactions.py -k "progressive and detail"</verify>
+  <done>Detail panels display immediate feedback and progressively hydrate section-by-section in priority order.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add partial-failure handling with section retry</name>
+  <files>app/web/main.py, app/web/dense_list.py</files>
+  <action>Return section-scoped error states from detail endpoints and render inline error blocks only for failed sections. Provide a retry control per failed section while preserving already-loaded content and current row context. Ensure failures do not collapse the panel or clear expanded-row state.</action>
+  <verify>RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://.../auction_test python -m pytest -q tests/integration/test_web_triage_interactions.py -k "retry or partial"</verify>
+  <done>Operators can recover failed detail sections without losing loaded information or queue position.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Implement and lock keyboard-first triage shortcuts</name>
+  <files>app/web/dense_list.py, tests/test_web_dense_list_contract.py, tests/integration/test_web_triage_interactions.py</files>
+  <action>Add explicit shortcut mapping for focus-search, row-next/row-prev navigation, and open/close detail on focused row. Suppress shortcuts while typing in inputs/selects/textareas. Add contract and integration tests validating shortcut behavior, focus placement, and no-op safety at list boundaries.</action>
+  <verify>RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://.../auction_test python -m pytest -q tests/test_web_dense_list_contract.py tests/integration/test_web_triage_interactions.py -k "keyboard or shortcut"</verify>
+  <done>Keyboard interactions support fast triage without disrupting input fields or list context.</done>
+</task>
+
+</tasks>
+
+<verification>
+Run triage integration tests for progressive loading + retries and dense-list contract/integration checks for keyboard shortcuts.
+</verification>
+
+<success_criteria>
+Detail loading is progressive and fault-tolerant, and keyboard-first triage actions are deterministic and regression-protected.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03-in-place-triage-interactions/03-in-place-triage-interactions-02-SUMMARY.md`
+</output>

--- a/.planning/phases/03-in-place-triage-interactions/03-03-PLAN.md
+++ b/.planning/phases/03-in-place-triage-interactions/03-03-PLAN.md
@@ -1,0 +1,105 @@
+---
+phase: 03-in-place-triage-interactions
+plan: "03"
+type: execute
+wave: 3
+depends_on:
+  - 03-01
+  - 03-02
+files_modified:
+  - app/web/main.py
+  - app/web/dense_list.py
+  - tests/test_web_dense_list_contract.py
+  - tests/integration/test_web_triage_interactions.py
+autonomous: true
+requirements:
+  - BULK-01
+must_haves:
+  truths:
+    - "Operators can select multiple rows and run supported bulk triage actions from the queue without leaving context."
+    - "Destructive bulk operations require explicit confirmation text before server action executes."
+    - "Bulk execution reports per-row outcomes so operators can continue with unresolved items in place."
+  artifacts:
+    - path: app/web/dense_list.py
+      provides: "Client-side multi-select state, bulk action toolbar, and confirmation workflow."
+      contains: "data-bulk-select|data-bulk-action|confirm"
+    - path: app/web/main.py
+      provides: "CSRF-protected bulk action endpoint validating queue scope, permissions, and per-row results."
+      contains: "bulk action|selected_ids|results"
+    - path: tests/integration/test_web_triage_interactions.py
+      provides: "End-to-end coverage for safe bulk actions, destructive confirmation, and partial success reporting."
+      contains: "bulk|confirm|partial success"
+  key_links:
+    - from: app/web/dense_list.py
+      to: app/web/main.py
+      via: "Bulk toolbar posts selected ids and chosen action; server returns row-level outcomes for in-place updates."
+      pattern: "selected_ids|bulk_action|results"
+    - from: tests/integration/test_web_triage_interactions.py
+      to: app/web/main.py
+      via: "Integration tests ensure unauthorized or invalid bulk mutations fail safely."
+      pattern: "401|403|validation"
+---
+
+<objective>
+Deliver queue-native batch triage actions with explicit safety confirmations and clear result feedback.
+
+Purpose: Complete BULK-01 on top of inline disclosure and keyboard foundation.
+Output: Bulk-selection UX, secure bulk action endpoint, and tests for destructive confirmation and mixed-result handling.
+</objective>
+
+<execution_context>
+@/home/n501/.config/opencode/get-shit-done/workflows/execute-plan.md
+@/home/n501/.config/opencode/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/03-in-place-triage-interactions/03-CONTEXT.md
+@.planning/phases/03-in-place-triage-interactions/03-RESEARCH.md
+@.planning/phases/03-in-place-triage-interactions/03-01-PLAN.md
+@.planning/phases/03-in-place-triage-interactions/03-02-PLAN.md
+@app/web/main.py
+@app/web/dense_list.py
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add multi-row selection and bulk action toolbar</name>
+  <files>app/web/main.py, app/web/dense_list.py</files>
+  <action>Add per-row selection controls and a context-aware bulk toolbar for supported actions (e.g., resolve/reopen flows that already exist per queue policy). Keep selection state visible while details are expanded, allow select-all-on-page behavior, and preserve row focus after bulk execution updates.</action>
+  <verify>python -m pytest -q tests/test_web_dense_list_contract.py -k "bulk and toolbar"</verify>
+  <done>Operators can select multiple rows and trigger supported queue bulk actions from in-place triage UI.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Implement destructive confirmation and secure bulk endpoint</name>
+  <files>app/web/main.py, app/web/dense_list.py</files>
+  <action>Create a CSRF-protected bulk action endpoint that validates queue key, selected ids, and role permissions before mutating any records. For destructive actions, require explicit confirmation text in client flow before submit. Return per-row success/failure results with reason codes so unresolved rows remain actionable in the same list view.</action>
+  <verify>RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://.../auction_test python -m pytest -q tests/integration/test_web_triage_interactions.py -k "bulk and (confirm or security)"</verify>
+  <done>Destructive bulk actions are gated by confirmation and protected by server-side validation and authorization checks.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Finalize end-to-end triage interaction coverage</name>
+  <files>tests/test_web_dense_list_contract.py, tests/integration/test_web_triage_interactions.py</files>
+  <action>Expand test coverage for complete Phase 3 flow: open inline details, progressive section behavior, keyboard navigation, multi-select, destructive bulk confirmation, and mixed-result handling. Add regression checks that list filters, density, and scroll/focus context remain stable after bulk operations.</action>
+  <verify>RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://.../auction_test python -m pytest -q tests/test_web_dense_list_contract.py tests/integration/test_web_triage_interactions.py</verify>
+  <done>Automated tests cover DISC/KEYB/BULK interaction chains and prevent queue-context-loss regressions.</done>
+</task>
+
+</tasks>
+
+<verification>
+Run dense-list contract tests and triage integration suite validating batch safety, confirmation gates, and context retention after bulk operations.
+</verification>
+
+<success_criteria>
+Batch triage actions are available, safe, and transparent: operators can process multiple rows quickly with explicit destructive confirmations and row-level outcome feedback.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/03-in-place-triage-interactions/03-in-place-triage-interactions-03-SUMMARY.md`
+</output>

--- a/.planning/phases/03-in-place-triage-interactions/03-CONTEXT.md
+++ b/.planning/phases/03-in-place-triage-interactions/03-CONTEXT.md
@@ -1,0 +1,53 @@
+# Phase 3: In-Place Triage Interactions - Context
+
+**Gathered:** 2026-02-20
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Enable operators to inspect queue rows and act without leaving list context by using inline disclosure with progressive detail loading. Preserve active triage context (position, focus, filters) and keep interactions within a two-level model (list + details).
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Detail reveal pattern
+- Row details open inline under the selected row.
+- Multiple row details can remain expanded at the same time.
+- Closing details must preserve scroll position, keyboard focus, and active filters.
+- While details are open, non-active rows are visually dimmed to keep attention on active review context.
+
+### Progressive detail states
+- Show skeleton placeholders plus key fields immediately on open.
+- Load detail sections progressively from highest triage priority to lower-priority sections.
+- On partial load failure, keep available sections visible and provide retry on failed sections.
+- Show errors inline in the affected section.
+
+### Claude's Discretion
+- Keyboard shortcut mapping and focus choreography for search/row navigation/detail open.
+- Batch-selection interaction model and destructive-confirmation phrasing.
+- Exact visual treatment for skeletons, dimming intensity, and section hierarchy.
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+- Strong preference for inline triage flow that avoids context loss.
+- Progressive loading should prioritize immediately actionable information.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+None - discussion stayed within phase scope.
+
+</deferred>
+
+---
+
+*Phase: 03-in-place-triage-interactions*
+*Context gathered: 2026-02-20*

--- a/.planning/phases/03-in-place-triage-interactions/03-RESEARCH.md
+++ b/.planning/phases/03-in-place-triage-interactions/03-RESEARCH.md
@@ -1,0 +1,117 @@
+# Phase 3: In-Place Triage Interactions - Research
+
+**Researched:** 2026-02-20
+**Domain:** FastAPI server-rendered queue triage interactions (inline disclosure, progressive details, keyboard and batch flows)
+**Confidence:** HIGH
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+### Detail reveal pattern
+- Row details open inline under the selected row.
+- Multiple row details can remain expanded at the same time.
+- Closing details must preserve scroll position, keyboard focus, and active filters.
+- While details are open, non-active rows are visually dimmed to keep attention on active review context.
+
+### Progressive detail states
+- Show skeleton placeholders plus key fields immediately on open.
+- Load detail sections progressively from highest triage priority to lower-priority sections.
+- On partial load failure, keep available sections visible and provide retry on failed sections.
+- Show errors inline in the affected section.
+
+### Claude's Discretion
+- Keyboard shortcut mapping and focus choreography for search/row navigation/detail open.
+- Batch-selection interaction model and destructive-confirmation phrasing.
+- Exact visual treatment for skeletons, dimming intensity, and section hierarchy.
+
+### Deferred Ideas (OUT OF SCOPE)
+None.
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|-----------------|
+| DISC-01 | Open row details without losing list position or active filters | Keep details inline in table context and persist open-row intent in URL/query state so reload/back keeps list position/filter state |
+| DISC-02 | Load detailed sections progressively while list stays responsive | Use small initial detail payload + section-by-section fetch endpoint with per-section error/retry contract |
+| DISC-03 | Keep disclosure to two levels | Enforce only list row + inline detail panel, avoid nested detail navigation routes |
+| KEYB-01 | Keyboard shortcuts for search, row nav, and open details | Extend dense-list client script with roving focus index + deterministic shortcuts bound to table shell |
+| BULK-01 | Multi-select + supported bulk actions with destructive confirmation | Add explicit row selection state and server-validated bulk actions endpoint with confirmation text for destructive paths |
+</phase_requirements>
+
+## Summary
+
+The existing Phase 1 and Phase 2 direction already centralizes queue interaction logic in `app/web/dense_list.py` and queue page rendering in `app/web/main.py`. Phase 3 should extend this same contract instead of adding a new frontend runtime. The safest path is: render lightweight inline detail containers in each queue row, hydrate them via JSON endpoints, and keep row/filter context in existing queue query parameters.
+
+The largest risk is context loss when expanding/closing details or running keyboard/bulk actions. To avoid this, all interactions should be shell-scoped to the dense-list table and should never navigate away from the queue route except explicit row action links. For progressive loading, partial failure must degrade by section, not by panel.
+
+**Primary recommendation:** implement triage interactions as dense-list contract extensions (data attributes + script behavior) with queue-specific server JSON detail builders and integration tests for context persistence, progressive loading, keyboard flow, and batch confirmations.
+
+## Standard Stack
+
+### Core
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| FastAPI | `>=0.116,<1` | Queue HTML routes + detail/bulk action JSON endpoints | Existing admin web runtime and auth/CSRF flow |
+| SQLAlchemy async + PostgreSQL | `>=2.0.38,<3` | Fetch detail payload data and apply batch mutations transactionally | Existing ORM/session model and integration tests |
+| Vanilla JS in server-rendered HTML | browser baseline | Inline disclosure UI, section retries, keyboard and batch selection state | Matches existing dense-list interaction architecture |
+
+### Supporting
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| pytest + pytest-asyncio | repo standard | Unit/integration coverage for disclosure, keyboard, and bulk contracts | Required for DISC/KEYB/BULK regression protection |
+| Existing CSRF and RBAC helpers | repo standard | Guard all write actions and queue moderation operations | Required for bulk action safety |
+
+## Architecture Patterns
+
+### Pattern 1: Inline Detail Shell + Progressive Section Hydration
+**What:** Render an inline details row immediately, then fetch prioritized sections asynchronously.
+**Why:** Satisfies immediate visual feedback while keeping list responsive.
+
+### Pattern 2: URL-Stable Triage Context
+**What:** Preserve filter/density/page and open-row ids in query-compatible state so refresh/back returns to same triage surface.
+**Why:** Prevents operator disorientation and supports DISC-01.
+
+### Pattern 3: Shell-Scoped Keyboard and Selection Model
+**What:** Keep keyboard handlers and row-selection state scoped to one dense-list shell instance.
+**Why:** Avoids global hotkey collisions and makes behavior deterministic across queue pages.
+
+### Anti-Patterns to Avoid
+- Full-page navigation for row details (breaks in-place triage).
+- Nested disclosure stacks inside details (violates DISC-03).
+- Bulk actions without server-side CSRF/RBAC validation.
+- Single-shot detail load that fails all content on one section error.
+
+## Common Pitfalls
+
+### Pitfall 1: Expanded Rows Collapse on Any Interaction
+Persist expanded ids and focus target in script state and reapply after sort/filter/pager changes.
+
+### Pitfall 2: Keyboard Flow Hijacks Form Inputs
+Ignore shortcuts while focus is inside editable controls and require table-shell focus for navigation keys.
+
+### Pitfall 3: Partial Detail Failure Appears as Empty Panel
+Return per-section status (`ready`, `loading`, `error`) and render retry controls inline for failed sections.
+
+### Pitfall 4: Batch Actions Apply to Invisible or Stale Rows
+Server must validate selected ids against current queue scope and return rejected ids/causes.
+
+## Concrete File Targets
+
+- `app/web/dense_list.py`: disclosure, progressive section, keyboard, and bulk-selection client contract.
+- `app/web/main.py`: queue markup hooks and JSON endpoints for details and batch actions.
+- `tests/test_web_dense_list_contract.py`: contract coverage for data attributes and script behaviors.
+- `tests/integration/test_web_triage_interactions.py`: DB-backed regression tests for DISC/KEYB/BULK paths.
+
+## Validation Strategy
+
+- Unit/contract tests for script output containing required data hooks and confirmation prompts.
+- Integration tests for inline open/close context retention, progressive section retries, keyboard shortcuts, and bulk confirmation branches.
+- Security checks ensuring unauthorized bulk/detail actions fail with 401/403.
+
+## Metadata
+
+**Research date:** 2026-02-20
+**Valid until:** 2026-03-22

--- a/.planning/phases/03-in-place-triage-interactions/03-in-place-triage-interactions-03-SUMMARY.md
+++ b/.planning/phases/03-in-place-triage-interactions/03-in-place-triage-interactions-03-SUMMARY.md
@@ -1,0 +1,24 @@
+# Phase 3 - Execution Summary
+
+Completed Phase 3 implementation for in-place triage interactions with progressive inline details, keyboard-first navigation hooks, and queue-native bulk operations.
+
+## Delivered
+
+- Added inline detail row structure (`data-triage-row`, `data-triage-detail`) for complaints, signals, trade feedback, and appeals queues.
+- Extended dense-list toolbar and script with triage controls, section loading/retry behavior, keyboard shortcuts, and bulk action controls.
+- Added triage detail endpoint: `GET /actions/triage/detail-section` with queue/section validation and section-scoped responses.
+- Added bulk endpoint: `POST /actions/triage/bulk` with CSRF checks, destructive confirmation text gating, queue/action validation, and per-row results.
+- Added and expanded coverage in:
+  - `tests/test_web_dense_list_contract.py`
+  - `tests/integration/test_web_triage_interactions.py`
+
+## Notes
+
+- Destructive bulk actions (`dismiss`, `hide`, `reject`) require `CONFIRM` confirmation text.
+- Bulk responses return row-level `ok` status and next status when available, enabling mixed-result handling in-place.
+- Progressive section loading intentionally supports partial failure with retry affordance.
+
+## Verification
+
+- Local syntax validation completed via:
+  - `python -m py_compile app/web/main.py app/web/dense_list.py tests/test_web_dense_list_contract.py tests/integration/test_web_triage_interactions.py`

--- a/tests/integration/test_web_triage_interactions.py
+++ b/tests/integration/test_web_triage_interactions.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app.web.auth import AdminAuthContext
+from app.web.dense_list import DenseListConfig
+from app.web.main import (
+    action_triage_bulk,
+    action_triage_detail_section,
+    appeals,
+    complaints,
+    signals,
+    trade_feedback,
+)
+
+
+def _telegram_auth() -> AdminAuthContext:
+    return AdminAuthContext(
+        authorized=True,
+        via="telegram",
+        role="owner",
+        can_manage=True,
+        scopes=frozenset({"user:ban"}),
+        tg_user_id=900001,
+    )
+
+
+def _make_request(path: str = "/") -> Request:
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("utf-8"),
+        "query_string": b"",
+        "headers": [],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(scope, receive)
+
+
+def _make_json_request(path: str, payload: dict[str, object]) -> Request:
+    body = json.dumps(payload).encode("utf-8")
+    state = {"sent": False}
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("utf-8"),
+        "query_string": b"",
+        "headers": [(b"content-type", b"application/json")],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+
+    async def receive() -> dict[str, object]:
+        if not state["sent"]:
+            state["sent"] = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(scope, receive)
+
+
+class _SessionStub:
+    class _BeginCtx:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    async def execute(self, _stmt):
+        stmt_text = str(_stmt)
+
+        class _Rows:
+            def __init__(self, rows):
+                self._rows = rows
+
+            def all(self):
+                return list(self._rows)
+
+        if "trade_feedback" in stmt_text:
+            feedback = SimpleNamespace(
+                id=66,
+                status="VISIBLE",
+                rating=5,
+                comment="great",
+                moderation_note="",
+                created_at=None,
+                moderated_at=None,
+            )
+            auction = SimpleNamespace(id="00000000-0000-0000-0000-000000000066")
+            author = SimpleNamespace(tg_user_id=6001, username="alpha")
+            target = SimpleNamespace(tg_user_id=6002, username="beta")
+            return _Rows([(feedback, auction, author, target, None)])
+
+        if "appeals" in stmt_text:
+            appeal = SimpleNamespace(
+                id=77,
+                appeal_ref="risk_77",
+                source_type="risk",
+                source_id=9,
+                status="OPEN",
+                resolution_note="",
+                resolver_user_id=None,
+                created_at=None,
+                resolved_at=None,
+                sla_deadline_at=None,
+                escalated_at=None,
+                escalation_level=0,
+                priority_boosted_at=None,
+            )
+            appellant = SimpleNamespace(id=5, tg_user_id=5005, username="delta")
+            return _Rows([(appeal, appellant, None)])
+
+        return _Rows([])
+
+    async def scalar(self, _stmt):
+        return None
+
+    def begin(self):
+        return self._BeginCtx()
+
+
+class _SessionFactoryCtx:
+    async def __aenter__(self):
+        return _SessionStub()
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+def _stub_session_factory() -> _SessionFactoryCtx:
+    return _SessionFactoryCtx()
+
+
+def _dense_config(queue_key: str, table_id: str) -> DenseListConfig:
+    return DenseListConfig(
+        queue_key=queue_key,
+        density="compact",
+        table_id=table_id,
+        quick_filter_placeholder="filter",
+        columns_order=("id",),
+        columns_visible=("id",),
+        columns_pinned=(),
+        csrf_token="csrf",
+    )
+
+
+@pytest.mark.asyncio
+async def test_triage_markup_renders_for_primary_queues(monkeypatch) -> None:
+    async def _list_complaints(_session, **_kwargs):
+        return [
+            SimpleNamespace(
+                id=11,
+                auction_id=91,
+                reporter_user_id=333,
+                status="OPEN",
+                reason="duplicate",
+                created_at=None,
+            )
+        ]
+
+    async def _list_signals(_session, **_kwargs):
+        return [
+            SimpleNamespace(
+                id=12,
+                auction_id=92,
+                user_id=444,
+                score=8,
+                status="OPEN",
+                created_at=None,
+            )
+        ]
+
+    async def _dense(_session, *, queue_key, **_kwargs):
+        table = "complaints-table" if queue_key == "complaints" else "signals-table"
+        return _dense_config(queue_key, table)
+
+    async def _risk_map(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setattr("app.web.main._auth_context_or_unauthorized", lambda _req: (None, _telegram_auth()))
+    monkeypatch.setattr("app.web.main.SessionFactory", _stub_session_factory)
+    monkeypatch.setattr("app.web.main.list_complaints", _list_complaints)
+    monkeypatch.setattr("app.web.main.list_fraud_signals", _list_signals)
+    monkeypatch.setattr("app.web.main._load_dense_list_config", _dense)
+    monkeypatch.setattr("app.web.main._load_user_risk_snapshot_map", _risk_map)
+
+    complaints_body = bytes((await complaints(_make_request("/complaints"))).body).decode("utf-8")
+    signals_body = bytes((await signals(_make_request("/signals"))).body).decode("utf-8")
+
+    assert "data-triage-row='1'" in complaints_body
+    assert "data-triage-detail='11'" in complaints_body
+    assert "data-bulk-controls='complaints-table'" in complaints_body
+    assert "data-shortcut='row-next'" in complaints_body
+
+    assert "data-triage-row='1'" in signals_body
+    assert "data-triage-detail='12'" in signals_body
+    assert "data-bulk-controls='signals-table'" in signals_body
+
+
+@pytest.mark.asyncio
+async def test_triage_markup_renders_for_trade_feedback_and_appeals(monkeypatch) -> None:
+    async def _dense(_session, *, queue_key, **_kwargs):
+        table = "trade-feedback-table" if queue_key == "trade_feedback" else "appeals-table"
+        return _dense_config(queue_key, table)
+
+    monkeypatch.setattr("app.web.main._require_scope_permission", lambda _req, _scope: (None, _telegram_auth()))
+    monkeypatch.setattr("app.web.main._load_dense_list_config", _dense)
+    monkeypatch.setattr("app.web.main.SessionFactory", _stub_session_factory)
+    async def _risk_map(*_args, **_kwargs):
+        return {}
+
+    monkeypatch.setattr("app.web.main._load_user_risk_snapshot_map", _risk_map)
+
+    feedback_body = bytes((await trade_feedback(_make_request("/trade-feedback"))).body).decode("utf-8")
+    appeals_body = bytes((await appeals(_make_request("/appeals"))).body).decode("utf-8")
+
+    assert "data-triage-row='1'" in feedback_body
+    assert "data-bulk-controls='trade-feedback-table'" in feedback_body
+    assert "data-triage-row='1'" in appeals_body
+    assert "data-bulk-controls='appeals-table'" in appeals_body
+
+
+@pytest.mark.asyncio
+async def test_triage_detail_section_contract(monkeypatch) -> None:
+    monkeypatch.setattr("app.web.main._auth_context_or_unauthorized", lambda _req: (None, _telegram_auth()))
+
+    payload = await action_triage_detail_section(
+        _make_request("/actions/triage/detail-section"),
+        queue_key="complaints",
+        row_id=20,
+        section="primary",
+    )
+    assert payload["ok"] is True
+    assert "complaints #20" in payload["html"]
+
+    with pytest.raises(HTTPException):
+        await action_triage_detail_section(
+            _make_request("/actions/triage/detail-section"),
+            queue_key="unknown",
+            row_id=20,
+            section="primary",
+        )
+
+
+@pytest.mark.asyncio
+async def test_bulk_endpoint_requires_confirmation_for_destructive(monkeypatch) -> None:
+    monkeypatch.setattr("app.web.main.get_admin_auth_context", lambda _req: _telegram_auth())
+    monkeypatch.setattr("app.web.main._validate_csrf_token", lambda _req, _auth, _token: True)
+
+    with pytest.raises(HTTPException) as exc:
+        await action_triage_bulk(
+            _make_json_request(
+                "/actions/triage/bulk",
+                {
+                    "queue_key": "trade_feedback",
+                    "bulk_action": "hide",
+                    "selected_ids": [1, 2],
+                    "csrf_token": "ok",
+                    "confirm_text": "WRONG",
+                },
+            )
+        )
+
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_bulk_endpoint_returns_mixed_results(monkeypatch) -> None:
+    class _Result:
+        def __init__(self, *, ok: bool, message: str):
+            self.ok = ok
+            self.message = message
+
+    class _BulkSessionFactoryCtx:
+        async def __aenter__(self):
+            return _SessionStub()
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr("app.web.main.get_admin_auth_context", lambda _req: _telegram_auth())
+    monkeypatch.setattr("app.web.main._validate_csrf_token", lambda _req, _auth, _token: True)
+    async def _actor_id(_auth):
+        return 1
+
+    monkeypatch.setattr("app.web.main._resolve_actor_user_id", _actor_id)
+    monkeypatch.setattr("app.web.main.SessionFactory", lambda: _BulkSessionFactoryCtx())
+
+    async def _set_feedback_visibility(_session, *, feedback_id, **_kwargs):
+        if feedback_id == 1:
+            return _Result(ok=True, message="ok")
+        return _Result(ok=False, message="already hidden")
+
+    monkeypatch.setattr("app.web.main.set_trade_feedback_visibility", _set_feedback_visibility)
+
+    payload = await action_triage_bulk(
+        _make_json_request(
+            "/actions/triage/bulk",
+            {
+                "queue_key": "trade_feedback",
+                "bulk_action": "hide",
+                "selected_ids": [1, 2],
+                "csrf_token": "ok",
+                "confirm_text": "CONFIRM",
+                "reason": "bulk",
+            },
+        )
+    )
+
+    assert payload["ok"] is True
+    assert payload["results"][0]["ok"] is True
+    assert payload["results"][1]["ok"] is False

--- a/tests/test_web_dense_list_contract.py
+++ b/tests/test_web_dense_list_contract.py
@@ -153,3 +153,39 @@ def test_dense_list_contract_renders_preset_controls_when_enabled() -> None:
     assert "action:'save'" in script_html
     assert "action:'delete'" in script_html
     assert "You have unsaved changes. Switch preset?" in script_html
+
+
+def test_dense_list_contract_renders_bulk_controls_for_triage_queues() -> None:
+    config = DenseListConfig(
+        queue_key="appeals",
+        density="compact",
+        table_id="appeals-table",
+        quick_filter_placeholder="id / ref",
+        csrf_token="csrf-token",
+    )
+
+    toolbar_html = render_dense_list_toolbar(config, density_query_builder=_density_path)
+    script_html = render_dense_list_script(config)
+
+    assert "data-bulk-controls='appeals-table'" in toolbar_html
+    assert "data-bulk-action='appeals-table'" in toolbar_html
+    assert "data-bulk-execute='appeals-table'" in toolbar_html
+    assert "data-triage-row=\"1\"" in script_html
+    assert "data-detail-section='primary'" in script_html
+    assert "destructiveActions" in script_html
+
+
+def test_dense_list_contract_contains_keyboard_shortcuts_contract() -> None:
+    config = DenseListConfig(
+        queue_key="signals",
+        density="standard",
+        table_id="signals-table",
+        quick_filter_placeholder="id / user",
+    )
+
+    script_html = render_dense_list_script(config)
+
+    assert "event.key==='/'" in script_html
+    assert "event.key==='j'" in script_html
+    assert "event.key==='k'" in script_html
+    assert "event.key==='o'||event.key==='Enter'" in script_html


### PR DESCRIPTION
## Summary
- add in-place disclosure rows for complaints, signals, trade feedback, and appeals queues so operators can inspect details without losing list position
- introduce progressive detail section loading and retry flow plus keyboard-first triage hooks (`/`, `j`, `k`, `o`/`Enter`) and multi-row context-preserving behavior
- add queue-safe bulk triage endpoint with CSRF validation, destructive confirmation gating, and mixed-result responses; extend contract + integration tests and phase artifacts

## Validation
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m pytest -q tests`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:5432/auction_test .venv/bin/python -m pytest -q tests/integration`

## Rollout / Rollback
- Rollout: deploy web admin update; triage controls are queue-scoped and permission-checked
- Rollback: revert this PR to restore pre-triage queue behavior

Closes #212