### PR TITLE
[Sprint 52] S52-003 preset telemetry capture and aggregation

### DIFF
--- a/alembic/versions/0038_workflow_preset_telemetry.py
+++ b/alembic/versions/0038_workflow_preset_telemetry.py
@@ -1,0 +1,150 @@
+"""add workflow preset telemetry events
+
+Revision ID: 0038_workflow_preset_telemetry
+Revises: 0037_workflow_presets
+Create Date: 2026-02-20 11:05:00
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0038_workflow_preset_telemetry"
+down_revision: str | None = "0037_workflow_presets"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not inspector.has_table("admin_queue_preset_telemetry_events"):
+        op.create_table(
+            "admin_queue_preset_telemetry_events",
+            sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+            sa.Column("queue_context", sa.String(length=32), nullable=False),
+            sa.Column("queue_key", sa.String(length=32), nullable=False),
+            sa.Column("preset_id", sa.BigInteger(), nullable=True),
+            sa.Column("action", sa.String(length=32), nullable=False),
+            sa.Column("actor_subject_key", sa.String(length=128), nullable=False),
+            sa.Column("time_to_action_ms", sa.Integer(), nullable=True),
+            sa.Column("reopen_signal", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+            sa.Column("filter_churn_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("TIMEZONE('utc', NOW())"),
+                nullable=False,
+            ),
+            sa.CheckConstraint(
+                "queue_context IN ('moderation', 'appeals', 'risk', 'feedback')",
+                name="ck_admin_queue_preset_telemetry_events_admin_queue_preset_telemetry_events_queue_context_values",
+            ),
+            sa.CheckConstraint(
+                "queue_key IN ('complaints', 'appeals', 'signals', 'trade_feedback')",
+                name="ck_admin_queue_preset_telemetry_events_admin_queue_preset_telemetry_events_queue_key_values",
+            ),
+            sa.CheckConstraint(
+                "action IN ('save', 'update', 'select', 'delete', 'set_default')",
+                name="ck_admin_queue_preset_telemetry_events_admin_queue_preset_telemetry_events_action_values",
+            ),
+            sa.CheckConstraint(
+                "time_to_action_ms IS NULL OR (time_to_action_ms >= 0 AND time_to_action_ms <= 86400000)",
+                name="ck_admin_queue_preset_telemetry_events_admin_queue_preset_telemetry_events_time_to_action_ms_bounds",
+            ),
+            sa.CheckConstraint(
+                "filter_churn_count >= 0 AND filter_churn_count <= 1000",
+                name="ck_admin_queue_preset_telemetry_events_admin_queue_preset_telemetry_events_filter_churn_count_bounds",
+            ),
+            sa.PrimaryKeyConstraint("id", name="pk_admin_queue_preset_telemetry_events"),
+        )
+
+    index_names = {
+        index["name"] for index in inspector.get_indexes("admin_queue_preset_telemetry_events")
+    }
+    if "ix_admin_queue_preset_telemetry_events_queue_context" not in index_names:
+        op.create_index(
+            "ix_admin_queue_preset_telemetry_events_queue_context",
+            "admin_queue_preset_telemetry_events",
+            ["queue_context"],
+            unique=False,
+        )
+    if "ix_admin_queue_preset_telemetry_events_queue_key" not in index_names:
+        op.create_index(
+            "ix_admin_queue_preset_telemetry_events_queue_key",
+            "admin_queue_preset_telemetry_events",
+            ["queue_key"],
+            unique=False,
+        )
+    if "ix_admin_queue_preset_telemetry_events_preset_id" not in index_names:
+        op.create_index(
+            "ix_admin_queue_preset_telemetry_events_preset_id",
+            "admin_queue_preset_telemetry_events",
+            ["preset_id"],
+            unique=False,
+        )
+    if "ix_admin_queue_preset_telemetry_events_action" not in index_names:
+        op.create_index(
+            "ix_admin_queue_preset_telemetry_events_action",
+            "admin_queue_preset_telemetry_events",
+            ["action"],
+            unique=False,
+        )
+    if "ix_admin_queue_preset_telemetry_events_created_at" not in index_names:
+        op.create_index(
+            "ix_admin_queue_preset_telemetry_events_created_at",
+            "admin_queue_preset_telemetry_events",
+            ["created_at"],
+            unique=False,
+        )
+    if "ix_admin_queue_preset_telemetry_events_queue_preset_created" not in index_names:
+        op.create_index(
+            "ix_admin_queue_preset_telemetry_events_queue_preset_created",
+            "admin_queue_preset_telemetry_events",
+            ["queue_key", "preset_id", "created_at"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if inspector.has_table("admin_queue_preset_telemetry_events"):
+        index_names = {
+            index["name"] for index in inspector.get_indexes("admin_queue_preset_telemetry_events")
+        }
+        if "ix_admin_queue_preset_telemetry_events_queue_preset_created" in index_names:
+            op.drop_index(
+                "ix_admin_queue_preset_telemetry_events_queue_preset_created",
+                table_name="admin_queue_preset_telemetry_events",
+            )
+        if "ix_admin_queue_preset_telemetry_events_created_at" in index_names:
+            op.drop_index(
+                "ix_admin_queue_preset_telemetry_events_created_at",
+                table_name="admin_queue_preset_telemetry_events",
+            )
+        if "ix_admin_queue_preset_telemetry_events_action" in index_names:
+            op.drop_index(
+                "ix_admin_queue_preset_telemetry_events_action",
+                table_name="admin_queue_preset_telemetry_events",
+            )
+        if "ix_admin_queue_preset_telemetry_events_preset_id" in index_names:
+            op.drop_index(
+                "ix_admin_queue_preset_telemetry_events_preset_id",
+                table_name="admin_queue_preset_telemetry_events",
+            )
+        if "ix_admin_queue_preset_telemetry_events_queue_key" in index_names:
+            op.drop_index(
+                "ix_admin_queue_preset_telemetry_events_queue_key",
+                table_name="admin_queue_preset_telemetry_events",
+            )
+        if "ix_admin_queue_preset_telemetry_events_queue_context" in index_names:
+            op.drop_index(
+                "ix_admin_queue_preset_telemetry_events_queue_context",
+                table_name="admin_queue_preset_telemetry_events",
+            )
+        op.drop_table("admin_queue_preset_telemetry_events")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -546,6 +546,58 @@ class AdminQueuePresetDefault(Base, TimestampMixin):
     )
 
 
+class AdminQueuePresetTelemetryEvent(Base):
+    __tablename__ = "admin_queue_preset_telemetry_events"
+    __table_args__ = (
+        CheckConstraint(
+            "queue_context IN ('moderation', 'appeals', 'risk', 'feedback')",
+            name="admin_queue_preset_telemetry_events_queue_context_values",
+        ),
+        CheckConstraint(
+            "queue_key IN ('complaints', 'appeals', 'signals', 'trade_feedback')",
+            name="admin_queue_preset_telemetry_events_queue_key_values",
+        ),
+        CheckConstraint(
+            "action IN ('save', 'update', 'select', 'delete', 'set_default')",
+            name="admin_queue_preset_telemetry_events_action_values",
+        ),
+        CheckConstraint(
+            "time_to_action_ms IS NULL OR (time_to_action_ms >= 0 AND time_to_action_ms <= 86400000)",
+            name="admin_queue_preset_telemetry_events_time_to_action_ms_bounds",
+        ),
+        CheckConstraint(
+            "filter_churn_count >= 0 AND filter_churn_count <= 1000",
+            name="admin_queue_preset_telemetry_events_filter_churn_count_bounds",
+        ),
+        Index("ix_admin_queue_preset_telemetry_events_queue_context", "queue_context"),
+        Index("ix_admin_queue_preset_telemetry_events_queue_key", "queue_key"),
+        Index("ix_admin_queue_preset_telemetry_events_preset_id", "preset_id"),
+        Index("ix_admin_queue_preset_telemetry_events_action", "action"),
+        Index("ix_admin_queue_preset_telemetry_events_created_at", "created_at"),
+        Index(
+            "ix_admin_queue_preset_telemetry_events_queue_preset_created",
+            "queue_key",
+            "preset_id",
+            "created_at",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    queue_context: Mapped[str] = mapped_column(String(32), nullable=False)
+    queue_key: Mapped[str] = mapped_column(String(32), nullable=False)
+    preset_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    action: Mapped[str] = mapped_column(String(32), nullable=False)
+    actor_subject_key: Mapped[str] = mapped_column(String(128), nullable=False)
+    time_to_action_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    reopen_signal: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
+    filter_churn_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=text("TIMEZONE('utc', NOW())"),
+        nullable=False,
+    )
+
+
 class ModerationChecklistItem(Base, TimestampMixin):
     __tablename__ = "moderation_checklist_items"
     __table_args__ = (

--- a/app/services/admin_queue_preset_telemetry_service.py
+++ b/app/services/admin_queue_preset_telemetry_service.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import AdminQueuePresetTelemetryEvent
+from app.services.admin_list_preferences_service import _normalize_subject_key
+from app.web.auth import AdminAuthContext
+
+QUEUE_CONTEXT_TO_QUEUE_KEY = {
+    "moderation": "complaints",
+    "appeals": "appeals",
+    "risk": "signals",
+    "feedback": "trade_feedback",
+}
+_ALLOWED_ACTIONS = frozenset({"save", "update", "select", "delete", "set_default"})
+
+
+def _normalize_queue_context(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized not in QUEUE_CONTEXT_TO_QUEUE_KEY:
+        raise ValueError("Unknown queue context")
+    return normalized
+
+
+def _normalize_action(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized not in _ALLOWED_ACTIONS:
+        raise ValueError("Unknown workflow preset action")
+    return normalized
+
+
+def _normalize_optional_non_negative_int(
+    value: Any,
+    *,
+    maximum: int,
+) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0:
+        return None
+    return min(parsed, maximum)
+
+
+def _normalize_non_negative_int(value: Any, *, maximum: int, default: int = 0) -> int:
+    parsed = _normalize_optional_non_negative_int(value, maximum=maximum)
+    if parsed is None:
+        return default
+    return parsed
+
+
+def _normalize_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def _normalize_preset_id(value: Any) -> int | None:
+    parsed = _normalize_optional_non_negative_int(value, maximum=2_147_483_647)
+    if parsed is None or parsed <= 0:
+        return None
+    return parsed
+
+
+async def record_workflow_preset_telemetry_event(
+    session: AsyncSession,
+    *,
+    auth: AdminAuthContext,
+    queue_context: str,
+    action: str,
+    preset_id: Any = None,
+    time_to_action_ms: Any = None,
+    reopen_signal: Any = None,
+    filter_churn_count: Any = None,
+    admin_token: str | None = None,
+) -> None:
+    normalized_context = _normalize_queue_context(queue_context)
+    normalized_action = _normalize_action(action)
+    subject_key = _normalize_subject_key(auth=auth, admin_token=admin_token)
+
+    event = AdminQueuePresetTelemetryEvent(
+        queue_context=normalized_context,
+        queue_key=QUEUE_CONTEXT_TO_QUEUE_KEY[normalized_context],
+        preset_id=_normalize_preset_id(preset_id),
+        action=normalized_action,
+        actor_subject_key=subject_key,
+        time_to_action_ms=_normalize_optional_non_negative_int(time_to_action_ms, maximum=86_400_000),
+        reopen_signal=_normalize_bool(reopen_signal),
+        filter_churn_count=_normalize_non_negative_int(filter_churn_count, maximum=1000, default=0),
+    )
+    session.add(event)
+
+
+async def load_workflow_preset_telemetry_segments(
+    session: AsyncSession,
+    *,
+    queue_context: str | None = None,
+    lookback_hours: int = 24 * 7,
+) -> list[dict[str, Any]]:
+    now = datetime.now(UTC)
+    window_start = now - timedelta(hours=max(int(lookback_hours), 1))
+
+    stmt = (
+        select(
+            AdminQueuePresetTelemetryEvent.queue_context,
+            AdminQueuePresetTelemetryEvent.queue_key,
+            AdminQueuePresetTelemetryEvent.preset_id,
+            func.count(AdminQueuePresetTelemetryEvent.id).label("events_total"),
+            func.avg(AdminQueuePresetTelemetryEvent.time_to_action_ms).label("avg_time_to_action_ms"),
+            func.avg(AdminQueuePresetTelemetryEvent.filter_churn_count).label("avg_filter_churn_count"),
+            func.sum(
+                case(
+                    (AdminQueuePresetTelemetryEvent.reopen_signal.is_(True), 1),
+                    else_=0,
+                )
+            ).label("reopen_total"),
+        )
+        .where(AdminQueuePresetTelemetryEvent.created_at >= window_start)
+        .group_by(
+            AdminQueuePresetTelemetryEvent.queue_context,
+            AdminQueuePresetTelemetryEvent.queue_key,
+            AdminQueuePresetTelemetryEvent.preset_id,
+        )
+        .order_by(
+            func.count(AdminQueuePresetTelemetryEvent.id).desc(),
+            AdminQueuePresetTelemetryEvent.queue_key.asc(),
+            AdminQueuePresetTelemetryEvent.preset_id.asc().nullsfirst(),
+        )
+    )
+
+    if queue_context is not None:
+        stmt = stmt.where(AdminQueuePresetTelemetryEvent.queue_context == _normalize_queue_context(queue_context))
+
+    rows = (await session.execute(stmt)).all()
+    segments: list[dict[str, Any]] = []
+    for row in rows:
+        events_total = int(row.events_total or 0)
+        reopen_total = int(row.reopen_total or 0)
+        reopen_rate = float(reopen_total / events_total) if events_total > 0 else 0.0
+        segments.append(
+            {
+                "queue_context": str(row.queue_context),
+                "queue_key": str(row.queue_key),
+                "preset_id": int(row.preset_id) if row.preset_id is not None else None,
+                "events_total": events_total,
+                "avg_time_to_action_ms": float(row.avg_time_to_action_ms) if row.avg_time_to_action_ms is not None else None,
+                "avg_filter_churn_count": float(row.avg_filter_churn_count) if row.avg_filter_churn_count is not None else 0.0,
+                "reopen_total": reopen_total,
+                "reopen_rate": reopen_rate,
+            }
+        )
+    return segments

--- a/tests/test_admin_queue_preset_telemetry_service.py
+++ b/tests/test_admin_queue_preset_telemetry_service.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.admin_queue_preset_telemetry_service import (
+    load_workflow_preset_telemetry_segments,
+    record_workflow_preset_telemetry_event,
+)
+from app.web.auth import AdminAuthContext
+
+
+def _auth() -> AdminAuthContext:
+    return AdminAuthContext(
+        authorized=True,
+        via="telegram",
+        role="owner",
+        can_manage=True,
+        scopes=frozenset({"user:ban"}),
+        tg_user_id=900001,
+    )
+
+
+class _RecordingSession:
+    def __init__(self) -> None:
+        self.added: list[object] = []
+
+    def add(self, value: object) -> None:
+        self.added.append(value)
+
+
+@pytest.mark.asyncio
+async def test_record_workflow_preset_telemetry_normalizes_values() -> None:
+    session = _RecordingSession()
+
+    await record_workflow_preset_telemetry_event(
+        session,  # type: ignore[arg-type]
+        auth=_auth(),
+        queue_context="moderation",
+        action="select",
+        preset_id="42",
+        time_to_action_ms="1250",
+        reopen_signal="true",
+        filter_churn_count="7",
+    )
+
+    assert len(session.added) == 1
+    event = session.added[0]
+    assert getattr(event, "queue_context") == "moderation"
+    assert getattr(event, "queue_key") == "complaints"
+    assert getattr(event, "action") == "select"
+    assert getattr(event, "preset_id") == 42
+    assert getattr(event, "time_to_action_ms") == 1250
+    assert getattr(event, "reopen_signal") is True
+    assert getattr(event, "filter_churn_count") == 7
+
+
+class _SegmentsResult:
+    def __init__(self, rows: list[object]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[object]:
+        return list(self._rows)
+
+
+class _SegmentsSession:
+    def __init__(self, rows: list[object]) -> None:
+        self._rows = rows
+
+    async def execute(self, _stmt):
+        return _SegmentsResult(self._rows)
+
+
+@pytest.mark.asyncio
+async def test_load_workflow_preset_telemetry_segments_computes_rates() -> None:
+    rows = [
+        SimpleNamespace(
+            queue_context="moderation",
+            queue_key="complaints",
+            preset_id=11,
+            events_total=10,
+            avg_time_to_action_ms=820.0,
+            avg_filter_churn_count=2.5,
+            reopen_total=4,
+        ),
+        SimpleNamespace(
+            queue_context="appeals",
+            queue_key="appeals",
+            preset_id=None,
+            events_total=3,
+            avg_time_to_action_ms=None,
+            avg_filter_churn_count=0.0,
+            reopen_total=0,
+        ),
+    ]
+
+    segments = await load_workflow_preset_telemetry_segments(
+        _SegmentsSession(rows),  # type: ignore[arg-type]
+        lookback_hours=24,
+    )
+
+    assert len(segments) == 2
+    assert segments[0]["queue_key"] == "complaints"
+    assert segments[0]["preset_id"] == 11
+    assert segments[0]["events_total"] == 10
+    assert segments[0]["avg_time_to_action_ms"] == 820.0
+    assert segments[0]["reopen_rate"] == 0.4
+    assert segments[1]["preset_id"] is None
+    assert segments[1]["avg_time_to_action_ms"] is None
+
+
+@pytest.mark.asyncio
+async def test_load_workflow_preset_telemetry_segments_rejects_invalid_context() -> None:
+    with pytest.raises(ValueError):
+        await load_workflow_preset_telemetry_segments(
+            _SegmentsSession([]),  # type: ignore[arg-type]
+            queue_context="unknown",
+            lookback_hours=24,
+        )


### PR DESCRIPTION
## Summary
- add persistent workflow preset telemetry events (migration + model) for queue/preset/action context
- capture telemetry after successful preset mutations only, including time-to-action, reopen signal, and filter churn metrics
- add telemetry aggregation endpoint segmented by queue and preset for operations consumption
- add service/unit/integration coverage for telemetry recording, exclusion paths, and segmentation output

## Validation
- `.venv/bin/python -m ruff check alembic/versions/0038_workflow_preset_telemetry.py app/db/models.py app/services/admin_queue_preset_telemetry_service.py app/web/main.py tests/test_admin_queue_preset_telemetry_service.py tests/integration/test_web_workflow_presets.py`
- `.venv/bin/python -m pytest -q tests/test_admin_queue_preset_telemetry_service.py`
- `RUN_INTEGRATION_TESTS=1 .venv/bin/python -m pytest -q tests/integration/test_web_workflow_presets.py`

Closes #222