### PR TITLE
fix: restore auction lifecycle notifications in moderation chat

### DIFF
--- a/app/bot/handlers/bid_actions.py
+++ b/app/bot/handlers/bid_actions.py
@@ -65,6 +65,7 @@ from app.services.notification_copy_service import (
     auction_buyout_winner_text,
     outbid_digest_text,
     outbid_notification_text,
+    short_auction_ref,
 )
 from app.services.user_service import upsert_user
 
@@ -420,6 +421,19 @@ async def _notify_auction_finish(
             notification_event=NotificationEventType.AUCTION_WIN,
             auction_id=auction_id,
         )
+
+    seller_label = str(seller_tg_id) if seller_tg_id is not None else "нет"
+    winner_label = str(winner_tg_id) if winner_tg_id is not None else "нет"
+    await send_section_message(
+        bot,
+        section=ModerationTopicSection.AUCTIONS_CLOSED,
+        text=(
+            f"Лот {short_auction_ref(auction_id)} завершен выкупом.\n"
+            f"Продавец: {seller_label}\n"
+            f"Победитель: {winner_label}"
+        ),
+        reply_markup=reply_markup,
+    )
 
 
 @router.callback_query(F.data.startswith("bid:"))

--- a/app/bot/handlers/moderation.py
+++ b/app/bot/handlers/moderation.py
@@ -72,6 +72,7 @@ from app.services.moderation_service import (
     unban_user,
     unfreeze_auction,
 )
+from app.services.moderation_topic_router import ModerationTopicSection, send_section_message
 from app.services.moderation_dashboard_service import get_moderation_dashboard_snapshot
 from app.services.message_draft_service import send_progress_draft
 from app.services.chat_owner_guard_service import confirm_chat_owner_events
@@ -105,6 +106,7 @@ from app.services.notification_copy_service import (
     moderation_frozen_text,
     moderation_unfrozen_text,
     moderation_winner_text,
+    short_auction_ref,
 )
 from app.services.notification_metrics_service import load_notification_metrics_snapshot
 from app.services.bot_funnel_metrics_service import (
@@ -212,6 +214,45 @@ def _format_user_label(user: User | None) -> str:
     if user.username:
         return f"@{user.username}"
     return str(user.tg_user_id)
+
+
+def _format_actor_label(*, tg_user_id: int | None, username: str | None) -> str:
+    normalized_username = (username or "").strip().lstrip("@")
+    if normalized_username:
+        return f"@{normalized_username}"
+    if tg_user_id is None:
+        return "-"
+    return str(tg_user_id)
+
+
+async def _notify_auction_lifecycle_to_moderation(
+    bot: Bot,
+    *,
+    section: ModerationTopicSection,
+    event_text: str,
+    actor_tg_user_id: int | None,
+    actor_username: str | None,
+    reason: str | None = None,
+    winner_tg_user_id: int | None = None,
+    reply_markup: InlineKeyboardMarkup | None = None,
+) -> None:
+    actor_label = _format_actor_label(
+        tg_user_id=actor_tg_user_id,
+        username=actor_username,
+    )
+    lines = [event_text, f"Модератор: {actor_label}"]
+    normalized_reason = (reason or "").strip()
+    if normalized_reason:
+        lines.append(f"Причина: {normalized_reason}")
+    if winner_tg_user_id is not None:
+        lines.append(f"Победитель: {winner_tg_user_id}")
+
+    await send_section_message(
+        bot,
+        section=section,
+        text="\n".join(lines),
+        reply_markup=reply_markup,
+    )
 
 
 def _format_appeal_source(appeal: Appeal) -> str:
@@ -1889,8 +1930,9 @@ async def mod_freeze(message: Message, bot: Bot) -> None:
     await refresh_auction_posts(bot, auction_id)
     await message.answer(result.message)
 
+    reply_markup = await _auction_post_keyboard(bot, auction_id)
+
     if result.seller_tg_user_id:
-        reply_markup = await _auction_post_keyboard(bot, auction_id)
         await send_user_topic_message(
             bot,
             tg_user_id=result.seller_tg_user_id,
@@ -1900,6 +1942,16 @@ async def mod_freeze(message: Message, bot: Bot) -> None:
             notification_event=NotificationEventType.AUCTION_MOD_ACTION,
             auction_id=auction_id,
         )
+
+    await _notify_auction_lifecycle_to_moderation(
+        bot,
+        section=ModerationTopicSection.AUCTIONS_FROZEN,
+        event_text=f"Лот {short_auction_ref(auction_id)} заморожен.",
+        actor_tg_user_id=message.from_user.id,
+        actor_username=message.from_user.username,
+        reason=reason,
+        reply_markup=reply_markup,
+    )
 
 
 @router.message(Command("unfreeze"), F.chat.type == ChatType.PRIVATE)
@@ -1941,8 +1993,9 @@ async def mod_unfreeze(message: Message, bot: Bot) -> None:
     await refresh_auction_posts(bot, auction_id)
     await message.answer(result.message)
 
+    reply_markup = await _auction_post_keyboard(bot, auction_id)
+
     if result.seller_tg_user_id:
-        reply_markup = await _auction_post_keyboard(bot, auction_id)
         await send_user_topic_message(
             bot,
             tg_user_id=result.seller_tg_user_id,
@@ -1952,6 +2005,16 @@ async def mod_unfreeze(message: Message, bot: Bot) -> None:
             notification_event=NotificationEventType.AUCTION_MOD_ACTION,
             auction_id=auction_id,
         )
+
+    await _notify_auction_lifecycle_to_moderation(
+        bot,
+        section=ModerationTopicSection.AUCTIONS_ACTIVE,
+        event_text=f"Лот {short_auction_ref(auction_id)} разморожен.",
+        actor_tg_user_id=message.from_user.id,
+        actor_username=message.from_user.username,
+        reason=reason,
+        reply_markup=reply_markup,
+    )
 
 
 @router.message(Command("end"), F.chat.type == ChatType.PRIVATE)
@@ -2014,6 +2077,17 @@ async def mod_end(message: Message, bot: Bot) -> None:
             notification_event=NotificationEventType.AUCTION_MOD_ACTION,
             auction_id=auction_id,
         )
