### PR TITLE
[Sprint 54][S54-001] Define queue SLA health contract

### DIFF
--- a/app/services/queue_sla_health_service.py
+++ b/app/services/queue_sla_health_service.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+
+@dataclass(slots=True, frozen=True)
+class QueueSlaThresholds:
+    warning_window: timedelta
+    critical_window: timedelta
+    aging_fresh_max: timedelta
+    aging_aging_max: timedelta
+    aging_stale_max: timedelta
+
+
+@dataclass(slots=True, frozen=True)
+class QueueSlaHealthDecision:
+    queue_context: str
+    health_state: str
+    aging_bucket: str
+    reason_code: str
+    countdown_seconds: int | None
+    fallback_applied: bool
+    fallback_notes: tuple[str, ...]
+
+
+_DEFAULT_QUEUE_CONTEXT = "moderation"
+_TERMINAL_STATUSES = frozenset({"RESOLVED", "REJECTED", "CLOSED", "DISMISSED", "DONE"})
+_ACTIVE_STATUSES_BY_CONTEXT = {
+    "moderation": frozenset({"OPEN", "IN_REVIEW"}),
+    "appeals": frozenset({"OPEN", "IN_REVIEW"}),
+    "risk": frozenset({"OPEN"}),
+    "feedback": frozenset({"VISIBLE", "PENDING", "OPEN"}),
+}
+
+SLA_THRESHOLDS_BY_CONTEXT = {
+    "moderation": QueueSlaThresholds(
+        warning_window=timedelta(hours=4),
+        critical_window=timedelta(hours=1),
+        aging_fresh_max=timedelta(hours=2),
+        aging_aging_max=timedelta(hours=6),
+        aging_stale_max=timedelta(hours=12),
+    ),
+    "appeals": QueueSlaThresholds(
+        warning_window=timedelta(hours=6),
+        critical_window=timedelta(hours=2),
+        aging_fresh_max=timedelta(hours=4),
+        aging_aging_max=timedelta(hours=12),
+        aging_stale_max=timedelta(hours=24),
+    ),
+    "risk": QueueSlaThresholds(
+        warning_window=timedelta(hours=2),
+        critical_window=timedelta(minutes=30),
+        aging_fresh_max=timedelta(hours=1),
+        aging_aging_max=timedelta(hours=3),
+        aging_stale_max=timedelta(hours=8),
+    ),
+    "feedback": QueueSlaThresholds(
+        warning_window=timedelta(hours=8),
+        critical_window=timedelta(hours=3),
+        aging_fresh_max=timedelta(hours=6),
+        aging_aging_max=timedelta(hours=18),
+        aging_stale_max=timedelta(hours=36),
+    ),
+}
+
+
+def _coerce_aware_utc(value: datetime | None, *, field_name: str, fallback_notes: list[str]) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        fallback_notes.append(f"{field_name}_assumed_utc")
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def decide_queue_sla_health(
+    *,
+    queue_context: str,
+    status: str,
+    created_at: datetime | None,
+    deadline_at: datetime | None,
+    now: datetime | None = None,
+) -> QueueSlaHealthDecision:
+    fallback_notes: list[str] = []
+
+    normalized_context = queue_context.strip().lower()
+    if normalized_context not in SLA_THRESHOLDS_BY_CONTEXT:
+        fallback_notes.append("unknown_queue_context")
+        normalized_context = _DEFAULT_QUEUE_CONTEXT
+
+    normalized_status = status.strip().upper()
+    if not normalized_status:
+        fallback_notes.append("missing_status_assumed_open")
+        normalized_status = "OPEN"
+
+    thresholds = SLA_THRESHOLDS_BY_CONTEXT[normalized_context]
+    current_time = _coerce_aware_utc(now or datetime.now(UTC), field_name="now", fallback_notes=fallback_notes)
+    assert current_time is not None
+    created_time = _coerce_aware_utc(created_at, field_name="created_at", fallback_notes=fallback_notes)
+    deadline_time = _coerce_aware_utc(deadline_at, field_name="deadline_at", fallback_notes=fallback_notes)
+
+    if normalized_status not in _ACTIVE_STATUSES_BY_CONTEXT[normalized_context]:
+        if normalized_status not in _TERMINAL_STATUSES:
+            fallback_notes.append("unknown_status_assumed_active")
+        else:
+            return QueueSlaHealthDecision(
+                queue_context=normalized_context,
+                health_state="closed",
+                aging_bucket="closed",
+                reason_code="closed_status",
+                countdown_seconds=None,
+                fallback_applied=bool(fallback_notes),
+                fallback_notes=tuple(fallback_notes),
+            )
+
+    if created_time is None:
+        aging_bucket = "unknown"
+        fallback_notes.append("missing_created_at")
+    else:
+        age = current_time - created_time
+        if age.total_seconds() < 0:
+            fallback_notes.append("created_at_in_future")
+            age = timedelta(0)
+
+        if age <= thresholds.aging_fresh_max:
+            aging_bucket = "fresh"
+        elif age <= thresholds.aging_aging_max:
+            aging_bucket = "aging"
+        elif age <= thresholds.aging_stale_max:
+            aging_bucket = "stale"
+        else:
+            aging_bucket = "critical"
+
+    if deadline_time is None:
+        return QueueSlaHealthDecision(
+            queue_context=normalized_context,
+            health_state="no_sla",
+            aging_bucket=aging_bucket,
+            reason_code="missing_deadline",
+            countdown_seconds=None,
+            fallback_applied=bool(fallback_notes),
+            fallback_notes=tuple(fallback_notes),
+        )
+
+    if created_time is not None and deadline_time < created_time:
+        fallback_notes.append("deadline_before_created_at")
+
+    remaining = deadline_time - current_time
+    countdown_seconds = max(int(remaining.total_seconds()), 0)
+
+    if remaining <= timedelta(0):
+        return QueueSlaHealthDecision(
+            queue_context=normalized_context,
+            health_state="overdue",
+            aging_bucket="overdue",
+            reason_code="deadline_elapsed",
+            countdown_seconds=0,
+            fallback_applied=bool(fallback_notes),
+            fallback_notes=tuple(fallback_notes),
+        )
+
+    if remaining <= thresholds.critical_window:
+        health_state = "critical"
+        reason_code = "critical_window"
+    elif remaining <= thresholds.warning_window:
+        health_state = "warning"
+        reason_code = "warning_window"
+    else:
+        health_state = "healthy"
+        reason_code = "within_budget"
+
+    return QueueSlaHealthDecision(
+        queue_context=normalized_context,
+        health_state=health_state,
+        aging_bucket=aging_bucket,
+        reason_code=reason_code,
+        countdown_seconds=countdown_seconds,
+        fallback_applied=bool(fallback_notes),
+        fallback_notes=tuple(fallback_notes),
+    )

