### PR TITLE
[Sprint 53][S53-003] Re-verify and close v1.1 milestone

### DIFF
--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -1,20 +1,20 @@
 # Milestones
 
-## v1.1 Adaptive Triage Intelligence (Planned: 2026-02-20)
+## v1.1 Adaptive Triage Intelligence (Shipped: 2026-02-20)
 
-**Phases planned:** 3 phases
-**Timeline:** 2026-02-20 -> TBD
-**Git range:** `TBD`
-**Code delta:** `TBD`
+**Phases completed:** 3 phases, 7 plans
+**Timeline:** 2026-02-20 -> 2026-02-20
+**Git range:** `28553d5..a1a05c3`
 
-**Milestone scope:**
-- Deliver adaptive detail depth rules that preserve predictable triage navigation.
-- Add preset telemetry capture and segmented quality reporting for operator workflows.
-- Keep moderation safety posture intact with RBAC/CSRF guardrails and focused regression coverage.
+**Key accomplishments:**
+- Delivered adaptive detail depth rules with deterministic reason codes, fallback behavior, and per-row operator override controls.
+- Added workflow preset telemetry capture and segmented aggregation for time-to-action, reopen rate, and filter churn.
+- Hardened workflow telemetry semantics to exclude unauthorized, invalid, and failed business outcomes from sampling.
+- Added DB-backed integration coverage for telemetry ingestion and scoped aggregation outputs.
+- Kept RBAC/CSRF guardrails intact across adaptive and telemetry endpoints with regression assertions.
 
-**Entry criteria:**
-- `.planning/REQUIREMENTS.md` reflects approved v1.1 requirement IDs and traceability plan.
-- Sprint 52 manifest is synced to GitHub milestone/issues.
+**Known gaps:**
+- No blocking gaps at milestone close (10/10 requirements verified as met).
 
 ---
 

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-LiteAuction is a Telegram-first auction platform with a FastAPI admin panel for operators and moderators. It covers the full auction trust loop: lot intake, bidding, moderation and risk triage, appeals, feedback, and audit trails. The current admin UX baseline includes dense queue controls, named workflow presets, and in-place triage interactions for faster queue handling.
+LiteAuction is a Telegram-first auction platform with a FastAPI admin panel for operators and moderators. It covers the full trust loop for auctions: lot intake, bidding, moderation and risk triage, appeals, feedback, and audit trails. The admin surface now includes dense queue controls, deterministic workflow presets, adaptive triage detail depth, and preset telemetry insights.
 
 ## Core Value
 
@@ -11,8 +11,9 @@ Run trustworthy Telegram auctions end-to-end with fast operator intervention and
 ## Current State
 
 - Milestone **v1.0 Operator UX** is shipped and archived.
-- Moderation queues support persisted dense-list ergonomics, deterministic workflow presets, and in-place triage interactions.
-- Planning focus has shifted from delivery to defining the next milestone scope.
+- Milestone **v1.1 Adaptive Triage Intelligence** is shipped and archived.
+- Moderation queues support adaptive detail depth with transparent reason/fallback metadata and per-row override controls.
+- Workflow preset telemetry now provides segmented quality signals and excludes failed action outcomes from sampling.
 
 ## Requirements
 
@@ -21,32 +22,32 @@ Run trustworthy Telegram auctions end-to-end with fast operator intervention and
 - ✓ Operators can configure dense moderation queues (density, filters, column layout) with durable persistence.
 - ✓ Operators and admins can manage named workflow presets with deterministic default and last-selected behavior.
 - ✓ Operators can triage queue rows in place with progressive details, keyboard flow, and safe bulk actions.
-- ✓ Scope-based RBAC and CSRF protections remain enforced for web moderation actions.
-- ✓ Sprint 51 delivery traceability is complete (issues `#205`, `#206`, `#207`, `#208`, `#212`, `#215`, `#218` all closed).
+- ✓ Adaptive detail depth by risk/priority is deterministic, transparent, and override-capable (`ADPT-01..03`) — v1.1.
+- ✓ Preset telemetry captures and segments actionable quality metrics while excluding failed outcomes (`TELE-01..03`) — v1.1.
+- ✓ RBAC and CSRF protections remain enforced for adaptive and telemetry surfaces (`SAFE-01..02`) — v1.1.
+- ✓ Automated coverage includes adaptive behavior and DB-backed telemetry integration paths (`TEST-11..12`) — v1.1.
 
 ### Active
 