+
+    await _notify_auction_lifecycle_to_moderation(
+        bot,
+        section=ModerationTopicSection.AUCTIONS_CLOSED,
+        event_text=f"Лот {short_auction_ref(auction_id)} завершен модератором.",
+        actor_tg_user_id=message.from_user.id,
+        actor_username=message.from_user.username,
+        reason=reason,
+        winner_tg_user_id=result.winner_tg_user_id,
+        reply_markup=reply_markup,
+    )
 
 
 @router.message(Command("bids"), F.chat.type == ChatType.PRIVATE)
@@ -2788,8 +2862,8 @@ async def mod_panel_callbacks(callback: CallbackQuery, bot: Bot) -> None:
             return
 
         await refresh_auction_posts(bot, auction_id)
+        reply_markup = await _auction_post_keyboard(bot, auction_id)
         if seller_tg_user_id is not None:
-            reply_markup = await _auction_post_keyboard(bot, auction_id)
             await send_user_topic_message(
                 bot,
                 tg_user_id=seller_tg_user_id,
@@ -2799,6 +2873,16 @@ async def mod_panel_callbacks(callback: CallbackQuery, bot: Bot) -> None:
                 notification_event=NotificationEventType.AUCTION_MOD_ACTION,
                 auction_id=auction_id,
             )
+
+        await _notify_auction_lifecycle_to_moderation(
+            bot,
+            section=ModerationTopicSection.AUCTIONS_ACTIVE,
+            event_text=f"Лот {short_auction_ref(auction_id)} разморожен.",
+            actor_tg_user_id=callback.from_user.id,
+            actor_username=callback.from_user.username,
+            reason="Через modpanel",
+            reply_markup=reply_markup,
+        )
 
         text, keyboard = await _build_frozen_auctions_page(page)
         await callback.message.edit_text(text, reply_markup=keyboard)
@@ -3089,6 +3173,7 @@ async def mod_report_action(callback: CallbackQuery, bot: Bot) -> None:
     callback_message = "Действие выполнено"
     updated_text: str | None = None
     sanction_note: str | None = None
+    queue_event_reason: str | None = None
 
     async with SessionFactory() as session:
         async with session.begin():
@@ -3134,6 +3219,7 @@ async def mod_report_action(callback: CallbackQuery, bot: Bot) -> None:
                 )
                 callback_message = "Аукцион заморожен"
                 sanction_note = callback_message
+                queue_event_reason = f"Жалоба #{complaint_id}"
 
             elif action == "rm_top":
                 if view.complaint.target_bid_id is None:
@@ -3208,6 +3294,18 @@ async def mod_report_action(callback: CallbackQuery, bot: Bot) -> None:
     if auction_id is not None:
         await refresh_auction_posts(bot, auction_id)
 
