### PR TITLE
[Sprint 56][S56-003] Redesign /points output into compact and detailed modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ Use it as a reply to a message that contains premium/custom emoji.
 /tradefeedback <auction_id> <1..5> [комментарий]
 /points
 /points <1..20>
+/points detailed [1..20]
 /topics
 ```
 

--- a/app/bot/handlers/points.py
+++ b/app/bot/handlers/points.py
@@ -32,6 +32,14 @@ from app.services.user_service import upsert_user
 router = Router(name="points")
 DEFAULT_POINTS_HISTORY_LIMIT = 5
 MAX_POINTS_HISTORY_LIMIT = 20
+POINTS_VIEW_COMPACT = "compact"
+POINTS_VIEW_DETAILED = "detailed"
+POINTS_VIEW_DETAILED_ALIASES = {"detailed", "full", "diag"}
+POINTS_VIEW_COMPACT_ALIASES = {"compact", "short"}
+POINTS_USAGE_TEXT = (
+    f"Формат: /points [1..{MAX_POINTS_HISTORY_LIMIT}]\n"
+    f"/points detailed [1..{MAX_POINTS_HISTORY_LIMIT}]"
+)
 
 
 def _event_label(event_type: PointsEventType) -> str:
@@ -46,9 +54,7 @@ def _event_label(event_type: PointsEventType) -> str:
     return "Ручная корректировка"
 
 
-def _parse_history_limit(raw: str | None) -> int | None:
-    if raw is None:
-        return DEFAULT_POINTS_HISTORY_LIMIT
+def _parse_history_limit(raw: str) -> int | None:
     if not raw.isdigit():
         return None
     value = int(raw)
@@ -57,7 +63,170 @@ def _parse_history_limit(raw: str | None) -> int | None:
     return value
 
 
-def _render_points_text(
+def _parse_points_options(text: str | None) -> tuple[str, int] | None:
+    parts = (text or "").split()
+    args = parts[1:] if parts else []
+    if len(args) > 2:
+        return None
+
+    mode = POINTS_VIEW_COMPACT
+    mode_specified = False
+    limit = DEFAULT_POINTS_HISTORY_LIMIT
+    limit_specified = False
+
+    for raw_arg in args:
+        token = raw_arg.lower()
+        if token in POINTS_VIEW_DETAILED_ALIASES:
+            if mode_specified and mode != POINTS_VIEW_DETAILED:
+                return None
+            mode = POINTS_VIEW_DETAILED
+            mode_specified = True
+            continue
+        if token in POINTS_VIEW_COMPACT_ALIASES:
+            if mode_specified and mode != POINTS_VIEW_COMPACT:
+                return None
+            mode = POINTS_VIEW_COMPACT
+            mode_specified = True
+            continue
+
+        parsed_limit = _parse_history_limit(raw_arg)
+        if parsed_limit is None or limit_specified:
+            return None
+        limit = parsed_limit
+        limit_specified = True
+
+    return mode, limit
+
+
+def _render_points_history_text(*, entries: list[PointsLedgerEntry], shown_limit: int) -> list[str]:
+    if not entries:
+        return ["Начислений пока нет"]
+
+    lines = ["", f"Последние операции (до {shown_limit}):"]
+    for entry in entries:
+        created_at = entry.created_at.astimezone().strftime("%d.%m %H:%M")
+        amount_text = f"+{entry.amount}" if entry.amount > 0 else str(entry.amount)
+        lines.append(f"- {created_at} | {amount_text} | {_event_label(PointsEventType(entry.event_type))}")
+    return lines
+
+
+def _render_boost_policy_compact_line(
+    *,
+    title: str,
+    command_hint: str,
+    policy: FeedbackPriorityBoostPolicy | GuarantorPriorityBoostPolicy | AppealPriorityBoostPolicy,
+) -> str:
+    if policy.daily_limit > 0:
+        daily_text = f"{policy.used_today}/{policy.daily_limit} (осталось {policy.remaining_today})"
+    else:
+        daily_text = "без дневного лимита"
+
+    is_available = policy.enabled and policy.remaining_today > 0 and policy.cooldown_remaining_seconds <= 0
+    status_text = "доступен" if is_available else "ограничен"
+    cooldown_text = (
+        f", кулдаун {policy.cooldown_remaining_seconds} сек"
+        if policy.cooldown_remaining_seconds > 0
+        else ""
+    )
+    return (
+        f"- {title}: {command_hint} ({status_text}; цена {policy.cost_points} points; "
+        f"лимит {daily_text}{cooldown_text})"
+    )
+
+
+def _render_points_compact_text(
+    *,
+    summary: UserPointsSummary,
+    entries: list[PointsLedgerEntry],
+    shown_limit: int,
+    feedback_boost_policy: FeedbackPriorityBoostPolicy,
+    guarantor_boost_policy: GuarantorPriorityBoostPolicy,
+    appeal_boost_policy: AppealPriorityBoostPolicy,
+    redemptions_used_today: int,
+    redemptions_used_this_week: int,
+    redemptions_spent_today: int,
+    redemptions_spent_this_week: int,
+    redemptions_spent_this_month: int,
+    cooldown_remaining_seconds: int,
+    account_age_remaining_seconds: int,
+) -> str:
+    global_daily_limit = max(settings.points_redemption_daily_limit, 0)
+    global_remaining_today = max(global_daily_limit - redemptions_used_today, 0)
+    global_weekly_limit = max(settings.points_redemption_weekly_limit, 0)
+    global_remaining_week = max(global_weekly_limit - redemptions_used_this_week, 0)
+    global_daily_spend_cap = max(settings.points_redemption_daily_spend_cap, 0)
+    global_spend_remaining_today = max(global_daily_spend_cap - redemptions_spent_today, 0)
+    global_weekly_spend_cap = max(settings.points_redemption_weekly_spend_cap, 0)
+    global_spend_remaining_week = max(global_weekly_spend_cap - redemptions_spent_this_week, 0)
+    global_monthly_spend_cap = max(settings.points_redemption_monthly_spend_cap, 0)
+    global_spend_remaining_month = max(global_monthly_spend_cap - redemptions_spent_this_month, 0)
+    min_earned_points = max(settings.points_redemption_min_earned_points, 0)
+    min_earned_points_remaining = max(min_earned_points - summary.total_earned, 0)
+    min_balance_after_redemption = max(settings.points_redemption_min_balance, 0)
+
+    blockers: list[str] = []
+    if not settings.points_redemption_enabled:
+        blockers.append("Глобальные редимпшены временно отключены")
+    if account_age_remaining_seconds > 0:
+        blockers.append(f"До доступа по возрасту аккаунта: {account_age_remaining_seconds} сек")
+    if min_earned_points_remaining > 0:
+        blockers.append(f"До допуска по заработанным points: {min_earned_points_remaining} points")
+    if cooldown_remaining_seconds > 0:
+        blockers.append(f"До следующего буста: {cooldown_remaining_seconds} сек")
+    if min_balance_after_redemption > 0 and summary.balance <= min_balance_after_redemption:
+        blockers.append(f"Нужно держать минимум {min_balance_after_redemption} points после буста")
+    if global_daily_limit > 0 and global_remaining_today <= 0:
+        blockers.append("Достигнут глобальный дневной лимит бустов")
+    if global_weekly_limit > 0 and global_remaining_week <= 0:
+        blockers.append("Достигнут глобальный недельный лимит бустов")
+    if global_daily_spend_cap > 0 and global_spend_remaining_today <= 0:
+        blockers.append("Достигнут глобальный дневной лимит списания")
+    if global_weekly_spend_cap > 0 and global_spend_remaining_week <= 0:
+        blockers.append("Достигнут глобальный недельный лимит списания")
+    if global_monthly_spend_cap > 0 and global_spend_remaining_month <= 0:
+        blockers.append("Достигнут глобальный месячный лимит списания")
+
+    lines = [
+        f"Баланс: {summary.balance} points",
+        f"Начислено/списано: +{summary.total_earned} / -{summary.total_spent}",
+        "",
+        "Быстрые действия:",
+        _render_boost_policy_compact_line(
+            title="Фидбек",
+            command_hint="/boostfeedback <feedback_id>",
+            policy=feedback_boost_policy,
+        ),
+        _render_boost_policy_compact_line(
+            title="Гарант",
+            command_hint="/boostguarant <request_id>",
+            policy=guarantor_boost_policy,
+        ),
+        _render_boost_policy_compact_line(
+            title="Апелляция",
+            command_hint="/boostappeal <appeal_id>",
+            policy=appeal_boost_policy,
+        ),
+    ]
+
+    if blockers:
+        lines.append("")
+        lines.append("Сейчас блокирует:")
+        for blocker in blockers[:4]:
+            lines.append(f"- {blocker}")
+        hidden_count = len(blockers) - 4
+        if hidden_count > 0:
+            lines.append(f"- Еще ограничений: {hidden_count} (подробно: /points detailed)")
+    else:
+        lines.append("")
+        lines.append("Ограничения: критичных блокеров нет")
+
+    lines.extend(_render_points_history_text(entries=entries, shown_limit=shown_limit))
+    lines.append("")
+    lines.append("Подробный режим: /points detailed")
+    return "\n".join(lines)
+
+
+def _render_points_detailed_text(
     *,
     summary: UserPointsSummary,
     entries: list[PointsLedgerEntry],
@@ -177,16 +346,7 @@ def _render_points_text(
             else "Следующий буст доступен сейчас"
         ),
     ]
-    if not entries:
-        lines.append("Начислений пока нет")
-        return "\n".join(lines)
-
-    lines.append("")
-    lines.append(f"Последние операции (до {shown_limit}):")
-    for entry in entries:
-        created_at = entry.created_at.astimezone().strftime("%d.%m %H:%M")
-        amount_text = f"+{entry.amount}" if entry.amount > 0 else str(entry.amount)
-        lines.append(f"- {created_at} | {amount_text} | {_event_label(PointsEventType(entry.event_type))}")
+    lines.extend(_render_points_history_text(entries=entries, shown_limit=shown_limit))
     return "\n".join(lines)
 
 
@@ -195,14 +355,11 @@ async def command_points(message: Message, bot: Bot | None = None) -> None:
     if message.from_user is None:
         return
 
-    parts = (message.text or "").split()
-    if len(parts) > 2:
-        await message.answer(f"Формат: /points [1..{MAX_POINTS_HISTORY_LIMIT}]")
+    parsed_options = _parse_points_options(message.text)
+    if parsed_options is None:
+        await message.answer(POINTS_USAGE_TEXT)
         return
-    limit = _parse_history_limit(parts[1] if len(parts) == 2 else None)
-    if limit is None:
-        await message.answer(f"Формат: /points [1..{MAX_POINTS_HISTORY_LIMIT}]")
-        return
+    mode, limit = parsed_options
 
     async with SessionFactory() as session:
         async with session.begin():
@@ -272,8 +429,12 @@ async def command_points(message: Message, bot: Bot | None = None) -> None:
                 now=now,
             )
 
+    render_points_text = _render_points_compact_text
+    if mode == POINTS_VIEW_DETAILED:
+        render_points_text = _render_points_detailed_text
+
     await message.answer(
-        _render_points_text(
+        render_points_text(
             summary=summary,
             entries=entries,
             shown_limit=limit,

--- a/tests/test_points_handler_views.py
+++ b/tests/test_points_handler_views.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from app.bot.handlers.points import (
+    POINTS_VIEW_COMPACT,
+    POINTS_VIEW_DETAILED,
+    _parse_points_options,
+    _render_points_compact_text,
+    _render_points_detailed_text,
+)
+from app.services.appeal_service import AppealPriorityBoostPolicy
+from app.services.feedback_service import FeedbackPriorityBoostPolicy
+from app.services.guarantor_service import GuarantorPriorityBoostPolicy
+from app.services.points_service import UserPointsSummary
+
+
+def _seed_policies() -> tuple[
+    FeedbackPriorityBoostPolicy,
+    GuarantorPriorityBoostPolicy,
+    AppealPriorityBoostPolicy,
+]:
+    return (
+        FeedbackPriorityBoostPolicy(
+            enabled=True,
+            cost_points=20,
+            daily_limit=2,
+            used_today=1,
+            remaining_today=1,
+            cooldown_seconds=60,
+            cooldown_remaining_seconds=0,
+        ),
+        GuarantorPriorityBoostPolicy(
+            enabled=True,
+            cost_points=30,
+            daily_limit=2,
+            used_today=0,
+            remaining_today=2,
+            cooldown_seconds=120,
+            cooldown_remaining_seconds=0,
+        ),
+        AppealPriorityBoostPolicy(
+            enabled=False,
+            cost_points=15,
+            daily_limit=1,
+            used_today=0,
+            remaining_today=1,
+            cooldown_seconds=30,
+            cooldown_remaining_seconds=15,
+        ),
+    )
+
+
+def test_parse_points_options_supports_modes_and_limit() -> None:
+    assert _parse_points_options("/points") == (POINTS_VIEW_COMPACT, 5)
+    assert _parse_points_options("/points detailed") == (POINTS_VIEW_DETAILED, 5)
+    assert _parse_points_options("/points detailed 2") == (POINTS_VIEW_DETAILED, 2)
+    assert _parse_points_options("/points 2 detailed") == (POINTS_VIEW_DETAILED, 2)
+    assert _parse_points_options("/points compact 3") == (POINTS_VIEW_COMPACT, 3)
+
+    assert _parse_points_options("/points detailed compact") is None
+    assert _parse_points_options("/points 0") is None
+    assert _parse_points_options("/points 1 2") is None
+
+
+def test_render_points_compact_text_is_actionable(monkeypatch) -> None:
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "points_redemption_enabled", True)
+    monkeypatch.setattr(settings, "points_redemption_daily_limit", 3)
+    monkeypatch.setattr(settings, "points_redemption_weekly_limit", 5)
+    monkeypatch.setattr(settings, "points_redemption_daily_spend_cap", 100)
+    monkeypatch.setattr(settings, "points_redemption_weekly_spend_cap", 200)
+    monkeypatch.setattr(settings, "points_redemption_monthly_spend_cap", 400)
+    monkeypatch.setattr(settings, "points_redemption_min_balance", 10)
+    monkeypatch.setattr(settings, "points_redemption_min_earned_points", 20)
+
+    feedback_policy, guarantor_policy, appeal_policy = _seed_policies()
+    text = _render_points_compact_text(
+        summary=UserPointsSummary(balance=42, total_earned=80, total_spent=38, operations_count=5),
+        entries=[],
+        shown_limit=5,
+        feedback_boost_policy=feedback_policy,
+        guarantor_boost_policy=guarantor_policy,
+        appeal_boost_policy=appeal_policy,
+        redemptions_used_today=1,
+        redemptions_used_this_week=2,
+        redemptions_spent_today=20,
+        redemptions_spent_this_week=35,
+        redemptions_spent_this_month=70,
+        cooldown_remaining_seconds=0,
+        account_age_remaining_seconds=0,
+    )
+
+    assert "Баланс: 42 points" in text
+    assert "Быстрые действия:" in text
+    assert "Подробный режим: /points detailed" in text
+    assert "Глобальный лимит бустов в день:" not in text
+
+
+def test_render_points_detailed_text_keeps_policy_diagnostics(monkeypatch) -> None:
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "points_redemption_enabled", False)
+    monkeypatch.setattr(settings, "points_redemption_daily_limit", 2)
+    monkeypatch.setattr(settings, "points_redemption_weekly_limit", 4)
+    monkeypatch.setattr(settings, "points_redemption_daily_spend_cap", 60)
+    monkeypatch.setattr(settings, "points_redemption_weekly_spend_cap", 120)
+    monkeypatch.setattr(settings, "points_redemption_monthly_spend_cap", 180)
+    monkeypatch.setattr(settings, "points_redemption_min_balance", 15)
+    monkeypatch.setattr(settings, "points_redemption_min_account_age_seconds", 3600)
+    monkeypatch.setattr(settings, "points_redemption_min_earned_points", 40)
+    monkeypatch.setattr(settings, "points_redemption_cooldown_seconds", 900)
+
+    feedback_policy, guarantor_policy, appeal_policy = _seed_policies()
+    text = _render_points_detailed_text(
+        summary=UserPointsSummary(balance=18, total_earned=30, total_spent=12, operations_count=3),
+        entries=[],
+        shown_limit=5,
+        feedback_boost_policy=feedback_policy,
+        guarantor_boost_policy=guarantor_policy,
+        appeal_boost_policy=appeal_policy,
+        redemptions_used_today=1,
+        redemptions_used_this_week=2,
+        redemptions_spent_today=20,
+        redemptions_spent_this_week=40,
+        redemptions_spent_this_month=80,
+        cooldown_remaining_seconds=120,
+        account_age_remaining_seconds=180,
+    )
+
+    assert "Ваш баланс: 18 points" in text
+    assert "Глобальный лимит бустов в день: 1/2 (осталось 1)" in text
+    assert "Глобальный статус редимпшенов: временно отключены" in text
+    assert "Минимум заработанных points для буста: 40 points" in text
+    assert "До следующего буста: 120 сек" in text


### PR DESCRIPTION
## Summary
- Switch `/points` default output to a compact mobile-first format focused on balance, immediate actions, and active blockers.
- Keep full policy diagnostics available via explicit detailed mode (`/points detailed`) with optional history limit parsing.
- Update points handler tests for both modes and add unit coverage for argument parsing and rendering invariants.

## Validation
- `.venv/bin/python -m ruff check app tests`
- `BOT_TOKEN=test .venv/bin/python -m pytest -q tests/test_points_handler_views.py`
- `BOT_TOKEN=test .venv/bin/python -m pytest -q tests`
  - Fails on pre-existing unrelated SQLite/JSONB mismatch in `tests/test_moderation_checklist_service.py`
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@127.0.0.1:55432/auction_test BOT_TOKEN=test .venv/bin/python -m pytest -q tests/integration`
  - Fails on pre-existing unrelated missing telemetry table in `tests/integration/test_web_dense_list_foundations.py`

Closes #265