### PR TITLE
chore(planning): sync Sprint 56 closure status

### DIFF
--- a/planning/STATUS.md
+++ b/planning/STATUS.md
@@ -1,15 +1,15 @@
 # Planning Status
 
-Last sync: 2026-02-22 19:48 UTC
+Last sync: 2026-02-22 21:15 UTC
 Active sprint: Sprint 56
 
 | Item | Title | Issue | PR |
 |---|---|---|---|
-| S56-001 | Harden publish flow for album and post consistency | [#263](https://github.com/Nombah501/LiteAuction/issues/263) (open) | - |
-| S56-002 | Normalize moderation topic routing taxonomy | [#264](https://github.com/Nombah501/LiteAuction/issues/264) (open) | - |
+| S56-001 | Harden publish flow for album and post consistency | [#263](https://github.com/Nombah501/LiteAuction/issues/263) (closed) | - |
+| S56-002 | Normalize moderation topic routing taxonomy | [#264](https://github.com/Nombah501/LiteAuction/issues/264) (closed) | - |
 | S56-003 | Redesign /points output into compact and detailed modes | [#265](https://github.com/Nombah501/LiteAuction/issues/265) (closed) | - |
-| S56-004 | Modularize oversized bot handlers into use-case slices | [#266](https://github.com/Nombah501/LiteAuction/issues/266) (open) | - |
-| S56-005 | Expand bot smoke and resilience test matrix | [#267](https://github.com/Nombah501/LiteAuction/issues/267) (open) | - |
+| S56-004 | Modularize oversized bot handlers into use-case slices | [#266](https://github.com/Nombah501/LiteAuction/issues/266) (closed) | - |
+| S56-005 | Expand bot smoke and resilience test matrix | [#267](https://github.com/Nombah501/LiteAuction/issues/267) (closed) | - |
 
 ## Recovery Checklist
 


### PR DESCRIPTION
## Summary
- refresh `planning/STATUS.md` after Sprint 56 merges
- mark S56-001..S56-005 issue states as closed to match current GitHub state

## Validation
- `python scripts/sprint_sync.py --manifest planning/sprints/sprint-56.toml`

Closes #267