+    if auction_id is not None and queue_event_reason is not None:
+        reply_markup = await _auction_post_keyboard(bot, auction_id)
+        await _notify_auction_lifecycle_to_moderation(
+            bot,
+            section=ModerationTopicSection.AUCTIONS_FROZEN,
+            event_text=f"Лот {short_auction_ref(auction_id)} заморожен.",
+            actor_tg_user_id=callback.from_user.id,
+            actor_username=callback.from_user.username,
+            reason=queue_event_reason,
+            reply_markup=reply_markup,
+        )
+
     if notify_target_tg_user_id is not None:
         sanction_label = sanction_note or "Применены санкции"
         appeal_note, appeal_keyboard = _build_appeal_cta(f"complaint_{complaint_id}")
@@ -3265,6 +3363,7 @@ async def mod_risk_action(callback: CallbackQuery, bot: Bot) -> None:
     auction_id: uuid.UUID | None = None
     banned_user_tg: int | None = None
     sanction_note: str | None = None
+    queue_event_reason: str | None = None
 
     async with SessionFactory() as session:
         async with session.begin():
@@ -3310,6 +3409,7 @@ async def mod_risk_action(callback: CallbackQuery, bot: Bot) -> None:
                 )
                 callback_message = "Аукцион заморожен"
                 sanction_note = callback_message
+                queue_event_reason = f"Фрод-сигнал #{signal_id}"
 
             elif action == "ban":
                 ban_result = await ban_user(
@@ -3345,6 +3445,18 @@ async def mod_risk_action(callback: CallbackQuery, bot: Bot) -> None:
 
     if auction_id is not None:
         await refresh_auction_posts(bot, auction_id)
+
+    if auction_id is not None and queue_event_reason is not None:
+        reply_markup = await _auction_post_keyboard(bot, auction_id)
+        await _notify_auction_lifecycle_to_moderation(
+            bot,
+            section=ModerationTopicSection.AUCTIONS_FROZEN,
+            event_text=f"Лот {short_auction_ref(auction_id)} заморожен.",
+            actor_tg_user_id=callback.from_user.id,
+            actor_username=callback.from_user.username,
+            reason=queue_event_reason,
+            reply_markup=reply_markup,
+        )
 
     if banned_user_tg is not None:
         sanction_label = sanction_note or "Применены санкции"

--- a/app/bot/handlers/publish_auction.py
+++ b/app/bot/handlers/publish_auction.py
@@ -8,7 +8,7 @@ from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError
 from aiogram.filters import Command
 from aiogram.types import InputMediaPhoto, Message
 
-from app.bot.keyboards.auction import auction_active_keyboard
+from app.bot.keyboards.auction import auction_active_keyboard, open_auction_post_keyboard
 from app.db.enums import AuctionStatus
 from app.db.session import SessionFactory
 from app.services.auction_service import (
@@ -18,7 +18,9 @@ from app.services.auction_service import (
     parse_auction_uuid,
     refresh_auction_posts,
     render_auction_caption,
+    resolve_auction_post_link,
 )
+from app.services.moderation_topic_router import ModerationTopicSection, send_section_message
 from app.services.publish_gate_service import evaluate_seller_publish_gate
 from app.services.user_service import upsert_user
 
@@ -185,6 +187,26 @@ async def publish_auction_to_current_chat(message: Message, bot: Bot) -> None:
         )
         await message.answer("Лот уже был опубликован. Обновите статус в личном чате с ботом.")
         return
+
+    post_username = sent_message.chat.username if isinstance(sent_message.chat.username, str) else None
+    post_url = resolve_auction_post_link(
+        chat_id=sent_message.chat.id,
+        message_id=sent_message.message_id,
+        username=post_username,
+    )
+    moderation_reply_markup = open_auction_post_keyboard(post_url) if post_url else None
+    publisher_label = (
+        f"@{message.from_user.username}" if message.from_user.username else str(message.from_user.id)
+    )
+    await send_section_message(
+        bot,
+        section=ModerationTopicSection.AUCTIONS_ACTIVE,
+        text=(
+            f"Новый активный лот #{str(auction_id)[:8]}.\n"
+            f"Публикатор: {publisher_label}."
+        ),
+        reply_markup=moderation_reply_markup,
+    )
 
     await refresh_auction_posts(bot, auction_id)
     try:

--- a/app/services/auction_service.py
+++ b/app/services/auction_service.py
@@ -31,9 +31,10 @@ from app.services.message_effects_service import (
     AuctionMessageEffectEvent,
     resolve_auction_message_effect_id,
 )
+from app.services.moderation_topic_router import ModerationTopicSection, send_section_message
 from app.services.private_topics_service import PrivateTopicPurpose, send_user_topic_message
 from app.services.notification_policy_service import NotificationEventType
-from app.services.notification_copy_service import auction_finished_text, auction_winner_text
+from app.services.notification_copy_service import auction_finished_text, auction_winner_text, short_auction_ref
 
 logger = logging.getLogger(__name__)
 
@@ -850,5 +851,17 @@ async def finalize_expired_auctions(bot: Bot) -> int:
                 notification_event=NotificationEventType.AUCTION_WIN,
                 auction_id=result.auction_id,
             )