-- [x] Define and plan milestone v1.1 scope and acceptance criteria.
-- [ ] Deliver adaptive detail depth controls with predictable navigation (`ADPT-01`).
-- [ ] Add operator preset telemetry for quality analysis (`TELE-01`).
-- [ ] Validate adaptive/telemetry rollout with focused safety and integration gates.
+- [ ] Define and scope milestone v1.2 requirements.
+- [ ] Identify next operator-trust outcomes to improve without regressing queue speed.
+- [ ] Build Sprint 54 manifest and sync issue scaffolds for v1.2 kickoff.
 
 ### Out of Scope
 
-- Native mobile app clients - current strategy is Telegram + web admin first.
-- Multi-platform auction channels outside Telegram - current operations are optimized for Telegram workflows.
-- Non-auction social feature expansion - outside trust-first auction operations scope.
+- Native mobile app clients - current strategy remains Telegram + web admin first.
+- Multi-platform auction channels outside Telegram - operations remain optimized for Telegram workflows.
+- Autonomous moderation decisioning - conflicts with trust and auditability posture.
 
 ## Context
 
-The codebase is a Python 3.12 modular monolith using aiogram (bot), FastAPI (admin web), SQLAlchemy/Alembic (data), PostgreSQL, and Redis with Docker Compose services (`bot`, `admin`, `db`, `redis`). Milestone v1.0 (Sprint 51 delivery line) completed three phases and delivered operator UX improvements for focus, presets, and in-place triage while preserving moderation and security guarantees.
+The codebase is a Python 3.12 modular monolith using aiogram (bot), FastAPI (admin web), SQLAlchemy/Alembic (data), PostgreSQL, and Redis with Docker Compose services (`bot`, `admin`, `db`, `redis`). v1.0 and v1.1 are now archived milestones; v1.1 added adaptive triage intelligence and telemetry quality signals while preserving moderation safety boundaries.
 
 ## Next Milestone Goals
 
-- Define a focused v1.1 milestone that extends v1.0 operator workflows without regressing queue speed.
-- Prioritize measurable operator outcomes (time-to-action, reopen risk, filter churn) to guide preset tuning.
-- Preserve strict safety posture (RBAC, CSRF, explicit confirmations, deterministic state transitions).
-- Sequence delivery through Sprint 52 issue set before implementation begins.
+- Define focused v1.2 scope from post-v1.1 operational feedback.
+- Prioritize measurable operator outcomes that improve triage speed and decision confidence.
+- Keep deterministic behavior, auditability, and security posture as non-negotiable constraints.
 
 ## Constraints
 
