### PR TITLE
[Sprint 54][S54-005] Harden v1.2 safety and regression coverage

### DIFF
--- a/docs/planning/sprint-54-safety-regression-coverage.md
+++ b/docs/planning/sprint-54-safety-regression-coverage.md
@@ -1,0 +1,22 @@
+# Sprint 54 S54-005: Safety and Regression Coverage Hardening
+
+## Goal
+
+Lock in v1.2 behavior with explicit regression tests for SLA/evidence/trend surfaces and security checks for sensitive endpoints.
+
+## Coverage Added
+
+- Appeals action CSRF regressions:
+  - resolve/review/reject reject invalid CSRF tokens with 403.
+- Triage detail endpoint safety:
+  - requires authenticated context.
+  - enforces `user:ban` scope for appeals detail access.
+- Workflow preset telemetry endpoint safety:
+  - explicit 401 behavior for unauthenticated callers.
+- Persisted telemetry regression:
+  - aggregated segments expose low-sample guardrail fields and suppress trend deltas.
+
+## Rationale
+
+- Keeps v1.2 trust-signal features from regressing into permissive read access.
+- Ensures mutating actions retain CSRF protection as UI/telemetry features evolve.

--- a/tests/integration/test_web_appeals.py
+++ b/tests/integration/test_web_appeals.py
@@ -271,6 +271,59 @@ async def test_action_review_appeal_requires_user_ban_scope(monkeypatch) -> None
 
 
 @pytest.mark.asyncio
+async def test_action_resolve_appeal_rejects_invalid_csrf(monkeypatch) -> None:
+    monkeypatch.setattr("app.web.main._require_scope_permission", lambda _req, _scope: (None, _stub_auth()))
+    monkeypatch.setattr("app.web.main._validate_csrf_token", lambda *_args, **_kwargs: False)
+
+    response = await action_resolve_appeal(
+        _make_request("/actions/appeal/resolve", method="POST"),
+        appeal_id=7,
+        reason="checked",
+        return_to="/appeals?status=open&source=all",
+        csrf_token="bad",
+        confirmed="1",
+    )
+
+    assert response.status_code == 403
+    assert "CSRF check failed" in bytes(response.body).decode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_action_review_appeal_rejects_invalid_csrf(monkeypatch) -> None:
+    monkeypatch.setattr("app.web.main._require_scope_permission", lambda _req, _scope: (None, _stub_auth()))
+    monkeypatch.setattr("app.web.main._validate_csrf_token", lambda *_args, **_kwargs: False)
+
+    response = await action_review_appeal(
+        _make_request("/actions/appeal/review", method="POST"),
+        appeal_id=7,
+        reason="checked",
+        return_to="/appeals?status=open&source=all",
+        csrf_token="bad",
+    )
+
+    assert response.status_code == 403
+    assert "CSRF check failed" in bytes(response.body).decode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_action_reject_appeal_rejects_invalid_csrf(monkeypatch) -> None:
+    monkeypatch.setattr("app.web.main._require_scope_permission", lambda _req, _scope: (None, _stub_auth()))
+    monkeypatch.setattr("app.web.main._validate_csrf_token", lambda *_args, **_kwargs: False)
+
+    response = await action_reject_appeal(
+        _make_request("/actions/appeal/reject", method="POST"),
+        appeal_id=7,
+        reason="checked",
+        return_to="/appeals?status=open&source=all",
+        csrf_token="bad",
+        confirmed="1",
+    )
+
+    assert response.status_code == 403
+    assert "CSRF check failed" in bytes(response.body).decode("utf-8")
+
+
+@pytest.mark.asyncio
 async def test_action_review_appeal_updates_status(monkeypatch, integration_engine) -> None:
     session_factory = async_sessionmaker(bind=integration_engine, class_=AsyncSession, expire_on_commit=False)
 


### PR DESCRIPTION
## Summary
- add explicit RBAC/authorization regression checks for sensitive read endpoints (`/actions/triage/detail-section`, `/actions/workflow-presets/telemetry`)
- add CSRF regression tests for appeal mutation actions (resolve/review/reject)
- extend persisted telemetry integration assertions to verify low-sample guardrail outputs and trend-delta suppression semantics

## Validation
- `python -m py_compile tests/integration/test_web_triage_interactions.py tests/integration/test_web_appeals.py tests/integration/test_web_workflow_presets.py`
- `python -m pytest -q tests/integration/test_web_triage_interactions.py -k triage_detail_section` *(fails locally: `No module named pytest` in current environment)*

Closes #247