+
+        winner_label = str(result.winner_tg_user_id) if result.winner_tg_user_id is not None else "нет"
+        await send_section_message(
+            bot,
+            section=ModerationTopicSection.AUCTIONS_CLOSED,
+            text=(
+                f"Автозавершение: лот {short_auction_ref(result.auction_id)} закрыт по таймеру.\n"
+                f"Продавец: {result.seller_tg_user_id}\n"
+                f"Победитель: {winner_label}"
+            ),
+            reply_markup=reply_markup,
+        )
 
     return len(finalized_results)

--- a/tests/integration/test_publish_auction_flow.py
+++ b/tests/integration/test_publish_auction_flow.py
@@ -18,6 +18,7 @@ from app.bot.handlers.publish_auction import publish_auction_to_current_chat
 from app.db.enums import AuctionStatus
 from app.db.models import Auction, AuctionPhoto, AuctionPost, Bid, Complaint, User
 from app.services.auction_service import create_draft_auction
+from app.services.moderation_topic_router import ModerationTopicSection
 
 
 @pytest_asyncio.fixture
@@ -71,6 +72,7 @@ class _DummyFromUser:
 class _DummyChat:
     def __init__(self, chat_id: int) -> None:
         self.id = chat_id
+        self.username: str | None = None
 
 
 class _DummyMessage:
@@ -106,7 +108,7 @@ class _DummyBot:
         _ = message_thread_id
         self.sent_media_group_calls += 1
         return [
-            SimpleNamespace(chat=SimpleNamespace(id=chat_id), message_id=message_id)
+            SimpleNamespace(chat=SimpleNamespace(id=chat_id, username=None), message_id=message_id)
             for message_id in self.album_message_ids
         ]
 
@@ -117,10 +119,14 @@ class _DummyBot:
                 method=SendPhoto(chat_id=chat_id, photo=photo),
                 message="Bad Request: cannot send photo",
             )
-        return SimpleNamespace(chat=SimpleNamespace(id=chat_id), message_id=self.post_message_id)
+        return SimpleNamespace(chat=SimpleNamespace(id=chat_id, username=None), message_id=self.post_message_id)
 
     async def delete_message(self, *, chat_id: int, message_id: int, **_kwargs) -> None:
         self.deleted_messages.append((chat_id, message_id))
