### PR TITLE
[Sprint 54][S54-000] Kick off v1.2 planning scope

### DIFF
--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -1,5 +1,22 @@
 # Milestones
 
+## v1.2 Queue Trust Signals (Planned: 2026-02-20)
+
+**Phases planned:** 3 phases
+**Timeline:** 2026-02-20 -> TBD
+**Git range:** `TBD`
+
+**Milestone scope:**
+- Deliver deterministic queue SLA health signals and aging visibility for moderation operators.
+- Add inline evidence timeline and rationale artifacts to improve decision confidence and auditability.
+- Introduce telemetry trend guardrails while preserving RBAC/CSRF and trust-first moderation posture.
+
+**Entry criteria:**
+- `.planning/REQUIREMENTS.md` reflects approved v1.2 requirement IDs and traceability plan.
+- Sprint 54 manifest is synced to GitHub issue scaffolds.
+
+---
+
 ## v1.1 Adaptive Triage Intelligence (Shipped: 2026-02-20)
 
 **Phases completed:** 3 phases, 7 plans

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -29,9 +29,10 @@ Run trustworthy Telegram auctions end-to-end with fast operator intervention and
 
 ### Active
 
-- [ ] Define and scope milestone v1.2 requirements.
-- [ ] Identify next operator-trust outcomes to improve without regressing queue speed.
-- [ ] Build Sprint 54 manifest and sync issue scaffolds for v1.2 kickoff.
+- [x] Define and scope milestone v1.2 requirements.
+- [ ] Deliver queue SLA awareness surfaces with deterministic aging buckets (`SLA-01..02`).
+- [ ] Deliver inline evidence timeline and moderation rationale trail (`EVID-01..02`).
+- [ ] Deliver trend guardrails and safety verification for trust signals (`TRND-01..02`, `SAFE-11..12`, `TEST-21..22`).
 
 ### Out of Scope
 
