### PR TITLE
[Sprint 52][S52-007] Verify v1.1 coverage and define follow-up scope

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -7,24 +7,24 @@
 
 ### Adaptive Detail Depth
 
-- [ ] **ADPT-01**: Operator detail depth adapts by risk and priority rules while keeping predictable navigation.
-- [ ] **ADPT-02**: Adaptive behavior is transparent with a visible reason code and deterministic fallback.
-- [ ] **ADPT-03**: Operators can override adaptive depth per row without losing queue context.
+- [x] **ADPT-01**: Operator detail depth adapts by risk and priority rules while keeping predictable navigation.
+- [x] **ADPT-02**: Adaptive behavior is transparent with a visible reason code and deterministic fallback.
+- [x] **ADPT-03**: Operators can override adaptive depth per row without losing queue context.
 
 ### Preset Telemetry
 
-- [ ] **TELE-01**: Product team can review preset quality telemetry for time-to-action, reopen rate, and filter churn.
+- [x] **TELE-01**: Product team can review preset quality telemetry for time-to-action, reopen rate, and filter churn.
 - [ ] **TELE-02**: Telemetry sampling excludes unauthorized and failed actions to avoid misleading quality signals.
-- [ ] **TELE-03**: Telemetry export supports queue and preset segmentation for weekly operations review.
+- [x] **TELE-03**: Telemetry export supports queue and preset segmentation for weekly operations review.
 
 ### Guardrails and Safety
 
-- [ ] **SAFE-01**: RBAC and CSRF protections remain enforced for all adaptive and telemetry endpoints.
-- [ ] **SAFE-02**: Adaptive defaults are bounded to prevent high-risk auto-expansion churn in dense queues.
+- [x] **SAFE-01**: RBAC and CSRF protections remain enforced for all adaptive and telemetry endpoints.
+- [x] **SAFE-02**: Adaptive defaults are bounded to prevent high-risk auto-expansion churn in dense queues.
 
 ### Verification
 
-- [ ] **TEST-11**: Automated tests cover adaptive rule selection, override behavior, and fallback handling.
+- [x] **TEST-11**: Automated tests cover adaptive rule selection, override behavior, and fallback handling.
 - [ ] **TEST-12**: Integration tests cover telemetry event ingestion and scoped aggregation outputs.
 
 ## Out of Scope
@@ -35,20 +35,20 @@
 | Cross-product analytics warehouse | Too broad for v1.1 delivery window |
 | New non-Telegram operator channels | Outside current product strategy |
 
-## Traceability (Planned)
+## Traceability (Verification)
 
 | Requirement | Planned Phase | Status |
 |-------------|---------------|--------|
-| ADPT-01 | Phase 1 | Planned |
-| ADPT-02 | Phase 1 | Planned |
-| ADPT-03 | Phase 2 | Planned |
-| TELE-01 | Phase 2 | Planned |
-| TELE-02 | Phase 2 | Planned |
-| TELE-03 | Phase 3 | Planned |
-| SAFE-01 | Phase 3 | Planned |
-| SAFE-02 | Phase 1 | Planned |
-| TEST-11 | Phase 3 | Planned |
-| TEST-12 | Phase 3 | Planned |
+| ADPT-01 | Phase 1 | Verified (Met) |
+| ADPT-02 | Phase 1 | Verified (Met) |
+| ADPT-03 | Phase 2 | Verified (Met) |
+| TELE-01 | Phase 2 | Verified (Met) |
+| TELE-02 | Phase 2 | Verified (Partial) |
+| TELE-03 | Phase 3 | Verified (Met) |
+| SAFE-01 | Phase 3 | Verified (Met) |
+| SAFE-02 | Phase 1 | Verified (Met) |
+| TEST-11 | Phase 3 | Verified (Met) |
+| TEST-12 | Phase 3 | Verified (Partial) |
 
 ---
-*Last updated: 2026-02-20 for v1.1 kickoff*
+*Last updated: 2026-02-20 after v1.1 verification pass (8 met, 2 partial)*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -3,10 +3,10 @@
 ## Milestones
 
 - ✅ **v1.0 Operator UX** - shipped 2026-02-20 (Phases 1-3, 10 plans) -> `.planning/milestones/v1.0-ROADMAP.md`
-- 🚧 **v1.1 Adaptive Triage Intelligence** - in planning (Phases 1-3, kickoff Sprint 52)
+- 🚧 **v1.1 Adaptive Triage Intelligence** - verification in progress (8/10 requirements met, 2 follow-up items)
 
 ## Next
 
