### PR TITLE
[Sprint 54][S54-006] Sync Sprint 54 planning status after completion

### DIFF
--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -1,15 +1,15 @@
 # Planning Status
 
-Last sync: 2026-02-20 13:40 UTC
+Last sync: 2026-02-21 16:17 UTC
 Active sprint: Sprint 54
 
 | Item | Title | Issue | PR |
 |---|---|---|---|
-| S54-001 | Define queue SLA health model and aging thresholds | [#243](https://github.com/Nombah501/LiteAuction/issues/243) (open) | - |
-| S54-002 | Implement SLA indicators and aging filters in queue UI | [#244](https://github.com/Nombah501/LiteAuction/issues/244) (open) | - |
-| S54-003 | Add inline evidence timeline and moderation rationale artifact | [#245](https://github.com/Nombah501/LiteAuction/issues/245) (open) | - |
-| S54-004 | Add telemetry trend deltas with low-sample guardrails | [#246](https://github.com/Nombah501/LiteAuction/issues/246) (open) | - |
-| S54-005 | Harden v1.2 safety and regression coverage | [#247](https://github.com/Nombah501/LiteAuction/issues/247) (open) | - |
+| S54-001 | Define queue SLA health model and aging thresholds | [#243](https://github.com/Nombah501/LiteAuction/issues/243) (closed) | - |
+| S54-002 | Implement SLA indicators and aging filters in queue UI | [#244](https://github.com/Nombah501/LiteAuction/issues/244) (closed) | - |
+| S54-003 | Add inline evidence timeline and moderation rationale artifact | [#245](https://github.com/Nombah501/LiteAuction/issues/245) (closed) | - |
+| S54-004 | Add telemetry trend deltas with low-sample guardrails | [#246](https://github.com/Nombah501/LiteAuction/issues/246) (closed) | - |
+| S54-005 | Harden v1.2 safety and regression coverage | [#247](https://github.com/Nombah501/LiteAuction/issues/247) (closed) | - |
 
 ## Recovery Checklist
 


### PR DESCRIPTION
## Summary
- rerun sprint sync for `planning/sprints/sprint-54.toml`
- refresh `planning/STATUS.md` to reflect closed Sprint 54 issues after merged PRs
- keep recovery checklist and active sprint marker aligned with current planning state

## Validation
- `python scripts/sprint_sync.py --manifest planning/sprints/sprint-54.toml`

Closes #255