### PR TITLE
[Sprint 53][S53-000] Kick off follow-up scope from v1.1 verification

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -3,7 +3,7 @@
 ## Milestones
 
 - ✅ **v1.0 Operator UX** - shipped 2026-02-20 (Phases 1-3, 10 plans) -> `.planning/milestones/v1.0-ROADMAP.md`
-- 🚧 **v1.1 Adaptive Triage Intelligence** - verification in progress (8/10 requirements met, 2 follow-up items)
+- 🚧 **v1.1 Adaptive Triage Intelligence** - follow-up execution (Sprint 53, 8/10 met, issues #233-#235 open)
 
 ## Next
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,14 +5,14 @@
 See: `.planning/PROJECT.md` (updated 2026-02-20)
 
 **Core value:** Run trustworthy Telegram auctions end-to-end with fast operator intervention and clear auditability.
-**Current focus:** Verify v1.1 outcomes and prepare follow-up scope for remaining gaps
+**Current focus:** Execute Sprint 53 follow-up to close remaining v1.1 verification gaps
 
 ## Current Position
 
-Phase: Milestone verification (v1.1)
-Plan: Goal-backward validation after Sprint 52 delivery
-Status: v1.1 partially verified (8 met, 2 follow-up)
-Last activity: 2026-02-20 - wrote `.planning/verification/v1.1/VERIFICATION.md` and synced requirement status
+Phase: Follow-up execution (Sprint 53)
+Plan: Deliver `S53-001` + `S53-002`, then complete `S53-003` closeout
+Status: follow-up issues opened and ready for implementation (#233, #234, #235)
+Last activity: 2026-02-20 - created `planning/sprints/sprint-53.toml` and synced Sprint 53 issues
 
 Progress: [████████░░] 80%
 
@@ -59,6 +59,6 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-02-20 12:17 UTC
-Stopped at: Completed v1.1 verification report; identified 2 follow-up outcomes before closeout
-Resume file: `.planning/verification/v1.1/VERIFICATION.md`
+Last session: 2026-02-20 12:24 UTC
+Stopped at: Opened Sprint 53 follow-up scope from v1.1 verification gaps
+Resume file: `planning/sprints/sprint-53.toml`

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -1,17 +1,13 @@
 # Planning Status
 
-Last sync: 2026-02-20 12:18 UTC
-Active sprint: Sprint 52
+Last sync: 2026-02-20 12:23 UTC
+Active sprint: Sprint 53
 
 | Item | Title | Issue | PR |
 |---|---|---|---|
-| S52-001 | Define adaptive detail depth policy contract | [#220](https://github.com/Nombah501/LiteAuction/issues/220) (closed) | - |
-| S52-002 | Implement adaptive detail depth in moderation queue UI | [#221](https://github.com/Nombah501/LiteAuction/issues/221) (closed) | - |
-| S52-003 | Add preset telemetry event capture and aggregation | [#222](https://github.com/Nombah501/LiteAuction/issues/222) (closed) | - |
-| S52-004 | Expose preset telemetry insights in admin workflow surfaces | [#223](https://github.com/Nombah501/LiteAuction/issues/223) (closed) | - |
-| S52-005 | Harden v1.1 safety and regression coverage | [#224](https://github.com/Nombah501/LiteAuction/issues/224) (closed) | - |
-| S52-006 | Sync planning status after Sprint 52 completion | [#229](https://github.com/Nombah501/LiteAuction/issues/229) (closed) | - |
-| S52-007 | Verify v1.1 requirements coverage and milestone readiness | [#231](https://github.com/Nombah501/LiteAuction/issues/231) (open) | - |
+| S53-001 | Exclude failed business outcomes from preset telemetry sampling | [#233](https://github.com/Nombah501/LiteAuction/issues/233) (open) | - |
+| S53-002 | Add DB-backed telemetry ingestion and aggregation integration coverage | [#234](https://github.com/Nombah501/LiteAuction/issues/234) (open) | - |
+| S53-003 | Re-verify v1.1 requirements and close milestone | [#235](https://github.com/Nombah501/LiteAuction/issues/235) (open) | - |
 
 ## Recovery Checklist
 

--- a/planning/sprints/sprint-53.toml
+++ b/planning/sprints/sprint-53.toml
@@ -1,0 +1,53 @@
+sprint = "Sprint 53"
+milestone = "Sprint 53"
+milestone_description = "v1.1 follow-up: telemetry failure semantics and DB-backed verification closure"
+base_branch = "main"
+status_file = "planning/STATUS.md"
+
+[[items]]
+id = "S53-001"
+title = "Exclude failed business outcomes from preset telemetry sampling"
+description = "Tighten telemetry capture so only successful workflow actions are sampled; keep unauthorized, invalid, and failed business outcomes excluded from quality metrics."
+priority = "P1"
+estimate = "M"
+tech_debt = true
+labels = ["type:hardening", "area:backend", "area:moderation", "priority:p1", "tech-debt"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "Telemetry recorder writes events only when action result is successful",
+  "Unauthorized, invalid, and failed business outcomes are excluded from sampling",
+  "Regression tests cover success versus failure sampling behavior",
+]
+
+[[items]]
+id = "S53-002"
+title = "Add DB-backed telemetry ingestion and aggregation integration coverage"
+description = "Add integration coverage that persists telemetry records and validates queue/preset segmented aggregation against the test database without monkeypatch-only shortcuts."
+priority = "P1"
+estimate = "M"
+tech_debt = true
+labels = ["type:test", "area:tests", "area:db", "priority:p1", "tech-debt"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "Integration test persists telemetry events to test DB through real write path",
+  "Aggregation endpoint returns expected queue and preset segments from persisted data",
+  "Coverage avoids monkeypatching core telemetry persistence and aggregation services",
+]
+
+[[items]]
+id = "S53-003"
+title = "Re-verify v1.1 requirements and close milestone"
+description = "Re-run goal-backward verification after follow-up delivery, update planning artifacts, then complete v1.1 archival/tag closeout if all requirements are met."
+priority = "P2"
+estimate = "S"
+tech_debt = false
+labels = ["type:docs", "area:process", "priority:p2"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "Verification report shows TELE-02 and TEST-12 as met",
+  "Requirements and state docs reflect full v1.1 completion",
+  "Milestone closeout artifacts and tag are created per workflow when ready",
+]


### PR DESCRIPTION
## Summary
- add Sprint 53 manifest with follow-up scope for `TELE-02` and `TEST-12`
- sync sprint issues and make Sprint 53 active in `planning/STATUS.md`
- update milestone planning state to reflect follow-up execution phase

Closes #236