-- Start Phase 1 for adaptive detail depth policy and deterministic fallback behavior.
-- Start Phase 2 for preset telemetry capture and scoped aggregation.
-- Lock Phase 3 safety validation with RBAC/CSRF and integration coverage.
+- Close follow-up for `TELE-02`: exclude failed business outcomes from telemetry sampling, not only auth/validation failures.
+- Close follow-up for `TEST-12`: add DB-backed integration coverage for telemetry ingestion and scoped aggregation.
+- Run verification refresh and close v1.1 after both follow-up outcomes are complete.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,16 +5,16 @@
 See: `.planning/PROJECT.md` (updated 2026-02-20)
 
 **Core value:** Run trustworthy Telegram auctions end-to-end with fast operator intervention and clear auditability.
-**Current focus:** Kick off milestone v1.1 planning and sprint issue scaffolds
+**Current focus:** Verify v1.1 outcomes and prepare follow-up scope for remaining gaps
 
 ## Current Position
 
-Phase: Milestone planning (v1.1)
-Plan: Sprint 52 manifest kickoff
-Status: v1.1 scoped and ready for issue execution
-Last activity: 2026-02-20 - created fresh v1.1 requirements/roadmap and sprint planning manifest
+Phase: Milestone verification (v1.1)
+Plan: Goal-backward validation after Sprint 52 delivery
+Status: v1.1 partially verified (8 met, 2 follow-up)
+Last activity: 2026-02-20 - wrote `.planning/verification/v1.1/VERIFICATION.md` and synced requirement status
 
-Progress: [███░░░░░░░] 30%
+Progress: [████████░░] 80%
 
 ## Performance Metrics
 
@@ -49,8 +49,9 @@ Recent decisions affecting current work:
 
 ### Pending Todos
 
-- Execute Sprint 52 items and keep issue/PR traceability current.
-- Run sprint sync after manifest changes to refresh `planning/STATUS.md`.
+- Close follow-up scope for `TELE-02` failed-action telemetry exclusion.
+- Add DB-backed integration coverage for `TEST-12` telemetry ingestion and aggregation path.
+- Re-run v1.1 verification and decide milestone closeout.
 
 ### Blockers/Concerns
 
@@ -58,6 +59,6 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-02-20 09:09 UTC
-Stopped at: Initialized v1.1 milestone scaffolding and queued Sprint 52 sync
-Resume file: `planning/sprints/sprint-52.toml`
+Last session: 2026-02-20 12:17 UTC
+Stopped at: Completed v1.1 verification report; identified 2 follow-up outcomes before closeout
+Resume file: `.planning/verification/v1.1/VERIFICATION.md`