@@ -45,9 +46,9 @@ The codebase is a Python 3.12 modular monolith using aiogram (bot), FastAPI (adm
 
 ## Next Milestone Goals
 
-- Define focused v1.2 scope from post-v1.1 operational feedback.
-- Prioritize measurable operator outcomes that improve triage speed and decision confidence.
-- Keep deterministic behavior, auditability, and security posture as non-negotiable constraints.
+- Improve operator awareness of queue urgency using clear SLA health signals and aging visibility.
+- Increase moderation decision confidence with lightweight evidence timeline and rationale artifacts.
+- Keep telemetry advisory by adding trend guardrails and preserving strict safety enforcement.
 
 ## Constraints
 
@@ -68,4 +69,4 @@ The codebase is a Python 3.12 modular monolith using aiogram (bot), FastAPI (adm
 | Require DB-backed telemetry integration assertions before milestone closeout | Ensures aggregation confidence beyond monkeypatched route checks | ✓ Good |
 
 ---
-*Last updated: 2026-02-20 after v1.1 milestone closeout*
+*Last updated: 2026-02-20 for v1.2 milestone kickoff*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,57 @@
+# Requirements: LiteAuction v1.2 Queue Trust Signals
+
+**Defined:** 2026-02-20
+**Core Value:** Run trustworthy Telegram auctions end-to-end with fast operator intervention and clear auditability.
+
+## v1.2 Requirements
+
+### Queue SLA Awareness
+
+- [ ] **SLA-01**: Operators can see per-row SLA health state with deterministic countdown windows for pending moderation work.
+- [ ] **SLA-02**: Queue views provide aging buckets and SLA filter chips without losing current sort, filter, or focus context.
+
+### Decision Evidence Trail
+
+- [ ] **EVID-01**: Operators can open an inline evidence timeline showing key queue events and policy-relevant transitions for each row.
+- [ ] **EVID-02**: Moderation actions can include a concise rationale artifact suitable for later audit review.
+
+### Telemetry Trend Guardrails
+
+- [ ] **TRND-01**: Workflow preset telemetry exposes week-over-week trend deltas for time-to-action, reopen rate, and filter churn.
+- [ ] **TRND-02**: Trend insights apply minimum sample guardrails to avoid misleading recommendations from sparse data.
+
+### Guardrails and Safety
+
+- [ ] **SAFE-11**: RBAC and CSRF protections remain enforced for new SLA, evidence, and trend endpoints.
+- [ ] **SAFE-12**: Evidence and rationale records remain immutable after write, with explicit audit metadata for actor and timestamp.
+
+### Verification
+
+- [ ] **TEST-21**: Automated tests cover SLA state derivation, aging bucket assignment, and queue-filter continuity behavior.
+- [ ] **TEST-22**: Integration tests cover evidence timeline rendering and telemetry trend aggregation from persisted database events.
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| Autonomous moderation decisions from SLA/telemetry signals | Violates human-in-the-loop trust posture |
+| Cross-product analytics warehouse integration | Too broad for v1.2 delivery window |
+| Non-Telegram operator channels | Outside current product strategy |
+
+## Traceability (Planned)
+
+| Requirement | Planned Phase | Status |
+|-------------|---------------|--------|
+| SLA-01 | Phase 1 | Planned |
+| SLA-02 | Phase 1 | Planned |
+| EVID-01 | Phase 2 | Planned |
+| EVID-02 | Phase 2 | Planned |
+| TRND-01 | Phase 3 | Planned |
+| TRND-02 | Phase 3 | Planned |
+| SAFE-11 | Phase 3 | Planned |
+| SAFE-12 | Phase 2 | Planned |
+| TEST-21 | Phase 3 | Planned |
+| TEST-22 | Phase 3 | Planned |
+
+---
+*Last updated: 2026-02-20 for v1.2 kickoff*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -4,7 +4,10 @@
 
 - ✅ **v1.0 Operator UX** - shipped 2026-02-20 (Phases 1-3, 10 plans) -> `.planning/milestones/v1.0-ROADMAP.md`
 - ✅ **v1.1 Adaptive Triage Intelligence** - shipped 2026-02-20 (Phases 1-3, 7 plans) -> `.planning/milestones/v1.1-ROADMAP.md`
+- 🚧 **v1.2 Queue Trust Signals** - in planning (Phases 1-3, kickoff Sprint 54)
 
 ## Next
 
-- Create and scope next milestone (`v1.2`) with fresh requirements and sprint manifest.
+- Start Phase 1 for queue SLA health signals and deterministic aging thresholds.
+- Start Phase 2 for decision-evidence timeline surfaces and operator rationale exportability.
+- Lock Phase 3 for telemetry trend guardrails with RBAC/CSRF and regression validation.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,16 +5,16 @@
 See: `.planning/PROJECT.md` (updated 2026-02-20)
 
 **Core value:** Run trustworthy Telegram auctions end-to-end with fast operator intervention and clear auditability.
-**Current focus:** Initialize next milestone planning after v1.1 closeout
+**Current focus:** Kick off milestone v1.2 planning and sprint issue scaffolds
 
 ## Current Position
 
-Phase: Milestone closeout complete (v1.1)
-Plan: Begin v1.2 scope definition and sprint kickoff
-Status: v1.1 archived and verified complete (10 met, 0 partial)
-Last activity: 2026-02-20 - archived v1.1 roadmap/requirements and prepared release tagging
+Phase: Milestone planning (v1.2)
+Plan: Sprint 54 manifest kickoff
+Status: v1.2 scoped and ready for issue execution
+Last activity: 2026-02-20 - created fresh v1.2 requirements and sprint planning manifest
 
-Progress: [██████████] 100%
+Progress: [███░░░░░░░] 30%
 
 ## Performance Metrics
 
@@ -49,9 +49,9 @@ Recent decisions affecting current work:
 
 ### Pending Todos
 
-- Create fresh v1.2 requirements and roadmap scaffold.
-- Sync Sprint 54 manifest to GitHub issues/PR stubs.
-- Start implementation from the highest-priority v1.2 item.
+- Execute Sprint 54 items and keep issue/PR traceability current.
+- Run sprint sync after manifest changes to refresh `planning/STATUS.md`.
+- Re-verify v1.2 requirements before milestone closeout.
 
 ### Blockers/Concerns
 
@@ -59,6 +59,6 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-02-20 13:10 UTC
-Stopped at: Completed v1.1 archival closeout and queued next milestone planning
-Resume file: `planning/sprints/sprint-53.toml`
+Last session: 2026-02-20 13:18 UTC
+Stopped at: Initialized v1.2 scope and prepared Sprint 54 sync
+Resume file: `planning/sprints/sprint-54.toml`

--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -1,13 +1,15 @@
 # Planning Status
 
-Last sync: 2026-02-20 13:13 UTC
-Active sprint: Sprint 53
+Last sync: 2026-02-20 13:40 UTC
+Active sprint: Sprint 54
 
 | Item | Title | Issue | PR |
 |---|---|---|---|
-| S53-001 | Exclude failed business outcomes from preset telemetry sampling | [#233](https://github.com/Nombah501/LiteAuction/issues/233) (closed) | - |
-| S53-002 | Add DB-backed telemetry ingestion and aggregation integration coverage | [#234](https://github.com/Nombah501/LiteAuction/issues/234) (closed) | - |
-| S53-003 | Re-verify v1.1 requirements and close milestone | [#235](https://github.com/Nombah501/LiteAuction/issues/235) (closed) | - |
+| S54-001 | Define queue SLA health model and aging thresholds | [#243](https://github.com/Nombah501/LiteAuction/issues/243) (open) | - |
+| S54-002 | Implement SLA indicators and aging filters in queue UI | [#244](https://github.com/Nombah501/LiteAuction/issues/244) (open) | - |
+| S54-003 | Add inline evidence timeline and moderation rationale artifact | [#245](https://github.com/Nombah501/LiteAuction/issues/245) (open) | - |
+| S54-004 | Add telemetry trend deltas with low-sample guardrails | [#246](https://github.com/Nombah501/LiteAuction/issues/246) (open) | - |
+| S54-005 | Harden v1.2 safety and regression coverage | [#247](https://github.com/Nombah501/LiteAuction/issues/247) (open) | - |
 
 ## Recovery Checklist
 

--- a/planning/sprints/sprint-54.toml
+++ b/planning/sprints/sprint-54.toml
@@ -1,0 +1,85 @@
+sprint = "Sprint 54"
+milestone = "Sprint 54"
+milestone_description = "v1.2 kickoff: queue trust signals and evidence-aware triage"
+base_branch = "main"
+status_file = "planning/STATUS.md"
+
+[[items]]
+id = "S54-001"
+title = "Define queue SLA health model and aging thresholds"
+description = "Design deterministic SLA health states and aging-bucket thresholds for moderation queues with clear operator-facing semantics."
+priority = "P1"
+estimate = "M"
+tech_debt = true
+labels = ["type:feature", "area:moderation", "area:backend", "priority:p1", "tech-debt"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "SLA health states and countdown windows are documented with deterministic derivation rules",
+  "Aging bucket thresholds are bounded and testable across queue contexts",
+  "Contract notes include fallback behavior for missing or stale timing inputs",
+]
+
+[[items]]
+id = "S54-002"
+title = "Implement SLA indicators and aging filters in queue UI"
+description = "Expose per-row SLA health indicators and queue-level aging filter controls while preserving current dense-list context behavior."
+priority = "P1"
+estimate = "L"
+tech_debt = true
+labels = ["type:feature", "area:web", "area:admin", "area:moderation", "priority:p1", "tech-debt"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "Rows render SLA health and countdown metadata with stable visual ordering",
+  "Aging filter chips update list scope without losing existing sort/filter/focus context",
+  "Keyboard triage flow remains functional after SLA and aging controls are enabled",
+]
+
+[[items]]
+id = "S54-003"
+title = "Add inline evidence timeline and moderation rationale artifact"
+description = "Provide row-level evidence timeline context and capture concise moderation rationale artifacts for downstream audit review."
+priority = "P1"
+estimate = "L"
+tech_debt = true
+labels = ["type:enhancement", "area:web", "area:moderation", "area:trust", "priority:p1", "tech-debt"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "Operators can open an inline evidence timeline without leaving queue context",
+  "Moderation actions can include rationale artifacts with actor and timestamp metadata",
+  "Evidence and rationale records are immutable after write",
+]
+
+[[items]]
+id = "S54-004"
+title = "Add telemetry trend deltas with low-sample guardrails"
+description = "Extend workflow preset telemetry to report week-over-week trend deltas and suppress misleading signals when sample sizes are below configured thresholds."
+priority = "P2"
+estimate = "M"
+tech_debt = true
+labels = ["type:enhancement", "area:metrics", "area:backend", "priority:p2", "tech-debt"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "Telemetry surfaces include trend deltas for time-to-action, reopen rate, and filter churn",
+  "Low-sample segments are flagged or suppressed according to guardrail policy",
+  "Trend logic preserves queue and preset segmentation semantics",
+]
+
+[[items]]
+id = "S54-005"
+title = "Harden v1.2 safety and regression coverage"
+description = "Expand automated coverage for SLA, evidence, and trend surfaces with explicit RBAC/CSRF checks and integration assertions on persisted data paths."
+priority = "P1"
+estimate = "M"
+tech_debt = true
+labels = ["type:test", "area:tests", "area:security", "priority:p1", "tech-debt"]
+assignees = []
+create_draft_pr = true
+acceptance = [
+  "Automated tests cover SLA derivation and aging bucket behavior",
+  "Integration coverage validates evidence timeline and rationale persistence outputs",
+  "RBAC/CSRF assertions protect all new mutating and sensitive read endpoints",
+]


### PR DESCRIPTION
## Summary
- create fresh `.planning/REQUIREMENTS.md` for v1.2 Queue Trust Signals
- add Sprint 54 manifest and sync issue scaffolds (#243-#247)
- update roadmap/project/state/milestones/status docs for v1.2 kickoff continuity

Closes #248
