### PR TITLE
[Sprint 56][S56-005] Expand bot smoke and resilience test matrix

### DIFF
--- a/docs/quality/s56-bot-smoke-resilience-matrix.md
+++ b/docs/quality/s56-bot-smoke-resilience-matrix.md
@@ -1,0 +1,28 @@
+# Sprint 56 Bot Smoke and Resilience Matrix
+
+This matrix tracks critical cross-role bot journeys and degraded Telegram API branches.
+
+## Coverage Matrix
+
+| Case | Role / Journey | Scenario | Automated Check |
+|---|---|---|---|
+| SMK-U1 | User | `/points` default and detailed outputs stay actionable | `tests/integration/test_points_command.py` |
+| SMK-S1 | Seller | Publish draft auction successfully | `tests/integration/test_publish_auction_flow.py::test_publish_command_activates_auction_and_persists_post` |
+| SMK-S2 | Seller | Publish rollback on partial failure | `tests/integration/test_publish_auction_flow.py::test_publish_command_rolls_back_album_when_send_photo_fails` |
+| SMK-M1 | Moderator | Resolve moderation callback and persist side effects | `tests/integration/test_moderation_callbacks_e2e.py::test_modrep_freeze_updates_db_and_refresh` |
+| CONT-1 | Moderator continuity | Repeated callback remains idempotent (restart/retry-safe) | `tests/integration/test_moderation_callbacks_e2e.py::test_modrep_freeze_repeat_click_is_idempotent` |
+| CONT-2 | Seller continuity | Activation-failure rollback avoids duplicate artifacts | `tests/integration/test_publish_auction_flow.py::test_publish_command_rolls_back_album_and_post_when_activation_fails` |
+| RES-R1 | Telegram degraded API | Retry-after while refreshing post caption | `tests/test_auction_media_upgrade.py::test_refresh_post_logs_retry_after_and_stops` |
+| RES-T1 | Telegram degraded API | Transient network error while refreshing post caption | `tests/test_auction_media_upgrade.py::test_refresh_post_logs_transient_network_error_and_stops` |
+| RES-F1 | Telegram degraded API | Forbidden while attaching media during refresh | `tests/test_auction_media_upgrade.py::test_refresh_post_logs_forbidden_while_attaching_media` |
+| RES-F2 | Telegram degraded API | Forbidden in moderation chat falls back to admins | `tests/test_moderation_topic_router.py::test_send_section_message_falls_back_to_admins_on_forbidden_in_moderation_chat` |
+| RES-F3 | Telegram degraded API | Forbidden DM delivery is classified and suppressed | `tests/test_private_topics_delivery_diagnostics.py::test_delivery_failure_log_includes_forbidden_reason_and_metric` |
+| RES-T2 | Telegram degraded API | Generic Telegram API error is classified and suppressed | `tests/test_private_topics_delivery_diagnostics.py::test_delivery_failure_log_includes_telegram_api_error_reason_and_metric` |
+
+## CI Evidence Commands
+
+- `python -m ruff check app tests`
+- `python -m pytest -q tests`
+- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://.../auction_test python -m pytest -q tests/integration`
+
+For PR evidence, include command output lines with pass/fail counts and links to CI jobs.

--- a/tests/test_auction_media_upgrade.py
+++ b/tests/test_auction_media_upgrade.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from typing import cast
 
 import pytest
 from aiogram import Bot
-from aiogram.exceptions import TelegramBadRequest
+from aiogram.exceptions import (
+    TelegramBadRequest,
+    TelegramForbiddenError,
+    TelegramNetworkError,
+    TelegramRetryAfter,
+)
 from aiogram.methods import EditMessageCaption, EditMessageMedia
 from aiogram.types import InputMediaPhoto
 
@@ -118,3 +124,114 @@ async def test_refresh_post_does_not_upgrade_for_unrelated_caption_error() -> No
 
     assert calls["caption"] == 1
     assert calls["media"] == 0