--- a/docs/planning/sprint-54-queue-sla-health-contract.md
+++ b/docs/planning/sprint-54-queue-sla-health-contract.md
@@ -1,0 +1,42 @@
+# Sprint 54: Queue SLA Health Contract
+
+## Purpose
+
+Define deterministic SLA health and aging semantics for moderation queues so operators get consistent urgency signals before UI rollout.
+
+## Decision Surface
+
+`app/services/queue_sla_health_service.py` exposes `decide_queue_sla_health(...)` and returns:
+
+- `health_state`: `healthy`, `warning`, `critical`, `overdue`, `no_sla`, `closed`
+- `aging_bucket`: `fresh`, `aging`, `stale`, `critical`, `overdue`, `unknown`, `closed`
+- `reason_code`: deterministic reason for state assignment
+- `countdown_seconds`: remaining seconds to deadline (or `None` when no SLA)
+- `fallback_applied` and `fallback_notes`: explicit handling for missing or stale inputs
+
+## Thresholds by Queue Context
+
+| Queue context | Warning window | Critical window | Fresh max age | Aging max age | Stale max age |
+|---|---:|---:|---:|---:|---:|
+| `moderation` | 4h | 1h | 2h | 6h | 12h |
+| `appeals` | 6h | 2h | 4h | 12h | 24h |
+| `risk` | 2h | 30m | 1h | 3h | 8h |
+| `feedback` | 8h | 3h | 6h | 18h | 36h |
+
+## Deterministic Rules
+
+1. Unknown queue context falls back to `moderation` with `fallback_notes += ["unknown_queue_context"]`.
+2. Empty status falls back to `OPEN` with `fallback_notes += ["missing_status_assumed_open"]`.
+3. Terminal statuses (`RESOLVED`, `REJECTED`, `CLOSED`, `DISMISSED`, `DONE`) return `health_state=closed`.
+4. Missing deadline returns `health_state=no_sla` and keeps age-derived bucket.
+5. Deadline elapsed returns `health_state=overdue`, `aging_bucket=overdue`, `countdown_seconds=0`.
+6. Remaining time inside critical/warning windows maps to `critical` or `warning`; otherwise `healthy`.
+7. Missing `created_at` produces `aging_bucket=unknown` with `fallback_notes += ["missing_created_at"]`.
+8. Stale timing inputs are explicit:
+   - future `created_at` -> `created_at_in_future`
+   - `deadline_at < created_at` -> `deadline_before_created_at`
+
+## Notes for Phase 2 Integration
+
+- This contract intentionally does not prescribe CSS or UI wording; it stabilizes backend semantics first.
+- S54-002 should map `health_state` and `aging_bucket` to operator-facing labels/chips while preserving existing queue context behavior.