@@ -63,6 +64,8 @@ The codebase is a Python 3.12 modular monolith using aiogram (bot), FastAPI (adm
 | Use deterministic preset precedence (first-entry admin default, then last-selected) | Prevents non-deterministic queue state and operator confusion | ✓ Good |
 | Keep triage interaction model to two disclosure levels (list + inline details) | Maintains scan speed and avoids deep navigation context loss | ✓ Good |
 | Gate destructive bulk actions with explicit confirmation + server-side validation | Reduces accidental moderation mutations and improves safety posture | ✓ Good |
+| Gate telemetry sampling on successful business outcomes only | Avoids misleading quality signals from conflict/failure paths | ✓ Good |
+| Require DB-backed telemetry integration assertions before milestone closeout | Ensures aggregation confidence beyond monkeypatched route checks | ✓ Good |
 
 ---
-*Last updated: 2026-02-20 for v1.1 milestone kickoff*
+*Last updated: 2026-02-20 after v1.1 milestone closeout*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -3,10 +3,8 @@
 ## Milestones
 
 - ✅ **v1.0 Operator UX** - shipped 2026-02-20 (Phases 1-3, 10 plans) -> `.planning/milestones/v1.0-ROADMAP.md`
-- 🚧 **v1.1 Adaptive Triage Intelligence** - follow-up execution (Sprint 53, 8/10 met, issues #233-#235 open)
+- ✅ **v1.1 Adaptive Triage Intelligence** - shipped 2026-02-20 (Phases 1-3, 7 plans) -> `.planning/milestones/v1.1-ROADMAP.md`
 
 ## Next
 
-- Close follow-up for `TELE-02`: exclude failed business outcomes from telemetry sampling, not only auth/validation failures.
-- Close follow-up for `TEST-12`: add DB-backed integration coverage for telemetry ingestion and scoped aggregation.
-- Run verification refresh and close v1.1 after both follow-up outcomes are complete.
+- Create and scope next milestone (`v1.2`) with fresh requirements and sprint manifest.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,16 +5,16 @@
 See: `.planning/PROJECT.md` (updated 2026-02-20)
 
 **Core value:** Run trustworthy Telegram auctions end-to-end with fast operator intervention and clear auditability.
-**Current focus:** Execute Sprint 53 follow-up to close remaining v1.1 verification gaps
+**Current focus:** Initialize next milestone planning after v1.1 closeout
 
 ## Current Position
 
-Phase: Follow-up execution (Sprint 53)
-Plan: Deliver `S53-001` + `S53-002`, then complete `S53-003` closeout
-Status: follow-up issues opened and ready for implementation (#233, #234, #235)
-Last activity: 2026-02-20 - created `planning/sprints/sprint-53.toml` and synced Sprint 53 issues
+Phase: Milestone closeout complete (v1.1)
+Plan: Begin v1.2 scope definition and sprint kickoff
+Status: v1.1 archived and verified complete (10 met, 0 partial)
+Last activity: 2026-02-20 - archived v1.1 roadmap/requirements and prepared release tagging
 
-Progress: [████████░░] 80%
+Progress: [██████████] 100%
 
 ## Performance Metrics
 
@@ -49,9 +49,9 @@ Recent decisions affecting current work:
 
 ### Pending Todos
 
-- Close follow-up scope for `TELE-02` failed-action telemetry exclusion.
-- Add DB-backed integration coverage for `TEST-12` telemetry ingestion and aggregation path.
-- Re-run v1.1 verification and decide milestone closeout.
+- Create fresh v1.2 requirements and roadmap scaffold.
+- Sync Sprint 54 manifest to GitHub issues/PR stubs.
+- Start implementation from the highest-priority v1.2 item.
 
 ### Blockers/Concerns
 
@@ -59,6 +59,6 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-02-20 12:24 UTC
-Stopped at: Opened Sprint 53 follow-up scope from v1.1 verification gaps
+Last session: 2026-02-20 13:10 UTC
+Stopped at: Completed v1.1 archival closeout and queued next milestone planning
 Resume file: `planning/sprints/sprint-53.toml`

--- a/.planning/milestones/v1.1-REQUIREMENTS.md
+++ b/.planning/milestones/v1.1-REQUIREMENTS.md
@@ -1,3 +1,20 @@
+# Requirements Archive: v1.1 Adaptive Triage Intelligence
+
+**Archived:** 2026-02-20
+**Status:** SHIPPED
+
+## Requirement Outcomes
+
+- **Validated:** 10
+- **Adjusted:** 0
+- **Dropped:** 0
+
+All v1.1 requirements were delivered and verified as complete after Sprint 53 follow-up closure (`TELE-02`, `TEST-12`).
+
+For the next milestone, create a fresh `.planning/REQUIREMENTS.md` via `/gsd-new-milestone`.
+
+---
+
 # Requirements: LiteAuction v1.1 Adaptive Triage Intelligence
 
 **Defined:** 2026-02-20
@@ -14,7 +31,7 @@
 ### Preset Telemetry
 
 - [x] **TELE-01**: Product team can review preset quality telemetry for time-to-action, reopen rate, and filter churn.
-- [ ] **TELE-02**: Telemetry sampling excludes unauthorized and failed actions to avoid misleading quality signals.
+- [x] **TELE-02**: Telemetry sampling excludes unauthorized and failed actions to avoid misleading quality signals.
 - [x] **TELE-03**: Telemetry export supports queue and preset segmentation for weekly operations review.
 
 ### Guardrails and Safety
@@ -25,7 +42,7 @@
 ### Verification
 
 - [x] **TEST-11**: Automated tests cover adaptive rule selection, override behavior, and fallback handling.
-- [ ] **TEST-12**: Integration tests cover telemetry event ingestion and scoped aggregation outputs.
+- [x] **TEST-12**: Integration tests cover telemetry event ingestion and scoped aggregation outputs.
 
 ## Out of Scope
 
@@ -43,12 +60,12 @@
 | ADPT-02 | Phase 1 | Verified (Met) |
 | ADPT-03 | Phase 2 | Verified (Met) |
 | TELE-01 | Phase 2 | Verified (Met) |
-| TELE-02 | Phase 2 | Verified (Partial) |
+| TELE-02 | Phase 2 | Verified (Met) |
 | TELE-03 | Phase 3 | Verified (Met) |
 | SAFE-01 | Phase 3 | Verified (Met) |
 | SAFE-02 | Phase 1 | Verified (Met) |
 | TEST-11 | Phase 3 | Verified (Met) |
-| TEST-12 | Phase 3 | Verified (Partial) |
+| TEST-12 | Phase 3 | Verified (Met) |
 
 ---
-*Last updated: 2026-02-20 after v1.1 verification pass (8 met, 2 partial)*
+*Last updated: 2026-02-20 after v1.1 re-verification pass (10 met, 0 partial)*

--- a/.planning/milestones/v1.1-ROADMAP.md
+++ b/.planning/milestones/v1.1-ROADMAP.md
@@ -1,0 +1,89 @@
+# Milestone v1.1: Adaptive Triage Intelligence
+
+**Status:** ✅ SHIPPED 2026-02-20
+**Phases:** 1-3
+**Total Plans:** 7
+
+## Overview
+
+Milestone v1.1 extended moderation operator intelligence without sacrificing predictability: adaptive detail depth decisions with transparent reason codes, preset telemetry quality signals, and safety-preserving follow-up hardening for telemetry semantics and integration coverage.
+
+## Phases
+
+### Phase 1: Adaptive Detail Depth
+
+**Goal**: Make row detail depth adaptive by queue risk/priority while preserving deterministic operator navigation.
+**Depends on**: v1.0 dense list and in-place triage foundations
+**Plans**: 2 plans
+
+Plans:
+
+- [x] S52-001: Define adaptive detail depth policy contract
+- [x] S52-002: Implement adaptive detail depth in moderation queue UI
+
+**Details:**
+- Implemented deterministic adaptive depth selection with explicit `reason_code` and fallback metadata.
+- Added per-row operator override controls while preserving row focus, filter, and scroll context.
+- Kept disclosure bounded to list plus inline details for scan speed and predictability.
+
+### Phase 2: Preset Telemetry Intelligence
+
+**Goal**: Capture and expose actionable preset quality telemetry for operators and product tuning.
+**Depends on**: Phase 1
+**Plans**: 2 plans
+
+Plans:
+
+- [x] S52-003: Add preset telemetry event capture and aggregation
+- [x] S53-001: Exclude failed business outcomes from preset telemetry sampling
+
+**Details:**
+- Added telemetry event capture for queue/preset actions with time-to-action, reopen, and filter churn signals.
+- Added segmented aggregation surfaces by queue context and preset.
+- Hardened sampling semantics so unauthorized, invalid, and failed action outcomes are excluded.
+
+### Phase 3: Safety and Verification Closure
+
+**Goal**: Preserve moderation safety posture and validate telemetry/adaptive behavior with robust coverage.
+**Depends on**: Phase 2
+**Plans**: 3 plans
+
+Plans:
+
+- [x] S52-004: Expose preset telemetry insights in admin workflow surfaces
+- [x] S52-005: Harden v1.1 safety and regression coverage
+- [x] S53-002: Add DB-backed telemetry ingestion and aggregation integration coverage
+
+**Details:**
+- Kept RBAC and CSRF enforcement on adaptive and telemetry mutation/read surfaces.
+- Added regression checks for fallback handling and destructive action safeguards.
+- Added DB-backed integration tests for telemetry write path and scoped aggregation outputs.
+
+---
+
+## Milestone Summary
+
+**Decimal Phases:**
+
+- None.
+
+**Key Decisions:**
+- Keep adaptive depth deterministic and transparent with reason/fallback metadata instead of hidden heuristics.
+- Treat telemetry as advisory signal only; do not automate moderation decisions from metrics.
+- Sample telemetry only from successful business outcomes to avoid misleading quality data.
+- Require DB-backed integration coverage for telemetry aggregation confidence.
+
+**Issues Resolved:**
+- Adaptive detail depth now responds to risk/priority while preserving queue context and operator control.
+- Preset telemetry now supports actionable queue/preset segmentation for operations review.
+- Telemetry sampling and aggregation verification gaps identified in early verification were closed in Sprint 53 follow-up.
+
+**Issues Deferred:**
+- None at v1.1 closeout.
+
+**Technical Debt Incurred:**
+- Local dev environment in this session lacked `pytest`/`ruff`; validation relied on CI checks for execution proof.
+
+---
+
+_For current project status, see `.planning/ROADMAP.md`._

--- a/.planning/verification/v1.1/VERIFICATION.md
+++ b/.planning/verification/v1.1/VERIFICATION.md
@@ -1,56 +1,38 @@
 # v1.1 Goal-Backward Verification (Outcome-Focused)
 
-Date: 2026-02-20
+Date: 2026-02-20 (re-run after Sprint 53 follow-up merges #238, #239)
 Scope reviewed: `ADPT-01..03`, `TELE-01..03`, `SAFE-01..02`, `TEST-11..12`
 
 ## Requirement Verdicts
 
 | Requirement | Verdict | Evidence (code/tests/docs) | Risks / Gaps |
 | --- | --- | --- | --- |
-| ADPT-01 | **Met** | Adaptive policy is rule-based by queue/risk/priority in `app/services/adaptive_triage_policy_service.py:53` and consumed by adaptive endpoint `app/web/main.py:4210`; predictable keyboard/focus flow exists in `app/web/dense_list.py:618` and `app/web/dense_list.py:655`; tests: `test_risk_rule_auto_expands_for_complaints_queue`, `test_priority_rule_auto_expands_for_complaints_queue`, `test_triage_markup_includes_keyboard_focus_and_scroll_hooks` | Navigation behavior is validated mostly via HTML/script contract tests, not browser-level runtime execution. |
-| ADPT-02 | **Met** | Visible reason code/fallback is returned by API metadata in `app/web/main.py:4217` and rendered in UI text `app/web/dense_list.py:403`; deterministic fallback logic in `app/services/adaptive_triage_policy_service.py:166`; tests: `test_unknown_queue_uses_fallback_default_reason`, `test_invalid_tokens_record_fallback_notes`, `test_triage_detail_section_reports_fallback_for_invalid_tokens` | None blocking. |
-| ADPT-03 | **Met** | Per-row override controls and request wiring in `app/web/dense_list.py:351`, `app/web/dense_list.py:594`, `app/web/dense_list.py:605`; row context continuity logic (focus/scroll/filter state) in `app/web/dense_list.py:300`, `app/web/dense_list.py:327`, `app/web/dense_list.py:443`; tests: `test_dense_list_contract_includes_adaptive_depth_override_controls`, `test_triage_detail_section_honors_operator_override` | Continuity is inferred from script paths/tests; no end-to-end browser assertion in repo. |
-| TELE-01 | **Met** | Telemetry event model includes time/reopen/churn fields in `app/db/models.py:591`; aggregation computes avg time/reopen rate/churn in `app/services/admin_queue_preset_telemetry_service.py:115`; telemetry panel renders all three metrics in `app/web/main.py:979`; tests: `test_load_workflow_preset_telemetry_segments_computes_rates`, `test_queue_routes_render_preset_controls_for_required_contexts` | None blocking. |
-| TELE-02 | **Partially Met** | Unauthorized/invalid paths are excluded before recording in `app/web/main.py:4030`, `app/web/main.py:4042`, `app/web/main.py:4130`; tests: `test_workflow_presets_action_rejects_unauthorized_before_telemetry`, `test_workflow_presets_action_rejects_csrf_before_telemetry`, `test_workflow_presets_action_does_not_record_telemetry_on_invalid_action` | Telemetry recording is unconditional after action handler result (`app/web/main.py:4142`), so non-success business outcomes (for example conflict-style `ok: false` results) can still be sampled; requirement asks to exclude failed actions. |
-| TELE-03 | **Met** | Export endpoint returns segmented JSON with queue filter and preset grouping: `app/web/main.py:4154`, `app/services/admin_queue_preset_telemetry_service.py:116`, `app/services/admin_queue_preset_telemetry_service.py:133`; UI supports queue/preset filtering in `app/web/main.py:893`; tests: `test_workflow_presets_telemetry_endpoint_returns_segments`, `test_trade_feedback_telemetry_filter_preserves_queue_context` | Export format is JSON only (no CSV artifact), but requirement did not mandate file format. |
-| SAFE-01 | **Met** | CSRF validation on mutating adaptive/telemetry endpoints: `app/web/main.py:4042` (`/actions/workflow-presets`) and `app/web/main.py:4263` (`/actions/triage/bulk`); RBAC/scope checks on telemetry read and sensitive queues: `app/web/main.py:4160`, `app/web/main.py:4207`, `app/web/main.py:4290`; tests: `test_workflow_presets_telemetry_endpoint_requires_scope`, `test_bulk_endpoint_rejects_forbidden_scope_without_mutation`, `test_bulk_endpoint_rejects_csrf_without_mutation` | Read-only GET endpoints rely on auth/scope (not CSRF), which is standard but should remain explicit in security docs. |
-| SAFE-02 | **Met** | Depth outputs are bounded to two values in `app/services/adaptive_triage_policy_service.py:7`; safe default/fallback prevents unintended expansion `app/services/adaptive_triage_policy_service.py:51`, `app/services/adaptive_triage_policy_service.py:166`; docs define bounded model `docs/planning/sprint-52-adaptive-detail-depth-policy-contract.md:7`; tests: `test_policy_surface_is_bounded_to_inline_summary_and_full`, `test_trade_feedback_requires_critical_risk_or_urgent_priority_for_auto_expand` | None blocking. |
-| TEST-11 | **Met** | Automated tests cover selection/override/fallback in `tests/test_adaptive_triage_policy_service.py:20`, `tests/test_adaptive_triage_policy_service.py:79`, `tests/integration/test_web_triage_interactions.py:330`, `tests/integration/test_web_triage_interactions.py:369` | Test execution was not run in this environment (`pytest` module unavailable), so status is based on code-level coverage presence. |
-| TEST-12 | **Partially Met** | Integration test file exists for telemetry flows: `tests/integration/test_web_workflow_presets.py:297`, `tests/integration/test_web_workflow_presets.py:433`; aggregation service unit coverage exists in `tests/test_admin_queue_preset_telemetry_service.py:76` | Current integration tests heavily monkeypatch telemetry write/read paths, so they do not verify DB-backed ingestion + scoped aggregation end-to-end. |
+| ADPT-01 | **Met** | Adaptive policy remains rule-based by queue/risk/priority in `app/services/adaptive_triage_policy_service.py:53` and consumed by adaptive endpoint `app/web/main.py:4217`; predictable keyboard/focus navigation in `app/web/dense_list.py:618` and `app/web/dense_list.py:655`; tests include `test_risk_rule_auto_expands_for_complaints_queue`, `test_priority_rule_auto_expands_for_complaints_queue`, `test_triage_markup_includes_keyboard_focus_and_scroll_hooks` | Runtime keyboard UX still validated primarily by HTML/script contract tests, not browser E2E. |
+| ADPT-02 | **Met** | Visible reason/fallback metadata returned by adaptive endpoint (`app/web/main.py:4224`) and rendered in UI (`app/web/dense_list.py:403`); deterministic fallback logic in `app/services/adaptive_triage_policy_service.py:166`; tests include `test_unknown_queue_uses_fallback_default_reason`, `test_invalid_tokens_record_fallback_notes`, `test_triage_detail_section_reports_fallback_for_invalid_tokens` | None blocking. |
+| ADPT-03 | **Met** | Per-row override controls + fetch wiring in `app/web/dense_list.py:351`, `app/web/dense_list.py:364`, `app/web/dense_list.py:594`; queue context continuity via focused row + filter + close context in `app/web/dense_list.py:300`, `app/web/dense_list.py:327`, `app/web/dense_list.py:443`; tests include `test_dense_list_contract_includes_adaptive_depth_override_controls`, `test_triage_detail_section_honors_operator_override` | No browser-driven E2E proof for override UX persistence across all operator flows. |
+| TELE-01 | **Met** | Telemetry model keeps time/reopen/churn fields in `app/db/models.py:591`; aggregation computes avg time, reopen rate, and churn in `app/services/admin_queue_preset_telemetry_service.py:115`; telemetry panel renders those metrics in `app/web/main.py:979`; tests include `test_load_workflow_preset_telemetry_segments_computes_rates` and route rendering checks in `tests/integration/test_web_workflow_presets.py:134` | None blocking. |
+| TELE-02 | **Met** | Telemetry write is now gated on successful action outcome via `_workflow_preset_result_is_successful` (`app/web/main.py:1128`) and callsite guard (`app/web/main.py:4142`); unauthorized/CSRF/invalid action paths still reject before telemetry; tests now cover failed outcome exclusion (`tests/integration/test_web_workflow_presets.py:234`) and successful mutation sampling (`tests/integration/test_web_workflow_presets.py:308`) | None blocking. |
+| TELE-03 | **Met** | Segmented telemetry endpoint remains wired (`app/web/main.py:4161`) to aggregation service (`app/services/admin_queue_preset_telemetry_service.py:105`) with queue_context and preset grouping in response; UI preset segmentation chips/table in `app/web/main.py:893`; tests include `test_workflow_presets_telemetry_endpoint_returns_segments` and `test_trade_feedback_telemetry_filter_preserves_queue_context` | Export remains JSON API output; no requirement gap identified. |
+| SAFE-01 | **Met** | CSRF enforced on mutating adaptive/telemetry endpoints in `app/web/main.py:4046` and `app/web/main.py:4270`; RBAC/scope checks enforced on telemetry read/sensitive queues in `app/web/main.py:4167`, `app/web/main.py:4214`, `app/web/main.py:4297`; tests include `test_workflow_presets_telemetry_endpoint_requires_scope`, `test_bulk_endpoint_rejects_forbidden_scope_without_mutation`, `test_bulk_endpoint_rejects_csrf_without_mutation` | None blocking. |
+| SAFE-02 | **Met** | Depth outputs remain bounded to `inline_summary`/`inline_full` (`app/services/adaptive_triage_policy_service.py:7`) with safe default/fallback behavior (`app/services/adaptive_triage_policy_service.py:51`, `app/services/adaptive_triage_policy_service.py:166`); policy contract doc remains explicit (`docs/planning/sprint-52-adaptive-detail-depth-policy-contract.md:7`); tests include `test_policy_surface_is_bounded_to_inline_summary_and_full` and `test_trade_feedback_requires_critical_risk_or_urgent_priority_for_auto_expand` | None blocking. |
+| TEST-11 | **Met** | Automated tests cover adaptive rule selection, override, fallback: `tests/test_adaptive_triage_policy_service.py:20`, `tests/test_adaptive_triage_policy_service.py:79`, `tests/integration/test_web_triage_interactions.py:330`, `tests/integration/test_web_triage_interactions.py:369` | Test execution not runnable in this environment because `pytest` is unavailable. |
+| TEST-12 | **Met** | DB-backed telemetry integration coverage now exists: ingestion persistence test `tests/integration/test_web_workflow_presets.py:502`; scoped aggregation over persisted events test `tests/integration/test_web_workflow_presets.py:550`; dedicated integration DB safety fixture in `tests/integration/conftest.py:17` ensures test-database execution path | Local execution unavailable (`No module named pytest`), so verification is code-level and wiring-level. |
 
 ## Outcome Summary
 
-- **Met:** 8
-- **Partially Met:** 2 (`TELE-02`, `TEST-12`)
+- **Met:** 10
+- **Partially Met:** 0
 - **Not Met:** 0
 
 ## Final Recommendation
 
-**Need follow-up scope**
+**Ready to close v1.1**
 
 Rationale:
-- v1.1 core adaptive triage and telemetry outcomes are largely implemented and wired.
-- Two outcome gaps remain: strict failed-action exclusion semantics in telemetry sampling and true integration coverage for telemetry ingestion/aggregation against the database.
-
-## Suggested Checkbox Updates for `.planning/REQUIREMENTS.md`
-
-Mark as complete:
-
-- `- [x] **ADPT-01**: Operator detail depth adapts by risk and priority rules while keeping predictable navigation.`
-- `- [x] **ADPT-02**: Adaptive behavior is transparent with a visible reason code and deterministic fallback.`
-- `- [x] **ADPT-03**: Operators can override adaptive depth per row without losing queue context.`
-- `- [x] **TELE-01**: Product team can review preset quality telemetry for time-to-action, reopen rate, and filter churn.`
-- `- [x] **TELE-03**: Telemetry export supports queue and preset segmentation for weekly operations review.`
-- `- [x] **SAFE-01**: RBAC and CSRF protections remain enforced for all adaptive and telemetry endpoints.`
-- `- [x] **SAFE-02**: Adaptive defaults are bounded to prevent high-risk auto-expansion churn in dense queues.`
-- `- [x] **TEST-11**: Automated tests cover adaptive rule selection, override behavior, and fallback handling.`
-
-Leave unchecked for follow-up:
-
-- `- [ ] **TELE-02**: Telemetry sampling excludes unauthorized and failed actions to avoid misleading quality signals.`
-- `- [ ] **TEST-12**: Integration tests cover telemetry event ingestion and scoped aggregation outputs.`
+- Sprint 53 follow-up closes prior telemetry quality gap by excluding failed action outcomes from sampling.
+- Sprint 53 follow-up adds DB-backed integration coverage for telemetry ingestion and scoped aggregation, resolving prior TEST-12 partial status.
 
 ## Verification Notes
 
 - Verification is based on repository source/tests/docs inspection (goal-backward), not summary claims.
-- Attempted targeted test execution, but this environment currently lacks `pytest` (`No module named pytest`).
+- Attempted targeted test execution (`python -m pytest -q tests/integration/test_web_workflow_presets.py`), but this environment lacks `pytest` (`No module named pytest`).

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -1,12 +1,12 @@
 # Planning Status
 
-Last sync: 2026-02-20 12:23 UTC
+Last sync: 2026-02-20 13:04 UTC
 Active sprint: Sprint 53
 
 | Item | Title | Issue | PR |
 |---|---|---|---|
-| S53-001 | Exclude failed business outcomes from preset telemetry sampling | [#233](https://github.com/Nombah501/LiteAuction/issues/233) (open) | - |
-| S53-002 | Add DB-backed telemetry ingestion and aggregation integration coverage | [#234](https://github.com/Nombah501/LiteAuction/issues/234) (open) | - |
+| S53-001 | Exclude failed business outcomes from preset telemetry sampling | [#233](https://github.com/Nombah501/LiteAuction/issues/233) (closed) | - |
+| S53-002 | Add DB-backed telemetry ingestion and aggregation integration coverage | [#234](https://github.com/Nombah501/LiteAuction/issues/234) (closed) | - |
 | S53-003 | Re-verify v1.1 requirements and close milestone | [#235](https://github.com/Nombah501/LiteAuction/issues/235) (open) | - |
 
 ## Recovery Checklist


### PR DESCRIPTION
## Summary
- re-run goal-backward v1.1 verification and mark all requirements met (10/10)
- archive v1.1 roadmap/requirements into `.planning/milestones/` and collapse active roadmap entry
- update project/milestone/state planning docs for post-closeout continuity

## Validation
- verification report updated at `.planning/verification/v1.1/VERIFICATION.md`
- local runtime tests unavailable in this environment (`No module named pytest`); CI remains source of execution validation

Closes #235