--- a/.planning/verification/v1.1/VERIFICATION.md
+++ b/.planning/verification/v1.1/VERIFICATION.md
@@ -1,0 +1,56 @@
+# v1.1 Goal-Backward Verification (Outcome-Focused)
+
+Date: 2026-02-20
+Scope reviewed: `ADPT-01..03`, `TELE-01..03`, `SAFE-01..02`, `TEST-11..12`
+
+## Requirement Verdicts
+
+| Requirement | Verdict | Evidence (code/tests/docs) | Risks / Gaps |
+| --- | --- | --- | --- |
+| ADPT-01 | **Met** | Adaptive policy is rule-based by queue/risk/priority in `app/services/adaptive_triage_policy_service.py:53` and consumed by adaptive endpoint `app/web/main.py:4210`; predictable keyboard/focus flow exists in `app/web/dense_list.py:618` and `app/web/dense_list.py:655`; tests: `test_risk_rule_auto_expands_for_complaints_queue`, `test_priority_rule_auto_expands_for_complaints_queue`, `test_triage_markup_includes_keyboard_focus_and_scroll_hooks` | Navigation behavior is validated mostly via HTML/script contract tests, not browser-level runtime execution. |
+| ADPT-02 | **Met** | Visible reason code/fallback is returned by API metadata in `app/web/main.py:4217` and rendered in UI text `app/web/dense_list.py:403`; deterministic fallback logic in `app/services/adaptive_triage_policy_service.py:166`; tests: `test_unknown_queue_uses_fallback_default_reason`, `test_invalid_tokens_record_fallback_notes`, `test_triage_detail_section_reports_fallback_for_invalid_tokens` | None blocking. |
+| ADPT-03 | **Met** | Per-row override controls and request wiring in `app/web/dense_list.py:351`, `app/web/dense_list.py:594`, `app/web/dense_list.py:605`; row context continuity logic (focus/scroll/filter state) in `app/web/dense_list.py:300`, `app/web/dense_list.py:327`, `app/web/dense_list.py:443`; tests: `test_dense_list_contract_includes_adaptive_depth_override_controls`, `test_triage_detail_section_honors_operator_override` | Continuity is inferred from script paths/tests; no end-to-end browser assertion in repo. |
+| TELE-01 | **Met** | Telemetry event model includes time/reopen/churn fields in `app/db/models.py:591`; aggregation computes avg time/reopen rate/churn in `app/services/admin_queue_preset_telemetry_service.py:115`; telemetry panel renders all three metrics in `app/web/main.py:979`; tests: `test_load_workflow_preset_telemetry_segments_computes_rates`, `test_queue_routes_render_preset_controls_for_required_contexts` | None blocking. |
+| TELE-02 | **Partially Met** | Unauthorized/invalid paths are excluded before recording in `app/web/main.py:4030`, `app/web/main.py:4042`, `app/web/main.py:4130`; tests: `test_workflow_presets_action_rejects_unauthorized_before_telemetry`, `test_workflow_presets_action_rejects_csrf_before_telemetry`, `test_workflow_presets_action_does_not_record_telemetry_on_invalid_action` | Telemetry recording is unconditional after action handler result (`app/web/main.py:4142`), so non-success business outcomes (for example conflict-style `ok: false` results) can still be sampled; requirement asks to exclude failed actions. |
+| TELE-03 | **Met** | Export endpoint returns segmented JSON with queue filter and preset grouping: `app/web/main.py:4154`, `app/services/admin_queue_preset_telemetry_service.py:116`, `app/services/admin_queue_preset_telemetry_service.py:133`; UI supports queue/preset filtering in `app/web/main.py:893`; tests: `test_workflow_presets_telemetry_endpoint_returns_segments`, `test_trade_feedback_telemetry_filter_preserves_queue_context` | Export format is JSON only (no CSV artifact), but requirement did not mandate file format. |
+| SAFE-01 | **Met** | CSRF validation on mutating adaptive/telemetry endpoints: `app/web/main.py:4042` (`/actions/workflow-presets`) and `app/web/main.py:4263` (`/actions/triage/bulk`); RBAC/scope checks on telemetry read and sensitive queues: `app/web/main.py:4160`, `app/web/main.py:4207`, `app/web/main.py:4290`; tests: `test_workflow_presets_telemetry_endpoint_requires_scope`, `test_bulk_endpoint_rejects_forbidden_scope_without_mutation`, `test_bulk_endpoint_rejects_csrf_without_mutation` | Read-only GET endpoints rely on auth/scope (not CSRF), which is standard but should remain explicit in security docs. |
+| SAFE-02 | **Met** | Depth outputs are bounded to two values in `app/services/adaptive_triage_policy_service.py:7`; safe default/fallback prevents unintended expansion `app/services/adaptive_triage_policy_service.py:51`, `app/services/adaptive_triage_policy_service.py:166`; docs define bounded model `docs/planning/sprint-52-adaptive-detail-depth-policy-contract.md:7`; tests: `test_policy_surface_is_bounded_to_inline_summary_and_full`, `test_trade_feedback_requires_critical_risk_or_urgent_priority_for_auto_expand` | None blocking. |
+| TEST-11 | **Met** | Automated tests cover selection/override/fallback in `tests/test_adaptive_triage_policy_service.py:20`, `tests/test_adaptive_triage_policy_service.py:79`, `tests/integration/test_web_triage_interactions.py:330`, `tests/integration/test_web_triage_interactions.py:369` | Test execution was not run in this environment (`pytest` module unavailable), so status is based on code-level coverage presence. |
+| TEST-12 | **Partially Met** | Integration test file exists for telemetry flows: `tests/integration/test_web_workflow_presets.py:297`, `tests/integration/test_web_workflow_presets.py:433`; aggregation service unit coverage exists in `tests/test_admin_queue_preset_telemetry_service.py:76` | Current integration tests heavily monkeypatch telemetry write/read paths, so they do not verify DB-backed ingestion + scoped aggregation end-to-end. |
+
+## Outcome Summary
+
+- **Met:** 8
+- **Partially Met:** 2 (`TELE-02`, `TEST-12`)
+- **Not Met:** 0
+
+## Final Recommendation
+
+**Need follow-up scope**
+
+Rationale:
+- v1.1 core adaptive triage and telemetry outcomes are largely implemented and wired.
+- Two outcome gaps remain: strict failed-action exclusion semantics in telemetry sampling and true integration coverage for telemetry ingestion/aggregation against the database.
+
+## Suggested Checkbox Updates for `.planning/REQUIREMENTS.md`
+
+Mark as complete:
+
+- `- [x] **ADPT-01**: Operator detail depth adapts by risk and priority rules while keeping predictable navigation.`
+- `- [x] **ADPT-02**: Adaptive behavior is transparent with a visible reason code and deterministic fallback.`
+- `- [x] **ADPT-03**: Operators can override adaptive depth per row without losing queue context.`
+- `- [x] **TELE-01**: Product team can review preset quality telemetry for time-to-action, reopen rate, and filter churn.`
+- `- [x] **TELE-03**: Telemetry export supports queue and preset segmentation for weekly operations review.`
+- `- [x] **SAFE-01**: RBAC and CSRF protections remain enforced for all adaptive and telemetry endpoints.`
+- `- [x] **SAFE-02**: Adaptive defaults are bounded to prevent high-risk auto-expansion churn in dense queues.`
+- `- [x] **TEST-11**: Automated tests cover adaptive rule selection, override behavior, and fallback handling.`
+
+Leave unchecked for follow-up:
+
+- `- [ ] **TELE-02**: Telemetry sampling excludes unauthorized and failed actions to avoid misleading quality signals.`
+- `- [ ] **TEST-12**: Integration tests cover telemetry event ingestion and scoped aggregation outputs.`
+
+## Verification Notes
+
+- Verification is based on repository source/tests/docs inspection (goal-backward), not summary claims.
+- Attempted targeted test execution, but this environment currently lacks `pytest` (`No module named pytest`).

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -1,6 +1,6 @@
 # Planning Status
 