+
+
+@pytest.mark.asyncio
+async def test_refresh_post_logs_retry_after_and_stops(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    calls = {"caption": 0, "media": 0}
+
+    class _DummyBot:
+        async def edit_message_caption(self, **kwargs):
+            _ = kwargs
+            calls["caption"] += 1
+            raise TelegramRetryAfter(
+                method=EditMessageCaption(chat_id=100, message_id=10, caption="updated"),
+                message="Too Many Requests",
+                retry_after=2,
+            )
+
+        async def edit_message_media(self, **kwargs):
+            _ = kwargs
+            calls["media"] += 1
+
+    post = SimpleNamespace(id=10, inline_message_id=None, chat_id=100, message_id=10)
+    caplog.set_level(logging.WARNING)
+
+    await auction_service._refresh_auction_post_message(
+        cast(Bot, _DummyBot()),
+        post=post,
+        caption="updated",
+        reply_markup=None,
+        photo_file_id="photo_file_id_4",
+    )
+
+    assert calls["caption"] == 1
+    assert calls["media"] == 0
+    assert "Rate limited while refreshing auction post 10" in caplog.text
+    assert "retry_after=2" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_refresh_post_logs_transient_network_error_and_stops(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    calls = {"caption": 0, "media": 0}
+
+    class _DummyBot:
+        async def edit_message_caption(self, **kwargs):
+            _ = kwargs
+            calls["caption"] += 1
+            raise TelegramNetworkError(
+                method=EditMessageCaption(chat_id=100, message_id=10, caption="updated"),
+                message="timed out",
+            )
+
+        async def edit_message_media(self, **kwargs):
+            _ = kwargs
+            calls["media"] += 1
+
+    post = SimpleNamespace(id=11, inline_message_id=None, chat_id=100, message_id=10)
+    caplog.set_level(logging.WARNING)
+
+    await auction_service._refresh_auction_post_message(
+        cast(Bot, _DummyBot()),
+        post=post,
+        caption="updated",
+        reply_markup=None,
+        photo_file_id="photo_file_id_5",
+    )
+
+    assert calls["caption"] == 1
+    assert calls["media"] == 0
+    assert "Transient error while refreshing auction post 11" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_refresh_post_logs_forbidden_while_attaching_media(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    calls = {"caption": 0, "media": 0}
+
+    class _DummyBot:
+        async def edit_message_caption(self, **kwargs):
+            _ = kwargs
+            calls["caption"] += 1
+            raise TelegramBadRequest(
+                method=EditMessageCaption(chat_id=100, message_id=10, caption="updated"),
+                message="Bad Request: there is no caption in the message to edit",
+            )
+
+        async def edit_message_media(self, **kwargs):
+            _ = kwargs
+            calls["media"] += 1
+            raise TelegramForbiddenError(
+                method=EditMessageMedia(chat_id=100, message_id=10, media=InputMediaPhoto(media="photo")),
+                message="Forbidden: bot was blocked by the user",
+            )
+
+    post = SimpleNamespace(id=12, inline_message_id=None, chat_id=100, message_id=10)
+    caplog.set_level(logging.WARNING)
+
+    await auction_service._refresh_auction_post_message(
+        cast(Bot, _DummyBot()),
+        post=post,
+        caption="updated",
+        reply_markup=None,
+        photo_file_id="photo_file_id_6",
+    )
+
+    assert calls["caption"] == 1
+    assert calls["media"] == 1
+    assert "No rights to attach media for auction post 12" in caplog.text

--- a/tests/test_private_topics_delivery_diagnostics.py
+++ b/tests/test_private_topics_delivery_diagnostics.py
@@ -5,7 +5,7 @@ from typing import cast
 
 import pytest
 from aiogram import Bot
-from aiogram.exceptions import TelegramBadRequest
+from aiogram.exceptions import TelegramAPIError, TelegramBadRequest, TelegramForbiddenError
 from aiogram.methods import SendMessage
 
 from app.services import private_topics_service
@@ -111,3 +111,111 @@ async def test_delivery_failure_log_includes_event_and_failure_class(
     assert "event=auction_outbid" in caplog.text
     assert "reason=bad_request" in caplog.text
     assert "failure_class=TelegramBadRequest" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_delivery_failure_log_includes_forbidden_reason_and_metric(
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(private_topics_service.settings, "private_topics_enabled", False)
+    monkeypatch.setattr(private_topics_service, "SessionFactory", lambda: _SessionCtx())
+
+    async def _decision(*_args, **_kwargs) -> NotificationDeliveryDecision:
+        return NotificationDeliveryDecision(allowed=True, reason="allowed")
+
+    async def _record_sent(*, event_type: NotificationEventType, reason: str = "delivered") -> None:  # noqa: ARG001
+        return None
+
+    suppressed_reasons: list[str] = []
+
+    async def _record_suppressed(*, event_type: NotificationEventType, reason: str) -> None:  # noqa: ARG001
+        suppressed_reasons.append(reason)
+
+    async def _record_aggregated(*, event_type: NotificationEventType, reason: str, count: int = 1) -> None:  # noqa: ARG001
+        return None
+
+    async def _pop_deferred(*, tg_user_id: int, event_type: NotificationEventType) -> int:  # noqa: ARG001
+        return 0
+
+    caplog.set_level(logging.WARNING)
+    monkeypatch.setattr(private_topics_service, "notification_delivery_decision", _decision)
+    monkeypatch.setattr(private_topics_service, "record_notification_sent", _record_sent)
+    monkeypatch.setattr(private_topics_service, "record_notification_suppressed", _record_suppressed)
+    monkeypatch.setattr(private_topics_service, "record_notification_aggregated", _record_aggregated)
+    monkeypatch.setattr(private_topics_service, "pop_deferred_notification_count", _pop_deferred)
+
+    class _BotStub:
+        async def send_message(self, **kwargs):  # noqa: ANN201
+            raise TelegramForbiddenError(
+                method=SendMessage(chat_id=kwargs["chat_id"], text=kwargs["text"]),
+                message="Forbidden: bot was blocked by the user",
+            )
+
+    delivered = await private_topics_service.send_user_topic_message(
+        cast(Bot, _BotStub()),
+        tg_user_id=888,
+        purpose=private_topics_service.PrivateTopicPurpose.AUCTIONS,
+        text="hello",
+        notification_event=NotificationEventType.AUCTION_OUTBID,
+    )
+
+    assert delivered is False
+    assert "notification_delivery_failed" in caplog.text
+    assert "reason=forbidden" in caplog.text
+    assert "failure_class=TelegramForbiddenError" in caplog.text
+    assert suppressed_reasons == ["forbidden"]
+
+
+@pytest.mark.asyncio
+async def test_delivery_failure_log_includes_telegram_api_error_reason_and_metric(
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(private_topics_service.settings, "private_topics_enabled", False)
+    monkeypatch.setattr(private_topics_service, "SessionFactory", lambda: _SessionCtx())
+
+    async def _decision(*_args, **_kwargs) -> NotificationDeliveryDecision:
+        return NotificationDeliveryDecision(allowed=True, reason="allowed")
+
+    async def _record_sent(*, event_type: NotificationEventType, reason: str = "delivered") -> None:  # noqa: ARG001
+        return None
+
+    suppressed_reasons: list[str] = []
+
+    async def _record_suppressed(*, event_type: NotificationEventType, reason: str) -> None:  # noqa: ARG001
+        suppressed_reasons.append(reason)
+
+    async def _record_aggregated(*, event_type: NotificationEventType, reason: str, count: int = 1) -> None:  # noqa: ARG001
+        return None
+
+    async def _pop_deferred(*, tg_user_id: int, event_type: NotificationEventType) -> int:  # noqa: ARG001
+        return 0
+
+    caplog.set_level(logging.WARNING)
+    monkeypatch.setattr(private_topics_service, "notification_delivery_decision", _decision)
+    monkeypatch.setattr(private_topics_service, "record_notification_sent", _record_sent)
+    monkeypatch.setattr(private_topics_service, "record_notification_suppressed", _record_suppressed)
+    monkeypatch.setattr(private_topics_service, "record_notification_aggregated", _record_aggregated)
+    monkeypatch.setattr(private_topics_service, "pop_deferred_notification_count", _pop_deferred)
+
+    class _BotStub:
+        async def send_message(self, **kwargs):  # noqa: ANN201
+            raise TelegramAPIError(
+                method=SendMessage(chat_id=kwargs["chat_id"], text=kwargs["text"]),
+                message="Internal Telegram API error",
+            )
+
+    delivered = await private_topics_service.send_user_topic_message(
+        cast(Bot, _BotStub()),
+        tg_user_id=999,
+        purpose=private_topics_service.PrivateTopicPurpose.AUCTIONS,
+        text="hello",
+        notification_event=NotificationEventType.AUCTION_OUTBID,
+    )
+
+    assert delivered is False
+    assert "notification_delivery_failed" in caplog.text
+    assert "reason=telegram_api_error" in caplog.text
+    assert "failure_class=TelegramAPIError" in caplog.text
+    assert suppressed_reasons == ["telegram_api_error"]


### PR DESCRIPTION
## Summary
- Add a Sprint 56 smoke/resilience matrix document that maps critical cross-role bot journeys to automated test coverage.
- Expand resilience test coverage for auction post refresh handling of retry-after, transient network, and forbidden media-attach branches.
- Add degraded-delivery tests for moderation-topic admin fallback and private-topic forbidden/API-error classification with suppression metrics.

## Validation
- `/home/n501/VibeCoding/LiteAuction-s56-003/.venv/bin/python -m ruff check app tests`
- `BOT_TOKEN=test /home/n501/VibeCoding/LiteAuction-s56-003/.venv/bin/python -m pytest -q tests/test_auction_media_upgrade.py tests/test_moderation_topic_router.py tests/test_private_topics_delivery_diagnostics.py`
- `BOT_TOKEN=test /home/n501/VibeCoding/LiteAuction-s56-003/.venv/bin/python -m pytest -q tests`
  - Fails on pre-existing unrelated SQLite JSONB issue in `tests/test_moderation_checklist_service.py`

## Rollout / Rollback
- Rollout: test/documentation-only change; no runtime migration or config update.
- Rollback: revert this PR to restore previous test scope and remove the Sprint 56 matrix doc.

Closes #267