--- a/tests/test_queue_sla_health_service.py
+++ b/tests/test_queue_sla_health_service.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from app.services.queue_sla_health_service import SLA_THRESHOLDS_BY_CONTEXT, decide_queue_sla_health
+
+
+def _now() -> datetime:
+    return datetime(2026, 2, 20, 12, 0, tzinfo=UTC)
+
+
+def test_thresholds_are_bounded_for_all_contexts() -> None:
+    for thresholds in SLA_THRESHOLDS_BY_CONTEXT.values():
+        assert thresholds.warning_window > timedelta(0)
+        assert thresholds.critical_window > timedelta(0)
+        assert thresholds.warning_window > thresholds.critical_window
+        assert thresholds.aging_fresh_max > timedelta(0)
+        assert thresholds.aging_fresh_max < thresholds.aging_aging_max < thresholds.aging_stale_max
+
+
+def test_decide_queue_sla_health_reports_healthy_with_long_remaining() -> None:
+    now = _now()
+    decision = decide_queue_sla_health(
+        queue_context="appeals",
+        status="OPEN",
+        created_at=now - timedelta(hours=1),
+        deadline_at=now + timedelta(hours=10),
+        now=now,
+    )
+
+    assert decision.queue_context == "appeals"
+    assert decision.health_state == "healthy"
+    assert decision.aging_bucket == "fresh"
+    assert decision.reason_code == "within_budget"
+    assert decision.countdown_seconds == 36000
+    assert decision.fallback_applied is False
+
+
+def test_decide_queue_sla_health_reports_warning_window() -> None:
+    now = _now()
+    decision = decide_queue_sla_health(
+        queue_context="moderation",
+        status="IN_REVIEW",
+        created_at=now - timedelta(hours=5),
+        deadline_at=now + timedelta(hours=2),
+        now=now,
+    )
+
+    assert decision.health_state == "warning"
+    assert decision.aging_bucket == "aging"
+    assert decision.reason_code == "warning_window"
+
+
+def test_decide_queue_sla_health_reports_critical_window() -> None:
+    now = _now()
+    decision = decide_queue_sla_health(
+        queue_context="risk",
+        status="OPEN",
+        created_at=now - timedelta(hours=4),
+        deadline_at=now + timedelta(minutes=20),
+        now=now,
+    )
+
+    assert decision.health_state == "critical"
+    assert decision.aging_bucket == "stale"
+    assert decision.reason_code == "critical_window"
+
+
+def test_decide_queue_sla_health_reports_overdue() -> None:
+    now = _now()
+    decision = decide_queue_sla_health(
+        queue_context="feedback",
+        status="VISIBLE",
+        created_at=now - timedelta(hours=20),
+        deadline_at=now - timedelta(minutes=1),
+        now=now,
+    )
+
+    assert decision.health_state == "overdue"
+    assert decision.aging_bucket == "overdue"
+    assert decision.reason_code == "deadline_elapsed"
+    assert decision.countdown_seconds == 0
+
+
+def test_decide_queue_sla_health_handles_missing_deadline() -> None:
+    now = _now()
+    decision = decide_queue_sla_health(
+        queue_context="appeals",
+        status="OPEN",
+        created_at=now - timedelta(hours=16),
+        deadline_at=None,
+        now=now,
+    )
+
+    assert decision.health_state == "no_sla"
+    assert decision.aging_bucket == "stale"
+    assert decision.reason_code == "missing_deadline"
+    assert decision.countdown_seconds is None
+
+
+def test_decide_queue_sla_health_falls_back_for_unknown_context_and_status() -> None:
+    now = _now()
+    decision = decide_queue_sla_health(
+        queue_context="mystery",
+        status="",
+        created_at=now - timedelta(hours=3),
+        deadline_at=now + timedelta(hours=3),
+        now=now,
+    )
+
+    assert decision.queue_context == "moderation"
+    assert decision.health_state == "warning"
+    assert decision.fallback_applied is True
+    assert decision.fallback_notes == ("unknown_queue_context", "missing_status_assumed_open")
+
+
+def test_decide_queue_sla_health_short_circuits_closed_status() -> None:
+    now = _now()
+    decision = decide_queue_sla_health(
+        queue_context="appeals",
+        status="RESOLVED",
+        created_at=now - timedelta(hours=30),
+        deadline_at=now - timedelta(hours=5),
+        now=now,
+    )
+
+    assert decision.health_state == "closed"
+    assert decision.aging_bucket == "closed"
+    assert decision.reason_code == "closed_status"
+    assert decision.countdown_seconds is None
+
+
+def test_decide_queue_sla_health_marks_invalid_timing_inputs() -> None:
+    now = _now()
+    decision = decide_queue_sla_health(
+        queue_context="appeals",
+        status="OPEN",
+        created_at=now + timedelta(hours=1),
+        deadline_at=now,
+        now=now,
+    )
+
+    assert decision.health_state == "overdue"
+    assert decision.fallback_applied is True
+    assert "created_at_in_future" in decision.fallback_notes
+    assert "deadline_before_created_at" in decision.fallback_notes


### PR DESCRIPTION
## Summary
- add deterministic queue SLA health service with per-context warning/critical windows and aging buckets
- include explicit fallback semantics for unknown context/status and stale timing inputs
- document the contract and add unit coverage for thresholds, countdown states, and fallback notes

## Validation
- `python -m py_compile app/services/queue_sla_health_service.py tests/test_queue_sla_health_service.py`
- `python -m pytest -q tests/test_queue_sla_health_service.py` *(fails in this environment: `No module named pytest`)*
- `python -m ruff check app/services/queue_sla_health_service.py tests/test_queue_sla_health_service.py` *(fails in this environment: `No module named ruff`)*

Closes #243