-Last sync: 2026-02-20 11:05 UTC
+Last sync: 2026-02-20 12:18 UTC
 Active sprint: Sprint 52
 
 | Item | Title | Issue | PR |
@@ -10,6 +10,8 @@ Active sprint: Sprint 52
 | S52-003 | Add preset telemetry event capture and aggregation | [#222](https://github.com/Nombah501/LiteAuction/issues/222) (closed) | - |
 | S52-004 | Expose preset telemetry insights in admin workflow surfaces | [#223](https://github.com/Nombah501/LiteAuction/issues/223) (closed) | - |
 | S52-005 | Harden v1.1 safety and regression coverage | [#224](https://github.com/Nombah501/LiteAuction/issues/224) (closed) | - |
+| S52-006 | Sync planning status after Sprint 52 completion | [#229](https://github.com/Nombah501/LiteAuction/issues/229) (closed) | - |
+| S52-007 | Verify v1.1 requirements coverage and milestone readiness | [#231](https://github.com/Nombah501/LiteAuction/issues/231) (open) | - |
 
 ## Recovery Checklist
 

--- a/planning/sprints/sprint-52.toml
+++ b/planning/sprints/sprint-52.toml
@@ -83,3 +83,35 @@ acceptance = [
   "Telemetry ingestion and aggregation paths are validated against RBAC/CSRF constraints",
   "Manual verification checklist records keyboard-flow and deep-scroll continuity after v1.1 changes",
 ]
+
+[[items]]
+id = "S52-006"
+title = "Sync planning status after Sprint 52 completion"
+description = "Refresh planning status to reflect post-merge Sprint 52 issue closure and maintain recovery continuity."
+priority = "P3"
+estimate = "S"
+tech_debt = false
+labels = ["type:docs", "area:process", "priority:p3"]
+assignees = []
+create_draft_pr = false
+acceptance = [
+  "planning/STATUS.md last sync timestamp is current",
+  "Sprint 52 rows reflect closed issue state",
+  "Sync is merged with sprint label traceability",
+]
+
+[[items]]
+id = "S52-007"
+title = "Verify v1.1 requirements coverage and milestone readiness"
+description = "Run goal-backward verification for v1.1 requirements and update planning artifacts with outcome status and follow-up scope."
+priority = "P2"
+estimate = "M"
+tech_debt = true
+labels = ["type:docs", "area:process", "priority:p2", "tech-debt"]
+assignees = []
+create_draft_pr = false
+acceptance = [
+  "Verification report maps each v1.1 requirement to concrete repo evidence",
+  "Requirements and state docs reflect met versus follow-up outcomes",
+  "Closeout recommendation is explicit: close milestone now or continue with follow-up scope",
+]


### PR DESCRIPTION
## Summary
- add outcome-based v1.1 verification report with requirement-level evidence
- update planning artifacts to reflect 8 met requirements and 2 follow-up items
- sync Sprint 52 manifest/status with post-delivery documentation tasks

## Verification
- documentation/planning only; no runtime code changes

Closes #231