+
+    async def send_message(self, *, chat_id: int, text: str, **_kwargs):
+        _ = text
+        return SimpleNamespace(chat=SimpleNamespace(id=chat_id, username=None), message_id=999)
 
 
 async def _seed_draft_auction(
@@ -162,12 +168,24 @@ async def test_publish_command_activates_auction_and_persists_post(
         return SimpleNamespace(allowed=True, block_message=None)
 
     refresh_calls: list[str] = []
+    moderation_calls: list[dict[str, object]] = []
 
     async def _refresh_stub(_bot, auction_id):
         refresh_calls.append(str(auction_id))
 
+    async def _send_section_stub(_bot, *, section, text, reply_markup=None):
+        moderation_calls.append(
+            {
+                "section": section,
+                "text": text,
+                "reply_markup": reply_markup,
+            }
+        )
+        return (999, 111)
+
     monkeypatch.setattr("app.bot.handlers.publish_auction.evaluate_seller_publish_gate", _allow_publish)
     monkeypatch.setattr("app.bot.handlers.publish_auction.refresh_auction_posts", _refresh_stub)
+    monkeypatch.setattr("app.bot.handlers.publish_auction.send_section_message", _send_section_stub)
 
     seller_tg_user_id, auction_id = await _seed_draft_auction(session_factory, seller_tg_user_id=94501)
     chat_id = -10094501
@@ -188,6 +206,9 @@ async def test_publish_command_activates_auction_and_persists_post(
     assert bot.sent_photo_calls == 1
     assert bot.deleted_messages == [(chat_id, command_message_id)]
     assert refresh_calls == [str(auction_id)]
+    assert len(moderation_calls) == 1
+    assert moderation_calls[0]["section"] == ModerationTopicSection.AUCTIONS_ACTIVE
+    assert f"#{str(auction_id)[:8]}" in str(moderation_calls[0]["text"])
 
     async with session_factory() as session:
         auction = await session.scalar(select(Auction).where(Auction.id == auction_id))

--- a/tests/test_bid_actions_outbid_notifications.py
+++ b/tests/test_bid_actions_outbid_notifications.py
@@ -105,7 +105,7 @@ async def test_notify_outbid_skips_debounce_gate_when_policy_disables_it(monkeyp
     def _disable_debounce_policy(_event_type: NotificationEventType) -> bool:
         return False
 
-    async def _raise_if_called(_auction_id: UUID, _tg_user_id: int) -> bool:
+    async def _raise_if_called_debounce(_auction_id: UUID, _tg_user_id: int) -> bool:
         raise AssertionError("debounce gate should not run when policy disables it")
 
     async def _capture_send(*_args, **kwargs):
@@ -120,15 +120,15 @@ async def test_notify_outbid_skips_debounce_gate_when_policy_disables_it(monkeyp
     ) -> None:
         return None
 
-    async def _raise_if_called(*, tg_user_id: int, auction_id: UUID) -> OutbidDigestDecision:  # noqa: ARG001
+    async def _raise_if_called_digest(*, tg_user_id: int, auction_id: UUID) -> OutbidDigestDecision:  # noqa: ARG001
         raise AssertionError("digest register should not run when suppression does not happen")
 
     monkeypatch.setattr(bid_actions, "should_apply_notification_debounce", _disable_debounce_policy)
-    monkeypatch.setattr(bid_actions, "acquire_outbid_notification_debounce", _raise_if_called)
+    monkeypatch.setattr(bid_actions, "acquire_outbid_notification_debounce", _raise_if_called_debounce)
     monkeypatch.setattr(bid_actions, "send_user_topic_message", _capture_send)
     monkeypatch.setattr(bid_actions, "record_notification_suppressed", _noop_suppressed)
     monkeypatch.setattr(bid_actions, "record_notification_aggregated", _noop_aggregated)
-    monkeypatch.setattr(bid_actions, "register_outbid_notification_suppression", _raise_if_called)
+    monkeypatch.setattr(bid_actions, "register_outbid_notification_suppression", _raise_if_called_digest)
 
     await bid_actions._notify_outbid(
         cast(Bot, _BotStub()),
@@ -181,3 +181,34 @@ async def test_notify_outbid_sends_digest_message_when_suppression_threshold_rea
     assert "Дайджест по лоту #12345678" in str(sent_calls[0]["text"])
     assert "перебивали 3 раза" in str(sent_calls[0]["text"])
     assert sent_calls[0]["reply_markup"] is not None
+
+
+@pytest.mark.asyncio
+async def test_notify_auction_finish_reports_closed_lot_to_moderation_topic(monkeypatch) -> None:
+    private_notifications: list[dict[str, object]] = []
+    moderation_notifications: list[dict[str, object]] = []
+
+    async def _capture_private(*_args, **kwargs):
+        private_notifications.append(kwargs)
+        return True
+
+    async def _capture_section(*_args, **kwargs):
+        moderation_notifications.append(kwargs)
+        return (700, 55)
+
+    monkeypatch.setattr(bid_actions, "send_user_topic_message", _capture_private)
+    monkeypatch.setattr(bid_actions, "send_section_message", _capture_section)
+
+    auction_id = UUID("12345678-1234-5678-1234-567812345678")
+    await bid_actions._notify_auction_finish(
+        cast(Bot, _BotStub()),
+        winner_tg_id=10,
+        seller_tg_id=20,
+        auction_id=auction_id,
+        post_url="https://t.me/example/10",
+    )
+
+    assert len(private_notifications) == 2
+    assert len(moderation_notifications) == 1
+    assert moderation_notifications[0]["section"] == bid_actions.ModerationTopicSection.AUCTIONS_CLOSED
+    assert "завершен выкупом" in str(moderation_notifications[0]["text"])


### PR DESCRIPTION
## Summary
- restore moderation-topic notifications for auction lifecycle events: publish, freeze/unfreeze, manual end, buyout close, and auto-close watcher
- route events into the dedicated auctions topic sections (`AUCTIONS_ACTIVE`, `AUCTIONS_FROZEN`, `AUCTIONS_CLOSED`) with contextual actor/reason details
- add regression coverage for publish and buyout-close moderation notifications and align test doubles with the handler message contract

## Verification
- `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@db:5432/auction_test python -m pytest -q tests/test_bid_actions_outbid_notifications.py tests/integration/test_publish_auction_flow.py`
- result: `8 passed`

Closes #284