### PR TITLE
feat: post-auction UX redesign — rich notifications, deal topics, guarantor integration

### DIFF
--- a/alembic/versions/0039_user_reputations.py
+++ b/alembic/versions/0039_user_reputations.py
@@ -1,0 +1,80 @@
+"""user_reputations
+
+Revision ID: 0039_user_reputations
+Revises: 0038_workflow_preset_telemetry
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0039_user_reputations"
+down_revision = "0038_workflow_preset_telemetry"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_reputation_events",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("delta", sa.Integer(), nullable=False),
+        sa.Column("reason", sa.String(32), nullable=False),
+        sa.Column("source_id", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("TIMEZONE('utc', NOW())"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_reputation_events_user_created",
+        "user_reputation_events",
+        ["user_id", "created_at"],
+    )
+    op.create_foreign_key(
+        "fk_user_reputation_events_user_id",
+        "user_reputation_events",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    op.create_table(
+        "user_reputations",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("score", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("tier", sa.String(16), nullable=False, server_default="NEW"),
+        sa.Column("last_event_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("TIMEZONE('utc', NOW())"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("TIMEZONE('utc', NOW())"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id"),
+    )
+    op.create_foreign_key(
+        "fk_user_reputations_user_id",
+        "user_reputations",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_reputations")
+    op.drop_table("user_reputation_events")

--- a/alembic/versions/d6ae79c2bdc0_add_deal_topics_and_guarantor_auction_id.py
+++ b/alembic/versions/d6ae79c2bdc0_add_deal_topics_and_guarantor_auction_id.py
@@ -1,0 +1,72 @@
+"""add_deal_topics_and_guarantor_auction_id
+
+Revision ID: d6ae79c2bdc0
+Revises: 0039_user_reputations
+Create Date: 2026-04-11 13:47:53.333670
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "d6ae79c2bdc0"
+down_revision: Union[str, None] = "0039_user_reputations"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "deal_topics",
+        sa.Column("id", sa.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "auction_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("auctions.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("seller_topic_id", sa.BigInteger(), nullable=False),
+        sa.Column("winner_topic_id", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "status",
+            sa.Enum("ACTIVE", "CLOSED", name="deal_topic_status"),
+            nullable=False,
+            server_default="ACTIVE",
+        ),
+        sa.Column("closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("TIMEZONE('utc', NOW())"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("TIMEZONE('utc', NOW())"),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_deal_topics_auction_id", "deal_topics", ["auction_id"])
+    op.create_index("ix_deal_topics_status", "deal_topics", ["status"])
+
+    op.add_column(
+        "guarantor_requests",
+        sa.Column(
+            "auction_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("auctions.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("guarantor_requests", "auction_id")
+    op.drop_index("ix_deal_topics_status", table_name="deal_topics")
+    op.drop_index("ix_deal_topics_auction_id", table_name="deal_topics")
+    op.drop_table("deal_topics")
+
+    op.execute("DROP TYPE IF EXISTS deal_topic_status")

--- a/app/bot/handlers/__init__.py
+++ b/app/bot/handlers/__init__.py
@@ -12,6 +12,7 @@ from .points import router as points_router
 from .publish_auction import router as publish_auction_router
 from .start import router as start_router
 from .suggested_posts import router as suggested_posts_router
+from .post_auction import router as post_auction_router
 from .trade_feedback import router as trade_feedback_router
 
 router = Router(name="root")
@@ -26,6 +27,7 @@ router.include_router(guarantor_router)
 router.include_router(points_router)
 router.include_router(publish_auction_router)
 router.include_router(trade_feedback_router)
+router.include_router(post_auction_router)
 router.include_router(suggested_posts_router)
 router.include_router(moderation_router)
 

--- a/app/bot/handlers/bid_actions.py
+++ b/app/bot/handlers/bid_actions.py
@@ -63,9 +63,15 @@ from app.services.notification_metrics_service import (
 from app.services.notification_copy_service import (
     auction_buyout_finished_text,
     auction_buyout_winner_text,
+    auction_finished_text,
+    auction_winner_text,
+    format_user_mention,
     outbid_digest_text,
     outbid_notification_text,
-    short_auction_ref,
+    seller_completion_text,
+    seller_no_bids_text,
+    winner_completion_text,
+    moderation_completion_text,
 )
 from app.services.user_service import upsert_user
 
@@ -391,48 +397,132 @@ async def _notify_auction_finish(
     seller_tg_id: int | None,
     auction_id: uuid.UUID,
     post_url: str | None,
+    final_price: int | None = None,
+    description: str | None = None,
+    winner_mention: str | None = None,
+    seller_mention: str | None = None,
+    is_buyout: bool = True,
+    had_bids: bool = True,
 ) -> None:
     resolved_post_url = post_url or await resolve_auction_post_url(bot, auction_id=auction_id)
-    reply_markup = open_auction_post_keyboard(resolved_post_url) if resolved_post_url else None
+    short_id = str(auction_id)[:8]
 
-    if seller_tg_id is not None:
+    if seller_tg_id is not None and had_bids and final_price is not None and winner_mention is not None:
+        from app.bot.keyboards.auction import deal_completion_keyboard
+
+        seller_text = seller_completion_text(
+            auction_id=auction_id,
+            description=description or "",
+            final_price=final_price,
+            counterparty_mention=winner_mention,
+            counterparty_role="победитель",
+            is_buyout=is_buyout,
+        )
+        seller_kb = deal_completion_keyboard(auction_id=short_id, post_url=resolved_post_url, is_seller=True)
+
         await send_user_topic_message(
             bot,
             tg_user_id=seller_tg_id,
             purpose=PrivateTopicPurpose.AUCTIONS,
-            text=auction_buyout_finished_text(auction_id),
-            reply_markup=reply_markup,
-            message_effect_id=resolve_auction_message_effect_id(
-                AuctionMessageEffectEvent.BUYOUT_SELLER
-            ),
+            text=seller_text,
+            reply_markup=seller_kb,
+            message_effect_id=resolve_auction_message_effect_id(AuctionMessageEffectEvent.BUYOUT_SELLER),
             notification_event=NotificationEventType.AUCTION_FINISH,
             auction_id=auction_id,
         )
-    if winner_tg_id is not None:
+    elif seller_tg_id is not None and not had_bids:
+        from app.bot.keyboards.auction import no_bids_keyboard
+
+        seller_text = seller_no_bids_text(
+            auction_id=auction_id,
+            description=description or "",
+            start_price=final_price or 0,
+        )
+        seller_kb = no_bids_keyboard(auction_id=short_id, post_url=resolved_post_url)
+
+        await send_user_topic_message(
+            bot,
+            tg_user_id=seller_tg_id,
+            purpose=PrivateTopicPurpose.AUCTIONS,
+            text=seller_text,
+            reply_markup=seller_kb,
+            notification_event=NotificationEventType.AUCTION_FINISH,
+            auction_id=auction_id,
+        )
+    elif seller_tg_id is not None:
+        reply_markup = open_auction_post_keyboard(resolved_post_url) if resolved_post_url else None
+        await send_user_topic_message(
+            bot,
+            tg_user_id=seller_tg_id,
+            purpose=PrivateTopicPurpose.AUCTIONS,
+            text=auction_buyout_finished_text(auction_id) if is_buyout else auction_finished_text(auction_id),
+            reply_markup=reply_markup,
+            message_effect_id=resolve_auction_message_effect_id(AuctionMessageEffectEvent.BUYOUT_SELLER),
+            notification_event=NotificationEventType.AUCTION_FINISH,
+            auction_id=auction_id,
+        )
+
+    if winner_tg_id is not None and had_bids and final_price is not None and seller_mention is not None:
+        from app.bot.keyboards.auction import deal_completion_keyboard
+
+        winner_text = winner_completion_text(
+            auction_id=auction_id,
+            description=description or "",
+            final_price=final_price,
+            counterparty_mention=seller_mention,
+            counterparty_role="продавец",
+            is_buyout=is_buyout,
+        )
+        winner_kb = deal_completion_keyboard(auction_id=short_id, post_url=resolved_post_url, is_seller=False)
+
         await send_user_topic_message(
             bot,
             tg_user_id=winner_tg_id,
             purpose=PrivateTopicPurpose.AUCTIONS,
-            text=auction_buyout_winner_text(auction_id),
+            text=winner_text,
+            reply_markup=winner_kb,
+            message_effect_id=resolve_auction_message_effect_id(AuctionMessageEffectEvent.BUYOUT_WINNER),
+            notification_event=NotificationEventType.AUCTION_WIN,
+            auction_id=auction_id,
+        )
+    elif winner_tg_id is not None:
+        reply_markup = open_auction_post_keyboard(resolved_post_url) if resolved_post_url else None
+        await send_user_topic_message(
+            bot,
+            tg_user_id=winner_tg_id,
+            purpose=PrivateTopicPurpose.AUCTIONS,
+            text=auction_buyout_winner_text(auction_id) if is_buyout else auction_winner_text(auction_id),
             reply_markup=reply_markup,
-            message_effect_id=resolve_auction_message_effect_id(
-                AuctionMessageEffectEvent.BUYOUT_WINNER
-            ),
+            message_effect_id=resolve_auction_message_effect_id(AuctionMessageEffectEvent.BUYOUT_WINNER),
             notification_event=NotificationEventType.AUCTION_WIN,
             auction_id=auction_id,
         )
 
-    seller_label = str(seller_tg_id) if seller_tg_id is not None else "нет"
-    winner_label = str(winner_tg_id) if winner_tg_id is not None else "нет"
+    from app.bot.keyboards.auction import moderation_completion_keyboard
+
+    seller_label = seller_mention or (str(seller_tg_id) if seller_tg_id is not None else "нет")
+    winner_label = winner_mention or (str(winner_tg_id) if winner_tg_id is not None else "нет")
+
+    mod_text = moderation_completion_text(
+        auction_id=auction_id,
+        description=description or "",
+        final_price=final_price or 0,
+        bid_count=0,
+        seller_mention=seller_label,
+        winner_mention=winner_label,
+        seller_reputation=0,
+        winner_reputation=0,
+        has_deal_topic=False,
+        has_guarantor=False,
+        reason="выкупом" if is_buyout else "по таймеру",
+    )
+    mod_kb = moderation_completion_keyboard(auction_id=short_id, post_url=resolved_post_url)
+
     await send_section_message(
         bot,
         section=ModerationTopicSection.AUCTIONS_CLOSED,
-        text=(
-            f"Лот {short_auction_ref(auction_id)} завершен выкупом.\n"
-            f"Продавец: {seller_label}\n"
-            f"Победитель: {winner_label}"
-        ),
-        reply_markup=reply_markup,
+        text=mod_text,
+        reply_markup=mod_kb,
     )
 
 
@@ -678,12 +768,36 @@ async def handle_buyout_action(callback: CallbackQuery, bot: Bot) -> None:
         await _maybe_send_fraud_alert(bot, result.fraud_signal_id)
 
     if result.auction_finished:
+        winner_mention_val = (
+            format_user_mention(
+                username=result.winner_username,
+                first_name=result.winner_first_name,
+                tg_user_id=result.winner_tg_user_id,
+            )
+            if result.winner_tg_user_id
+            else None
+        )
+        seller_mention_val = (
+            format_user_mention(
+                username=result.seller_username,
+                first_name=result.seller_first_name,
+                tg_user_id=result.seller_tg_user_id,
+            )
+            if result.seller_tg_user_id
+            else None
+        )
         await _notify_auction_finish(
             bot,
             winner_tg_id=result.winner_tg_user_id,
             seller_tg_id=result.seller_tg_user_id,
             auction_id=auction_id,
             post_url=post_url,
+            final_price=result.final_price,
+            description=result.description,
+            winner_mention=winner_mention_val,
+            seller_mention=seller_mention_val,
+            is_buyout=True,
+            had_bids=result.had_bids,
         )
 
 

--- a/app/bot/handlers/moderation.py
+++ b/app/bot/handlers/moderation.py
@@ -25,7 +25,12 @@ from app.bot.keyboards.moderation import (
     moderation_panel_keyboard,
     moderation_signals_list_keyboard,
 )
-from app.bot.keyboards.auction import open_auction_post_keyboard
+from app.bot.keyboards.auction import (
+    deal_completion_keyboard,
+    moderation_completion_keyboard,
+    no_bids_keyboard,
+    open_auction_post_keyboard,
+)
 from app.config import settings
 from app.db.enums import AppealSourceType, AppealStatus, AuctionStatus, ModerationAction, PointsEventType, ReputationEventReason
 from app.db.models import Appeal, Auction, User
@@ -102,11 +107,15 @@ from app.services.private_topics_service import (
 from app.services.notification_policy_service import NotificationEventType
 from app.services.notification_copy_service import (
     moderation_bid_removed_text,
+    moderation_completion_text,
     moderation_ended_text,
     moderation_frozen_text,
     moderation_unfrozen_text,
     moderation_winner_text,
+    seller_completion_text,
+    seller_no_bids_text,
     short_auction_ref,
+    winner_completion_text,
 )
 from app.services.notification_metrics_service import load_notification_metrics_snapshot
 from app.services.bot_funnel_metrics_service import (
@@ -215,6 +224,15 @@ def _format_user_label(user: User | None) -> str:
     if user.username:
         return f"@{user.username}"
     return str(user.tg_user_id)
+
+
+def _build_result_mention(username: str | None, first_name: str | None, tg_id: int | None) -> str:
+    if tg_id is None:
+        return "нет"
+    if username:
+        return f"@{username}"
+    display = first_name or "Пользователь"
+    return f'<a href="tg://user?id={tg_id}">{display}</a>'
 
 
 def _format_actor_label(*, tg_user_id: int | None, username: str | None) -> str:
@@ -2057,38 +2075,111 @@ async def mod_end(message: Message, bot: Bot) -> None:
     await refresh_auction_posts(bot, auction_id)
     await message.answer(result.message)
 
-    reply_markup = await _auction_post_keyboard(bot, auction_id)
-    if result.seller_tg_user_id:
-        await send_user_topic_message(
-            bot,
-            tg_user_id=result.seller_tg_user_id,
-            purpose=PrivateTopicPurpose.AUCTIONS,
-            text=moderation_ended_text(auction_id),
-            reply_markup=reply_markup,
-            notification_event=NotificationEventType.AUCTION_MOD_ACTION,
-            auction_id=auction_id,
+    from app.services.auction_service import FinalizeResult
+
+    fin: FinalizeResult | None = result.finalize_result
+    post_url = await resolve_auction_post_url(bot, auction_id=auction_id)
+    short_id = str(auction_id)[:8]
+
+    if fin is not None:
+        winner_mention = _build_result_mention(
+            fin.winner_username, fin.winner_first_name, fin.winner_tg_user_id,
         )
-    if result.winner_tg_user_id:
-        await send_user_topic_message(
-            bot,
-            tg_user_id=result.winner_tg_user_id,
-            purpose=PrivateTopicPurpose.AUCTIONS,
-            text=moderation_winner_text(auction_id),
-            reply_markup=reply_markup,
-            notification_event=NotificationEventType.AUCTION_MOD_ACTION,
-            auction_id=auction_id,
+        seller_mention = _build_result_mention(
+            fin.seller_username, fin.seller_first_name, fin.seller_tg_user_id,
         )
 
-    await _notify_auction_lifecycle_to_moderation(
-        bot,
-        section=ModerationTopicSection.AUCTIONS_CLOSED,
-        event_text=f"Лот {short_auction_ref(auction_id)} завершен модератором.",
-        actor_tg_user_id=message.from_user.id,
-        actor_username=message.from_user.username,
-        reason=reason,
-        winner_tg_user_id=result.winner_tg_user_id,
-        reply_markup=reply_markup,
-    )
+        if fin.had_bids and fin.final_price is not None:
+            seller_text = seller_completion_text(
+                auction_id=auction_id,
+                description=fin.description or "",
+                final_price=fin.final_price,
+                counterparty_mention=winner_mention,
+                counterparty_role="победитель",
+                is_mod_action=True,
+            )
+            seller_kb = deal_completion_keyboard(auction_id=short_id, post_url=post_url, is_seller=True)
+        else:
+            seller_text = seller_no_bids_text(
+                auction_id=auction_id,
+                description=fin.description or "",
+                start_price=fin.final_price or 0,
+            )
+            seller_kb = no_bids_keyboard(auction_id=short_id, post_url=post_url)
+
+        if result.seller_tg_user_id:
+            await send_user_topic_message(
+                bot,
+                tg_user_id=result.seller_tg_user_id,
+                purpose=PrivateTopicPurpose.AUCTIONS,
+                text=seller_text,
+                reply_markup=seller_kb,
+                notification_event=NotificationEventType.AUCTION_MOD_ACTION,
+                auction_id=auction_id,
+            )
+
+        if fin.winner_tg_user_id is not None and fin.had_bids and fin.final_price is not None:
+            winner_text = winner_completion_text(
+                auction_id=auction_id,
+                description=fin.description or "",
+                final_price=fin.final_price,
+                counterparty_mention=seller_mention,
+                counterparty_role="продавец",
+                is_mod_action=True,
+            )
+            winner_kb = deal_completion_keyboard(auction_id=short_id, post_url=post_url, is_seller=False)
+            await send_user_topic_message(
+                bot,
+                tg_user_id=fin.winner_tg_user_id,
+                purpose=PrivateTopicPurpose.AUCTIONS,
+                text=winner_text,
+                reply_markup=winner_kb,
+                notification_event=NotificationEventType.AUCTION_MOD_ACTION,
+                auction_id=auction_id,
+            )
+
+        mod_text = moderation_completion_text(
+            auction_id=auction_id,
+            description=fin.description or "",
+            final_price=fin.final_price or 0,
+            bid_count=0,
+            seller_mention=seller_mention,
+            winner_mention=winner_mention,
+            seller_reputation=0,
+            winner_reputation=0,
+            has_deal_topic=False,
+            has_guarantor=False,
+            reason="модератором",
+        )
+        mod_kb = moderation_completion_keyboard(auction_id=short_id, post_url=post_url)
+        await send_section_message(
+            bot,
+            section=ModerationTopicSection.AUCTIONS_CLOSED,
+            text=mod_text,
+            reply_markup=mod_kb,
+        )
+    else:
+        reply_markup = await _auction_post_keyboard(bot, auction_id)
+        if result.seller_tg_user_id:
+            await send_user_topic_message(
+                bot,
+                tg_user_id=result.seller_tg_user_id,
+                purpose=PrivateTopicPurpose.AUCTIONS,
+                text=moderation_ended_text(auction_id),
+                reply_markup=reply_markup,
+                notification_event=NotificationEventType.AUCTION_MOD_ACTION,
+                auction_id=auction_id,
+            )
+        if result.winner_tg_user_id:
+            await send_user_topic_message(
+                bot,
+                tg_user_id=result.winner_tg_user_id,
+                purpose=PrivateTopicPurpose.AUCTIONS,
+                text=moderation_winner_text(auction_id),
+                reply_markup=reply_markup,
+                notification_event=NotificationEventType.AUCTION_MOD_ACTION,
+                auction_id=auction_id,
+            )
 
 
 @router.message(Command("bids"), F.chat.type == ChatType.PRIVATE)

--- a/app/bot/handlers/moderation.py
+++ b/app/bot/handlers/moderation.py
@@ -27,7 +27,7 @@ from app.bot.keyboards.moderation import (
 )
 from app.bot.keyboards.auction import open_auction_post_keyboard
 from app.config import settings
-from app.db.enums import AppealSourceType, AppealStatus, AuctionStatus, ModerationAction, PointsEventType
+from app.db.enums import AppealSourceType, AppealStatus, AuctionStatus, ModerationAction, PointsEventType, ReputationEventReason
 from app.db.models import Appeal, Auction, User
 from app.db.session import SessionFactory
 from app.services.bot_profile_photo_service import (
@@ -123,6 +123,7 @@ from app.services.rbac_service import (
     SCOPE_USER_BAN,
 )
 from app.services.user_service import upsert_user
+from app.services.reputation_service import adjust_reputation, get_or_create_reputation, get_reputation_history
 from app.services.verification_service import (
     get_user_verification_status,
     load_verified_tg_user_ids,
@@ -3480,3 +3481,84 @@ async def mod_risk_action(callback: CallbackQuery, bot: Bot) -> None:
             pass
 
     await callback.answer(callback_message)
+
+
+@router.message(Command("reputation"), F.chat.type == ChatType.PRIVATE)
+async def command_reputation(message: Message, bot: Bot) -> None:
+    if message.from_user is None:
+        return
+    if not await _ensure_moderation_topic(message, bot, "/reputation"):
+        return
+
+    target_text = (message.text or "").strip().split(maxsplit=1)
+    if len(target_text) < 2:
+        await message.answer("Формат: /reputation <user_id>")
+        return
+
+    try:
+        target_user_id = int(target_text[1].strip())
+    except ValueError:
+        await message.answer("user_id должен быть числом")
+        return
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            reputation = await get_or_create_reputation(session, target_user_id)
+            history = await get_reputation_history(session, target_user_id, limit=10)
+            user = await session.scalar(select(User).where(User.id == target_user_id))
+
+    tier_labels = {
+        "NEW": "🆕 NEW",
+        "BRONZE": "🥉 BRONZE",
+        "SILVER": "🥈 SILVER",
+        "GOLD": "🥇 GOLD",
+        "PLATINUM": "💎 PLATINUM",
+    }
+    user_label = f"@{user.username}" if user and user.username else str(target_user_id)
+    tier_display = tier_labels.get(reputation.tier, reputation.tier)
+
+    lines = [
+        f"Пользователь: {user_label}",
+        f"Уровень: {tier_display} (score: {reputation.score})",
+        "",
+        "Последние события:",
+    ]
+    for event in history:
+        sign = "+" if event.delta > 0 else ""
+        lines.append(f"  {sign}{event.delta} — {event.reason}")
+
+    await message.answer("\n".join(lines))
+
+
+@router.message(Command("modrepadjust"), F.chat.type == ChatType.PRIVATE)
+async def command_mod_reputation_adjust(message: Message, bot: Bot) -> None:
+    if message.from_user is None:
+        return
+    if not await _ensure_moderation_topic(message, bot, "/modrepadjust"):
+        return
+
+    parts = (message.text or "").strip().split(maxsplit=3)
+    if len(parts) < 3:
+        await message.answer("Формат: /modrepadjust <user_id> <delta> [reason]")
+        return
+
+    try:
+        target_user_id = int(parts[1])
+        delta = int(parts[2])
+    except ValueError:
+        await message.answer("user_id и delta должны быть числами")
+        return
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            reputation = await adjust_reputation(
+                session, target_user_id, delta, ReputationEventReason.MOD_ADJUST
+            )
+
+    if reputation is None:
+        await message.answer("Пользователь не найден или нет записи репутации")
+        return
+
+    await message.answer(
+        f"Репутация обновлена: score={reputation.score}, tier={reputation.tier}"
+    )

--- a/app/bot/handlers/post_auction.py
+++ b/app/bot/handlers/post_auction.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import uuid
+
+from aiogram import Bot, Router, F
+from aiogram.types import CallbackQuery, Message, InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.fsm.context import FSMContext
+from sqlalchemy import select
+
+from app.db.models import Auction, User
+from app.db.enums import AuctionStatus
+from app.bot.states.post_auction import FeedbackFSM, DealGuarantorFSM
+from app.db.session import SessionFactory
+from app.services.deal_topic_service import (
+    get_or_create_deal_topic,
+    ensure_winner_topic,
+)
+from app.services.trade_feedback_service import submit_trade_feedback
+from app.services.guarantor_service import create_guarantor_request
+from app.services.notification_copy_service import format_user_mention
+
+router = Router(name="post_auction")
+
+
+def parse_deal_callback(data: str) -> tuple[str, uuid.UUID]:
+    parts = data.split(":")
+    return parts[1], uuid.UUID(parts[2])
+
+
+@router.callback_query(F.data.startswith("deal:write:"))
+async def handle_deal_write(callback: CallbackQuery, bot: Bot, state: FSMContext) -> None:
+    await state.clear()
+    action, auction_id = parse_deal_callback(callback.data)
+    assert action == "write"
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            auction = await session.scalar(
+                select(Auction).where(Auction.id == auction_id)
+            )
+            if auction is None:
+                await callback.answer("Аукцион не найден", show_alert=True)
+                return
+
+            seller = await session.scalar(select(User).where(User.id == auction.seller_user_id))
+            winner = (
+                await session.scalar(select(User).where(User.id == auction.winner_user_id))
+                if auction.winner_user_id
+                else None
+            )
+
+            if winner is None:
+                await callback.answer("Нет победителя для связи", show_alert=True)
+                return
+
+            caller_tg_id = callback.from_user.id
+            is_seller = seller is not None and caller_tg_id == seller.tg_user_id
+
+            seller_mention = format_user_mention(
+                username=seller.username if seller else None,
+                first_name=seller.first_name if seller else None,
+                tg_user_id=seller.tg_user_id if seller else 0,
+            ) if seller else "—"
+            winner_mention = format_user_mention(
+                username=winner.username,
+                first_name=winner.first_name,
+                tg_user_id=winner.tg_user_id,
+            )
+
+            deal = await get_or_create_deal_topic(
+                session,
+                bot=bot,
+                auction_id=auction_id,
+                seller_tg_id=seller.tg_user_id if seller else 0,
+                winner_tg_id=winner.tg_user_id,
+                description=auction.description,
+                final_price=auction.start_price,
+                seller_mention=seller_mention,
+                winner_mention=winner_mention,
+            )
+
+            if is_seller:
+                await ensure_winner_topic(
+                    session,
+                    bot=bot,
+                    deal=deal,
+                    winner_tg_id=winner.tg_user_id,
+                    auction_id=auction_id,
+                    description=auction.description,
+                    final_price=auction.start_price,
+                    seller_mention=seller_mention,
+                    winner_mention=winner_mention,
+                )
+
+    await callback.answer("Топик сделки открыт")
+
+
+@router.callback_query(F.data.startswith("deal:feedback:"))
+async def handle_deal_feedback(callback: CallbackQuery, state: FSMContext) -> None:
+    await state.clear()
+    _, auction_id = parse_deal_callback(callback.data)
+
+    await state.update_data(feedback_auction_id=str(auction_id))
+    await state.set_state(FeedbackFSM.waiting_rating)
+
+    rating_kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(text="⭐", callback_data="rate:1"),
+                InlineKeyboardButton(text="⭐⭐", callback_data="rate:2"),
+                InlineKeyboardButton(text="⭐⭐⭐", callback_data="rate:3"),
+            ],
+            [
+                InlineKeyboardButton(text="⭐⭐⭐⭐", callback_data="rate:4"),
+                InlineKeyboardButton(text="⭐⭐⭐⭐⭐", callback_data="rate:5"),
+            ],
+        ]
+    )
+    await callback.message.answer("⭐ Оцените сделку:", reply_markup=rating_kb)
+    await callback.answer()
+
+
+@router.callback_query(F.data.startswith("rate:"))
+async def handle_rating(callback: CallbackQuery, state: FSMContext) -> None:
+    rating = int(callback.data.split(":")[1])
+    await state.update_data(feedback_rating=rating)
+    await state.set_state(FeedbackFSM.waiting_comment)
+
+    await callback.message.answer(
+        "Комментарий (необязательно):",
+        reply_markup=InlineKeyboardMarkup(
+            inline_keyboard=[[InlineKeyboardButton(text="Пропустить", callback_data="rate:skip")]]
+        ),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "rate:skip", FeedbackFSM.waiting_comment)
+async def handle_rating_skip(callback: CallbackQuery, state: FSMContext) -> None:
+    data = await state.get_data()
+    auction_id = uuid.UUID(data["feedback_auction_id"])
+    rating = data["feedback_rating"]
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            user = await session.scalar(
+                select(User).where(User.tg_user_id == callback.from_user.id)
+            )
+            if user is None:
+                await callback.answer("Пользователь не найден", show_alert=True)
+                return
+            result = await submit_trade_feedback(
+                session,
+                auction_id=auction_id,
+                author_user_id=user.id,
+                rating=rating,
+                comment=None,
+            )
+
+    await state.clear()
+    await callback.message.answer(result.message)
+    await callback.answer()
+
+
+@router.message(FeedbackFSM.waiting_comment, F.text)
+async def handle_feedback_comment(message: Message, state: FSMContext) -> None:
+    data = await state.get_data()
+    auction_id = uuid.UUID(data["feedback_auction_id"])
+    rating = data["feedback_rating"]
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            user = await session.scalar(
+                select(User).where(User.tg_user_id == message.from_user.id)
+            )
+            if user is None:
+                await message.answer("Пользователь не найден")
+                return
+            result = await submit_trade_feedback(
+                session,
+                auction_id=auction_id,
+                author_user_id=user.id,
+                rating=rating,
+                comment=message.text,
+            )
+
+    await state.clear()
+    await message.answer(result.message)
+
+
+@router.callback_query(F.data.startswith("deal:guarant:"))
+async def handle_deal_guarant(callback: CallbackQuery, state: FSMContext) -> None:
+    await state.clear()
+    _, auction_id = parse_deal_callback(callback.data)
+
+    await state.update_data(guarant_auction_id=str(auction_id))
+    await state.set_state(DealGuarantorFSM.waiting_details)
+
+    await callback.message.answer("Опишите ваш запрос гаранта:")
+    await callback.answer()
+
+
+@router.message(DealGuarantorFSM.waiting_details, F.text)
+async def handle_guarant_details(message: Message, state: FSMContext) -> None:
+    data = await state.get_data()
+    auction_id = uuid.UUID(data["guarant_auction_id"])
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            user = await session.scalar(
+                select(User).where(User.tg_user_id == message.from_user.id)
+            )
+            if user is None:
+                await message.answer("Пользователь не найден")
+                return
+            await create_guarantor_request(
+                session,
+                submitter_user_id=user.id,
+                details=message.text,
+                auction_id=auction_id,
+            )
+
+    await state.clear()
+    await message.answer("Запрос гаранта отправлен модераторам.")
+
+
+@router.callback_query(F.data.startswith("deal:republish:"))
+async def handle_deal_republish(callback: CallbackQuery, state: FSMContext) -> None:
+    await state.clear()
+    _, auction_id = parse_deal_callback(callback.data)
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            auction = await session.scalar(
+                select(Auction).where(Auction.id == auction_id).with_for_update()
+            )
+            if auction is None:
+                await callback.answer("Аукцион не найден", show_alert=True)
+                return
+            if auction.status not in {AuctionStatus.ENDED, AuctionStatus.BOUGHT_OUT}:
+                await callback.answer("Можно переопубликовать только завершённый лот", show_alert=True)
+                return
+
+            from app.db.models import Auction as AuctionModel
+
+            new_auction = AuctionModel(
+                seller_user_id=auction.seller_user_id,
+                description=auction.description,
+                photo_file_id=auction.photo_file_id,
+                start_price=auction.start_price,
+                buyout_price=auction.buyout_price,
+                min_step=auction.min_step,
+                duration_hours=auction.duration_hours,
+                anti_sniper_enabled=auction.anti_sniper_enabled,
+            )
+            session.add(new_auction)
+
+    await callback.message.answer("Лот скопирован как черновик. Опубликуйте его через /sell.")
+    await callback.answer()

--- a/app/bot/handlers/start.py
+++ b/app/bot/handlers/start.py
@@ -1019,6 +1019,36 @@ async def callback_dashboard_guarant(callback: CallbackQuery, state: FSMContext,
     await callback.message.answer("Опишите запрос на гаранта одним сообщением. Для отмены используйте /cancel")
 
 
+@router.callback_query(F.data == "dash:notifications")
+async def callback_dashboard_notifications(callback: CallbackQuery) -> None:
+    if callback.from_user is None:
+        return
+    if callback.message is None or not isinstance(callback.message, Message):
+        await callback.answer("Не удалось открыть уведомления", show_alert=True)
+        return
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            user = await upsert_user(session, callback.from_user, mark_private_started=True)
+            snapshot = await load_notification_settings(session, user_id=user.id)
+            snoozes = await list_active_auction_notification_snoozes(session, user_id=user.id)
+
+    if snapshot is None:
+        await callback.answer("Настройки уведомлений недоступны", show_alert=True)
+        return
+
+    text = _render_settings_text(snapshot, snoozes=snoozes)
+    keyboard = _settings_keyboard(snapshot, snoozes=snoozes)
+    await callback.answer()
+    try:
+        await callback.message.edit_text(text, reply_markup=keyboard, disable_web_page_preview=True)
+        return
+    except TelegramBadRequest:
+        pass
+
+    await callback.message.answer(text, reply_markup=keyboard, disable_web_page_preview=True)
+
+
 @router.callback_query(F.data.startswith("dash:settings:"))
 async def callback_dashboard_settings_action(callback: CallbackQuery) -> None:
     if callback.from_user is None or callback.data is None:

--- a/app/bot/handlers/start.py
+++ b/app/bot/handlers/start.py
@@ -7,6 +7,7 @@ from aiogram import Bot, F, Router
 from aiogram.enums import ChatType
 from aiogram.exceptions import TelegramBadRequest
 from aiogram.filters import Command, CommandStart
+from aiogram.fsm.context import FSMContext
 from aiogram.types import CallbackQuery, CopyTextButton, InlineKeyboardButton, InlineKeyboardMarkup, Message
 
 from app.bot.keyboards.auction import (
@@ -70,6 +71,7 @@ from app.services.seller_dashboard_service import (
 )
 from app.services.points_service import UserPointsSummary, get_user_points_summary, list_user_points_entries
 from app.services.user_service import upsert_user
+from app.bot.states.guarantor_intake import GuarantorIntakeStates
 from app.bot.handlers.start_auction_views import (
     MY_AUCTIONS_PAGE_SIZE,
     _auction_list_button_label,
@@ -986,6 +988,35 @@ async def callback_dashboard_settings(callback: CallbackQuery) -> None:
 async def callback_dashboard_home(callback: CallbackQuery) -> None:
     await callback.answer()
     await _show_dashboard_home(callback, edit_message=True)
+
+
+@router.callback_query(F.data == "dash:guarant")
+async def callback_dashboard_guarant(callback: CallbackQuery, state: FSMContext, bot: Bot) -> None:
+    if callback.from_user is None:
+        return
+    if callback.message is None or not isinstance(callback.message, Message):
+        await callback.answer("Не удалось открыть раздел «Гарант»", show_alert=True)
+        return
+
+    await callback.answer()
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            user = await upsert_user(session, callback.from_user, mark_private_started=True)
+            if not await enforce_callback_topic(
+                callback,
+                bot=bot,
+                session=session,
+                user=user,
+                purpose=PrivateTopicPurpose.SUPPORT,
+                command_hint="/guarant",
+            ):
+                return
+
+    await state.set_state(GuarantorIntakeStates.waiting_request_text)
+    if isinstance(callback.message.message_thread_id, int):
+        await state.update_data(expected_thread_id=callback.message.message_thread_id)
+    await callback.message.answer("Опишите запрос на гаранта одним сообщением. Для отмены используйте /cancel")
 
 
 @router.callback_query(F.data.startswith("dash:settings:"))

--- a/app/bot/keyboards/auction.py
+++ b/app/bot/keyboards/auction.py
@@ -49,7 +49,7 @@ def start_private_keyboard(*, show_moderation_button: bool) -> InlineKeyboardMar
     rows: list[list[InlineKeyboardButton]] = [
         [
             styled_button(
-                text="Создать аукцион",
+                text="Создать лот",
                 callback_data="create:new",
                 style="primary",
                 icon_custom_emoji_id=_icon(settings.ui_emoji_create_auction_id),
@@ -57,21 +57,25 @@ def start_private_keyboard(*, show_moderation_button: bool) -> InlineKeyboardMar
         ],
         [
             styled_button(
-                text="Мои аукционы",
+                text="Мои лоты",
                 callback_data="dash:my_auctions",
                 style="primary",
             )
         ],
         [
             styled_button(
-                text="Настройки",
-                callback_data="dash:settings",
-            )
+                text="Гарант",
+                callback_data="dash:guarant",
+            ),
+            styled_button(
+                text="Уведомления",
+                callback_data="dash:notifications",
+            ),
         ],
         [
             styled_button(
-                text="Баланс",
-                callback_data="dash:balance",
+                text="Настройки",
+                callback_data="dash:settings",
             )
         ],
     ]
@@ -80,7 +84,7 @@ def start_private_keyboard(*, show_moderation_button: bool) -> InlineKeyboardMar
         rows.append(
             [
                 styled_button(
-                    text="Мод-панель",
+                    text="Модерация",
                     callback_data="mod:panel",
                     style="success",
                     icon_custom_emoji_id=_icon(settings.ui_emoji_mod_panel_id),

--- a/app/bot/keyboards/auction.py
+++ b/app/bot/keyboards/auction.py
@@ -608,3 +608,64 @@ def open_auction_post_keyboard(post_url: str) -> InlineKeyboardMarkup:
             ]
         ]
     )
+
+
+def deal_completion_keyboard(
+    *,
+    auction_id: str,
+    post_url: str | None,
+    is_seller: bool,
+) -> InlineKeyboardMarkup:
+    write_label = "💬 Написать победителю" if is_seller else "💬 Написать продавцу"
+    rows: list[list[InlineKeyboardButton]] = [
+        [styled_button(text=write_label, callback_data=f"deal:write:{auction_id}", style="primary")],
+        [
+            styled_button(text="🛡 Запросить гаранта", callback_data=f"deal:guarant:{auction_id}", style="success"),
+            styled_button(text="⭐ Оставить отзыв", callback_data=f"deal:feedback:{auction_id}"),
+        ],
+    ]
+    if post_url:
+        rows.append([styled_button(text="📄 Открыть пост лота", url=post_url)])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def no_bids_keyboard(
+    *,
+    auction_id: str,
+    post_url: str | None,
+) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = [
+        [styled_button(text="🔄 Опубликовать заново", callback_data=f"deal:republish:{auction_id}", style="primary")],
+    ]
+    if post_url:
+        rows.append([styled_button(text="📄 Открыть пост лота", url=post_url)])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def deal_topic_keyboard(
+    *,
+    auction_id: str,
+) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                styled_button(text="🛡 Запросить гаранта", callback_data=f"deal:guarant:{auction_id}", style="success"),
+                styled_button(text="⭐ Оставить отзыв", callback_data=f"deal:feedback:{auction_id}"),
+            ],
+            [
+                styled_button(text="⚠ Жалоба", callback_data=f"deal:complaint:{auction_id}"),
+            ],
+        ]
+    )
+
+
+def moderation_completion_keyboard(
+    *,
+    auction_id: str,
+    post_url: str | None,
+) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    if post_url:
+        rows.append([styled_button(text="📄 Открыть пост лота", url=post_url)])
+    rows.append([styled_button(text="⚠ Заморозить", callback_data=f"mod:freeze:{auction_id}", style="danger")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)

--- a/app/bot/states/post_auction.py
+++ b/app/bot/states/post_auction.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from aiogram.fsm.state import State, StatesGroup
+
+
+class FeedbackFSM(StatesGroup):
+    waiting_rating = State()
+    waiting_comment = State()
+
+
+class DealGuarantorFSM(StatesGroup):
+    waiting_details = State()

--- a/app/db/enums.py
+++ b/app/db/enums.py
@@ -87,3 +87,26 @@ class PointsEventType(StrEnum):
     FEEDBACK_PRIORITY_BOOST = "FEEDBACK_PRIORITY_BOOST"
     GUARANTOR_PRIORITY_BOOST = "GUARANTOR_PRIORITY_BOOST"
     APPEAL_PRIORITY_BOOST = "APPEAL_PRIORITY_BOOST"
+
+
+class ReputationTier(StrEnum):
+    NEW = "NEW"
+    BRONZE = "BRONZE"
+    SILVER = "SILVER"
+    GOLD = "GOLD"
+    PLATINUM = "PLATINUM"
+
+
+class ReputationEventReason(StrEnum):
+    AUCTION_COMPLETED = "auction_completed"
+    BID_WON = "bid_won"
+    GUARANTOR_ASSIGNED = "guarantor_assigned"
+    USER_VERIFIED = "user_verified"
+    COMPLAINT_FILED = "complaint_filed"
+    FRAUD_SIGNAL = "fraud_signal"
+    FRAUD_CONFIRMED = "fraud_confirmed"
+    BID_REMOVED = "bid_removed"
+    TEMP_BAN = "temp_ban"
+    PERM_BAN = "perm_ban"
+    MOD_ADJUST = "mod_adjust"
+    DECAY = "decay"

--- a/app/db/enums.py
+++ b/app/db/enums.py
@@ -81,6 +81,11 @@ class GuarantorRequestStatus(StrEnum):
     REJECTED = "REJECTED"
 
 
+class DealTopicStatus(StrEnum):
+    ACTIVE = "ACTIVE"
+    CLOSED = "CLOSED"
+
+
 class PointsEventType(StrEnum):
     FEEDBACK_APPROVED = "FEEDBACK_APPROVED"
     MANUAL_ADJUSTMENT = "MANUAL_ADJUSTMENT"

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -26,6 +26,7 @@ from app.db.enums import (
     AppealStatus,
     AppealSourceType,
     AuctionStatus,
+    DealTopicStatus,
     FeedbackStatus,
     FeedbackType,
     GuarantorRequestStatus,
@@ -815,12 +816,41 @@ class GuarantorRequest(Base, TimestampMixin):
         nullable=True,
     )
     details: Mapped[str] = mapped_column(Text, nullable=False)
+    auction_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("auctions.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     resolution_note: Mapped[str | None] = mapped_column(Text, nullable=True)
     queue_chat_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     queue_message_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     priority_boost_points_spent: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     priority_boosted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
     resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class DealTopic(Base, TimestampMixin):
+    __tablename__ = "deal_topics"
+    __table_args__ = (
+        Index("ix_deal_topics_auction_id", "auction_id"),
+        Index("ix_deal_topics_status", "status"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    auction_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("auctions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    seller_topic_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    winner_topic_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    status: Mapped[DealTopicStatus] = mapped_column(
+        Enum(DealTopicStatus, name="deal_topic_status"),
+        nullable=False,
+        default=DealTopicStatus.ACTIVE,
+        server_default=text("'ACTIVE'"),
+    )
+    closed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
 class IntegrationOutbox(Base, TimestampMixin):

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -32,8 +32,6 @@ from app.db.enums import (
     IntegrationOutboxStatus,
     ModerationAction,
     PointsEventType,
-    ReputationEventReason,
-    ReputationTier,
     UserRole,
 )
 

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -925,8 +925,6 @@ class UserReputationEvent(Base):
         DateTime(timezone=True), server_default=text("TIMEZONE('utc', NOW())"), nullable=False
     )
 
-    reputation: Mapped[UserReputation] = relationship(back_populates="events")
-
 
 class UserReputation(Base):
     __tablename__ = "user_reputations"
@@ -946,8 +944,4 @@ class UserReputation(Base):
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=text("TIMEZONE('utc', NOW())"), nullable=False
-    )
-
-    events: Mapped[list[UserReputationEvent]] = relationship(
-        back_populates="reputation", order_by="UserReputationEvent.created_at.desc()"
     )

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -19,7 +19,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base import Base, TimestampMixin
 from app.db.enums import (
@@ -32,6 +32,8 @@ from app.db.enums import (
     IntegrationOutboxStatus,
     ModerationAction,
     PointsEventType,
+    ReputationEventReason,
+    ReputationTier,
     UserRole,
 )
 
@@ -905,4 +907,49 @@ class FraudSignal(Base):
     resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=text("TIMEZONE('utc', NOW())"), nullable=False, index=True
+    )
+
+
+class UserReputationEvent(Base):
+    __tablename__ = "user_reputation_events"
+    __table_args__ = (
+        Index("ix_reputation_events_user_created", "user_id", "created_at"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    delta: Mapped[int] = mapped_column(Integer, nullable=False)
+    reason: Mapped[str] = mapped_column(String(32), nullable=False)
+    source_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("TIMEZONE('utc', NOW())"), nullable=False
+    )
+
+    reputation: Mapped[UserReputation] = relationship(back_populates="events")
+
+
+class UserReputation(Base):
+    __tablename__ = "user_reputations"
+    __table_args__ = (UniqueConstraint("user_id", name="uq_user_reputations_user_id"),)
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    score: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    tier: Mapped[str] = mapped_column(
+        String(16), nullable=False, server_default=text("'NEW'")
+    )
+    last_event_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("TIMEZONE('utc', NOW())"), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("TIMEZONE('utc', NOW())"), nullable=False
+    )
+
+    events: Mapped[list[UserReputationEvent]] = relationship(
+        back_populates="reputation", order_by="UserReputationEvent.created_at.desc()"
     )

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,7 @@ from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
 from aiogram.fsm.storage.redis import RedisEventIsolation, RedisStorage
-from aiogram.types import BotCommand, BotCommandScopeAllPrivateChats
+from aiogram.types import BotCommand, BotCommandScopeAllGroupChats, BotCommandScopeAllPrivateChats
 
 from app.bot.handlers import router as start_router
 from app.config import settings
@@ -28,27 +28,18 @@ async def startup_checks() -> None:
 
 
 async def configure_bot_commands(bot: Bot) -> None:
-    commands = [
-        BotCommand(command="start", description="Открыть главное меню"),
-        BotCommand(command="newauction", description="Создать новый аукцион"),
-        BotCommand(command="cancel", description="Отменить создание аукциона"),
-        BotCommand(command="settings", description="Настройки уведомлений"),
-        BotCommand(command="tradefeedback", description="Оценить завершенную сделку"),
-        BotCommand(command="boostfeedback", description="Поднять приоритет фидбека"),
-        BotCommand(command="topics", description="Показать разделы в личке"),
-        BotCommand(command="bug", description="Сообщить о проблеме"),
-        BotCommand(command="suggest", description="Предложить улучшение"),
-        BotCommand(command="guarant", description="Запросить гаранта для сделки"),
-        BotCommand(command="boostguarant", description="Поднять приоритет запроса гаранта"),
-        BotCommand(command="boostappeal", description="Поднять приоритет апелляции"),
-        BotCommand(command="points", description="Показать баланс наград"),
-        BotCommand(command="modpanel", description="Открыть панель модератора"),
-        BotCommand(command="modstats", description="Показать статистику модерации"),
-        BotCommand(command="notifstats", description="Показать snapshot метрик уведомлений"),
-        BotCommand(command="emojiid", description="Получить ID premium emoji (для UI)"),
-        BotCommand(command="effectid", description="Получить ID визуального эффекта"),
+    private_commands = [
+        BotCommand(command="start", description="Главное меню"),
+        BotCommand(command="newauction", description="Создать лот"),
+        BotCommand(command="guarant", description="Запрос гаранта"),
+        BotCommand(command="cancel", description="Отменить действие"),
     ]
-    await bot.set_my_commands(commands, scope=BotCommandScopeAllPrivateChats())
+    await bot.set_my_commands(private_commands, scope=BotCommandScopeAllPrivateChats())
+
+    group_commands = [
+        BotCommand(command="publish", description="Опубликовать лот"),
+    ]
+    await bot.set_my_commands(group_commands, scope=BotCommandScopeAllGroupChats())
 
 
 def build_dispatcher() -> Dispatcher:

--- a/app/services/auction_service.py
+++ b/app/services/auction_service.py
@@ -81,6 +81,13 @@ class FinalizeResult:
     auction_id: uuid.UUID
     winner_tg_user_id: int | None
     seller_tg_user_id: int
+    final_price: int | None = None
+    description: str | None = None
+    winner_username: str | None = None
+    winner_first_name: str | None = None
+    seller_username: str | None = None
+    seller_first_name: str | None = None
+    had_bids: bool = True
 
 
 def parse_auction_uuid(value: str) -> uuid.UUID | None:
@@ -507,9 +514,14 @@ async def _finalize_auction_locked(
 
     seller = await session.scalar(select(User).where(User.id == auction.seller_user_id))
     winner_tg_user_id: int | None = None
+    winner_username: str | None = None
+    winner_first_name: str | None = None
     if winner_user_id is not None:
         winner = await session.scalar(select(User).where(User.id == winner_user_id))
         winner_tg_user_id = winner.tg_user_id if winner is not None else None
+        if winner is not None:
+            winner_username = winner.username
+            winner_first_name = winner.first_name
 
     if seller is None:
         return None
@@ -518,10 +530,21 @@ async def _finalize_auction_locked(
     if winner_user_id is not None:
         await adjust_reputation(session, winner_user_id, 2, ReputationEventReason.BID_WON)
 
+    top_bids = await _top_bids_for_auction(session, auction.id, limit=1)
+    final_price = top_bids[0].amount if top_bids else None
+    had_bids = len(top_bids) > 0
+
     return FinalizeResult(
         auction_id=auction.id,
         winner_tg_user_id=winner_tg_user_id,
         seller_tg_user_id=seller.tg_user_id,
+        final_price=final_price,
+        description=auction.description,
+        winner_username=winner_username,
+        winner_first_name=winner_first_name,
+        seller_username=seller.username,
+        seller_first_name=seller.first_name,
+        had_bids=had_bids,
     )
 
 

--- a/app/services/auction_service.py
+++ b/app/services/auction_service.py
@@ -23,7 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.bot.keyboards.auction import auction_active_keyboard, open_auction_post_keyboard
 from app.config import settings
-from app.db.enums import AuctionStatus
+from app.db.enums import AuctionStatus, ReputationEventReason
 from app.db.models import Auction, AuctionPhoto, AuctionPost, Bid, BlacklistEntry, Complaint, User
 from app.db.session import SessionFactory
 from app.services.fraud_service import evaluate_and_store_bid_fraud_signal
@@ -35,6 +35,7 @@ from app.services.moderation_topic_router import ModerationTopicSection, send_se
 from app.services.private_topics_service import PrivateTopicPurpose, send_user_topic_message
 from app.services.notification_policy_service import NotificationEventType
 from app.services.notification_copy_service import auction_finished_text, auction_winner_text, short_auction_ref
+from app.services.reputation_service import adjust_reputation
 
 logger = logging.getLogger(__name__)
 
@@ -512,6 +513,10 @@ async def _finalize_auction_locked(
 
     if seller is None:
         return None
+
+    await adjust_reputation(session, auction.seller_user_id, 3, ReputationEventReason.AUCTION_COMPLETED)
+    if winner_user_id is not None:
+        await adjust_reputation(session, winner_user_id, 2, ReputationEventReason.BID_WON)
 
     return FinalizeResult(
         auction_id=auction.id,

--- a/app/services/auction_service.py
+++ b/app/services/auction_service.py
@@ -21,7 +21,12 @@ from aiogram.types import InlineKeyboardMarkup, InputMediaPhoto
 from sqlalchemy import Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.bot.keyboards.auction import auction_active_keyboard, open_auction_post_keyboard
+from app.bot.keyboards.auction import (
+    auction_active_keyboard,
+    deal_completion_keyboard,
+    moderation_completion_keyboard,
+    no_bids_keyboard,
+)
 from app.config import settings
 from app.db.enums import AuctionStatus, ReputationEventReason
 from app.db.models import Auction, AuctionPhoto, AuctionPost, Bid, BlacklistEntry, Complaint, User
@@ -34,7 +39,12 @@ from app.services.message_effects_service import (
 from app.services.moderation_topic_router import ModerationTopicSection, send_section_message
 from app.services.private_topics_service import PrivateTopicPurpose, send_user_topic_message
 from app.services.notification_policy_service import NotificationEventType
-from app.services.notification_copy_service import auction_finished_text, auction_winner_text, short_auction_ref
+from app.services.notification_copy_service import (
+    moderation_completion_text,
+    seller_completion_text,
+    seller_no_bids_text,
+    winner_completion_text,
+)
 from app.services.reputation_service import adjust_reputation
 
 logger = logging.getLogger(__name__)
@@ -88,6 +98,15 @@ class FinalizeResult:
     seller_username: str | None = None
     seller_first_name: str | None = None
     had_bids: bool = True
+
+
+def _build_result_mention(username: str | None, first_name: str | None, tg_id: int | None) -> str:
+    if tg_id is None:
+        return "нет"
+    if username:
+        return f"@{username}"
+    display = first_name or "Пользователь"
+    return f'<a href="tg://user?id={tg_id}">{display}</a>'
 
 
 def parse_auction_uuid(value: str) -> uuid.UUID | None:
@@ -852,44 +871,86 @@ async def finalize_expired_auctions(bot: Bot) -> int:
 
     for result in finalized_results:
         post_url = await resolve_auction_post_url(bot, auction_id=result.auction_id)
-        reply_markup = open_auction_post_keyboard(post_url) if post_url else None
+        short_id = str(result.auction_id)[:8]
+
+        winner_mention = _build_result_mention(
+            result.winner_username, result.winner_first_name, result.winner_tg_user_id
+        )
+        seller_mention = _build_result_mention(
+            result.seller_username, result.seller_first_name, result.seller_tg_user_id
+        )
+
+        if result.had_bids and result.final_price is not None:
+            seller_text = seller_completion_text(
+                auction_id=result.auction_id,
+                description=result.description or "",
+                final_price=result.final_price,
+                counterparty_mention=winner_mention,
+                counterparty_role="победитель",
+                is_buyout=False,
+            )
+            seller_kb = deal_completion_keyboard(auction_id=short_id, post_url=post_url, is_seller=True)
+        else:
+            seller_text = seller_no_bids_text(
+                auction_id=result.auction_id,
+                description=result.description or "",
+                start_price=result.final_price or 0,
+            )
+            seller_kb = no_bids_keyboard(auction_id=short_id, post_url=post_url)
+
         await send_user_topic_message(
             bot,
             tg_user_id=result.seller_tg_user_id,
             purpose=PrivateTopicPurpose.AUCTIONS,
-            text=auction_finished_text(result.auction_id),
-            reply_markup=reply_markup,
-            message_effect_id=resolve_auction_message_effect_id(
-                AuctionMessageEffectEvent.ENDED_SELLER
-            ),
+            text=seller_text,
+            reply_markup=seller_kb,
+            message_effect_id=resolve_auction_message_effect_id(AuctionMessageEffectEvent.ENDED_SELLER),
             notification_event=NotificationEventType.AUCTION_FINISH,
             auction_id=result.auction_id,
         )
 
-        if result.winner_tg_user_id is not None:
+        if result.winner_tg_user_id is not None and result.had_bids and result.final_price is not None:
+            winner_text = winner_completion_text(
+                auction_id=result.auction_id,
+                description=result.description or "",
+                final_price=result.final_price,
+                counterparty_mention=seller_mention,
+                counterparty_role="продавец",
+                is_buyout=False,
+            )
+            winner_kb = deal_completion_keyboard(auction_id=short_id, post_url=post_url, is_seller=False)
+
             await send_user_topic_message(
                 bot,
                 tg_user_id=result.winner_tg_user_id,
                 purpose=PrivateTopicPurpose.AUCTIONS,
-                text=auction_winner_text(result.auction_id),
-                reply_markup=reply_markup,
-                message_effect_id=resolve_auction_message_effect_id(
-                    AuctionMessageEffectEvent.ENDED_WINNER
-                ),
+                text=winner_text,
+                reply_markup=winner_kb,
+                message_effect_id=resolve_auction_message_effect_id(AuctionMessageEffectEvent.ENDED_WINNER),
                 notification_event=NotificationEventType.AUCTION_WIN,
                 auction_id=result.auction_id,
             )
 
-        winner_label = str(result.winner_tg_user_id) if result.winner_tg_user_id is not None else "нет"
+        mod_text = moderation_completion_text(
+            auction_id=result.auction_id,
+            description=result.description or "",
+            final_price=result.final_price or 0,
+            bid_count=0,
+            seller_mention=seller_mention,
+            winner_mention=winner_mention,
+            seller_reputation=0,
+            winner_reputation=0,
+            has_deal_topic=False,
+            has_guarantor=False,
+            reason="по таймеру",
+        )
+        mod_kb = moderation_completion_keyboard(auction_id=short_id, post_url=post_url)
+
         await send_section_message(
             bot,
             section=ModerationTopicSection.AUCTIONS_CLOSED,
-            text=(
-                f"Автозавершение: лот {short_auction_ref(result.auction_id)} закрыт по таймеру.\n"
-                f"Продавец: {result.seller_tg_user_id}\n"
-                f"Победитель: {winner_label}"
-            ),
-            reply_markup=reply_markup,
+            text=mod_text,
+            reply_markup=mod_kb,
         )
 
     return len(finalized_results)

--- a/app/services/auction_service.py
+++ b/app/services/auction_service.py
@@ -84,6 +84,13 @@ class BidActionResult:
     placed_bid_amount: int | None = None
     created_bid_id: uuid.UUID | None = None
     fraud_signal_id: int | None = None
+    final_price: int | None = None
+    description: str | None = None
+    winner_username: str | None = None
+    winner_first_name: str | None = None
+    seller_username: str | None = None
+    seller_first_name: str | None = None
+    had_bids: bool = True
 
 
 @dataclass(slots=True)
@@ -652,6 +659,13 @@ async def process_bid_action(
 
     winner_tg_user_id: int | None = None
     seller_tg_user_id: int | None = None
+    final_price: int | None = None
+    description: str | None = None
+    winner_username: str | None = None
+    winner_first_name: str | None = None
+    seller_username: str | None = None
+    seller_first_name: str | None = None
+    had_bids: bool = True
 
     if buyout_triggered:
         finalized = await _finalize_auction_locked(
@@ -663,6 +677,13 @@ async def process_bid_action(
         if finalized is not None:
             winner_tg_user_id = finalized.winner_tg_user_id
             seller_tg_user_id = finalized.seller_tg_user_id
+            final_price = finalized.final_price
+            description = finalized.description
+            winner_username = finalized.winner_username
+            winner_first_name = finalized.winner_first_name
+            seller_username = finalized.seller_username
+            seller_first_name = finalized.seller_first_name
+            had_bids = finalized.had_bids
         return BidActionResult(
             success=True,
             should_refresh=True,
@@ -674,6 +695,13 @@ async def process_bid_action(
             outbid_tg_user_id=outbid_tg_user_id,
             created_bid_id=created_bid.id,
             fraud_signal_id=fraud_signal_id,
+            final_price=final_price,
+            description=description,
+            winner_username=winner_username,
+            winner_first_name=winner_first_name,
+            seller_username=seller_username,
+            seller_first_name=seller_first_name,
+            had_bids=had_bids,
         )
 
     if (

--- a/app/services/complaint_service.py
+++ b/app/services/complaint_service.py
@@ -65,6 +65,14 @@ async def create_complaint(
     )
     session.add(complaint)
     await session.flush()
+
+    if complaint.target_user_id is not None:
+        from app.services.reputation_service import adjust_reputation
+
+        await adjust_reputation(
+            session, complaint.target_user_id, -8, "complaint_filed", source_id=complaint.id
+        )
+
     return ComplaintCreateResult(True, "Жалоба отправлена модераторам", complaint=complaint)
 
 

--- a/app/services/deal_topic_service.py
+++ b/app/services/deal_topic_service.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, UTC
+
+from aiogram import Bot
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.enums import DealTopicStatus
+from app.db.models import DealTopic
+from app.services.notification_copy_service import deal_topic_intro_text
+from app.bot.keyboards.auction import deal_topic_keyboard
+
+
+async def find_active_deal_topic(
+    session: AsyncSession,
+    *,
+    auction_id: uuid.UUID,
+) -> DealTopic | None:
+    return await session.scalar(
+        select(DealTopic).where(
+            DealTopic.auction_id == auction_id,
+            DealTopic.status == DealTopicStatus.ACTIVE,
+        )
+    )
+
+
+async def get_or_create_deal_topic(
+    session: AsyncSession,
+    *,
+    bot: Bot,
+    auction_id: uuid.UUID,
+    seller_tg_id: int,
+    winner_tg_id: int,
+    description: str,
+    final_price: int,
+    seller_mention: str,
+    winner_mention: str,
+) -> DealTopic:
+    existing = await find_active_deal_topic(session, auction_id=auction_id)
+    if existing is not None:
+        return existing
+
+    short_id = str(auction_id)[:8]
+
+    seller_topic = await bot.create_forum_topic(
+        chat_id=seller_tg_id,
+        name=f"🤝 Сделка #{short_id}",
+    )
+
+    intro = deal_topic_intro_text(
+        auction_id=auction_id,
+        description=description,
+        final_price=final_price,
+        seller_mention=seller_mention,
+        winner_mention=winner_mention,
+    )
+    kb = deal_topic_keyboard(auction_id=short_id)
+
+    await bot.send_message(
+        chat_id=seller_tg_id,
+        message_thread_id=seller_topic.message_thread_id,
+        text=intro,
+        reply_markup=kb,
+        parse_mode="HTML",
+    )
+
+    deal = DealTopic(
+        auction_id=auction_id,
+        seller_topic_id=seller_topic.message_thread_id,
+        status=DealTopicStatus.ACTIVE,
+    )
+    session.add(deal)
+    await session.flush()
+
+    return deal
+
+
+async def ensure_winner_topic(
+    session: AsyncSession,
+    *,
+    bot: Bot,
+    deal: DealTopic,
+    winner_tg_id: int,
+    auction_id: uuid.UUID,
+    description: str,
+    final_price: int,
+    seller_mention: str,
+    winner_mention: str,
+) -> None:
+    if deal.winner_topic_id is not None:
+        return
+
+    short_id = str(auction_id)[:8]
+
+    winner_topic = await bot.create_forum_topic(
+        chat_id=winner_tg_id,
+        name=f"🤝 Сделка #{short_id}",
+    )
+
+    intro = deal_topic_intro_text(
+        auction_id=auction_id,
+        description=description,
+        final_price=final_price,
+        seller_mention=seller_mention,
+        winner_mention=winner_mention,
+    )
+    kb = deal_topic_keyboard(auction_id=short_id)
+
+    await bot.send_message(
+        chat_id=winner_tg_id,
+        message_thread_id=winner_topic.message_thread_id,
+        text=intro,
+        reply_markup=kb,
+        parse_mode="HTML",
+    )
+
+    deal.winner_topic_id = winner_topic.message_thread_id
+    await session.flush()
+
+
+async def forward_deal_message(
+    bot: Bot,
+    *,
+    deal: DealTopic,
+    sender_label: str,
+    recipient_tg_id: int,
+    recipient_topic_id: int,
+    text: str | None = None,
+    photo_file_id: str | None = None,
+) -> None:
+    prefix = f"<b>{sender_label}:</b>\n"
+    if photo_file_id:
+        caption = f"{prefix}{text}" if text else prefix.rstrip(":")
+        await bot.send_photo(
+            chat_id=recipient_tg_id,
+            message_thread_id=recipient_topic_id,
+            photo=photo_file_id,
+            caption=caption,
+            parse_mode="HTML",
+        )
+    elif text:
+        await bot.send_message(
+            chat_id=recipient_tg_id,
+            message_thread_id=recipient_topic_id,
+            text=f"{prefix}{text}",
+            parse_mode="HTML",
+        )
+
+
+async def close_deal_topic(
+    session: AsyncSession,
+    *,
+    deal: DealTopic,
+) -> None:
+    deal.status = DealTopicStatus.CLOSED
+    deal.closed_at = datetime.now(UTC)
+    await session.flush()

--- a/app/services/fraud_service.py
+++ b/app/services/fraud_service.py
@@ -310,6 +310,11 @@ async def evaluate_and_store_bid_fraud_signal(
     )
     session.add(signal)
     await session.flush()
+
+    from app.services.reputation_service import adjust_reputation
+
+    await adjust_reputation(session, user_id, -15, "fraud_signal", source_id=signal.id)
+
     return signal.id
 
 
@@ -410,6 +415,12 @@ async def resolve_fraud_signal(
     signal.resolved_by_user_id = resolver_user_id
     signal.resolution_note = note
     signal.resolved_at = datetime.now(UTC)
+
+    if status == "CONFIRMED":
+        from app.services.reputation_service import adjust_reputation
+
+        await adjust_reputation(session, signal.user_id, -10, "fraud_confirmed", source_id=signal.id)
+
     return signal
 
 

--- a/app/services/guarantor_service.py
+++ b/app/services/guarantor_service.py
@@ -7,7 +7,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
-from app.db.enums import GuarantorRequestStatus, PointsEventType
+from app.db.enums import GuarantorRequestStatus, PointsEventType, ReputationEventReason
 from app.db.models import GuarantorRequest, User
 from app.services.points_service import (
     get_points_redemption_account_age_remaining_seconds,
@@ -201,6 +201,17 @@ async def assign_guarantor_request(
     item.resolution_note = note.strip() or "Назначен гарант"
     item.resolved_at = now
     item.updated_at = now
+
+    from app.services.reputation_service import adjust_reputation
+
+    await adjust_reputation(
+        session,
+        item.submitter_user_id,
+        10,
+        ReputationEventReason.GUARANTOR_ASSIGNED,
+        source_id=item.id,
+    )
+
     return GuarantorRequestModerationResult(True, "Гарант назначен", item=item, changed=True)
 
 

--- a/app/services/guarantor_service.py
+++ b/app/services/guarantor_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from uuid import UUID
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -74,6 +75,7 @@ async def create_guarantor_request(
     *,
     submitter_user_id: int,
     details: str,
+    auction_id: UUID | None = None,
 ) -> GuarantorRequestCreateResult:
     normalized = _normalize_details(details)
     min_length = max(settings.guarantor_intake_min_length, 1)
@@ -99,6 +101,7 @@ async def create_guarantor_request(
         status=GuarantorRequestStatus.NEW,
         submitter_user_id=submitter_user_id,
         details=normalized,
+        auction_id=auction_id,
         updated_at=now,
     )
     session.add(item)

--- a/app/services/moderation_service.py
+++ b/app/services/moderation_service.py
@@ -412,6 +412,10 @@ async def remove_bid(
         payload={"amount": bid.amount},
     )
 
+    from app.services.reputation_service import adjust_reputation
+
+    await adjust_reputation(session, bid.user_id, -5, "bid_removed", source_id=bid.id)
+
     target_user = await session.scalar(select(User).where(User.id == bid.user_id))
     return ModerationResult(
         True,
@@ -466,6 +470,11 @@ async def ban_user(
         target_user_id=target_user.id,
         auction_id=auction_id,
     )
+
+    from app.services.reputation_service import adjust_reputation
+
+    await adjust_reputation(session, target_user.id, 0, "perm_ban")
+
     return ModerationResult(True, "Пользователь заблокирован", target_tg_user_id=target_tg_user_id)
 
 

--- a/app/services/moderation_service.py
+++ b/app/services/moderation_service.py
@@ -24,6 +24,7 @@ class ModerationResult:
     seller_tg_user_id: int | None = None
     winner_tg_user_id: int | None = None
     target_tg_user_id: int | None = None
+    finalize_result: object | None = None
 
 
 @dataclass(slots=True)
@@ -329,27 +330,19 @@ async def end_auction(
     auction_id: uuid.UUID,
     reason: str,
 ) -> ModerationResult:
-    auction = await _get_auction_for_update(session, auction_id)
+    from app.services.auction_service import FinalizeResult, _finalize_auction_locked, get_auction_by_id
+
+    auction = await get_auction_by_id(session, auction_id, for_update=True)
     if auction is None:
         return ModerationResult(False, "Аукцион не найден")
 
     if auction.status not in {AuctionStatus.ACTIVE, AuctionStatus.FROZEN}:
         return ModerationResult(False, "Завершить можно только активный/замороженный аукцион")
 
-    top_bid = await _top_bid(session, auction.id)
-    winner_user: User | None = None
-    if top_bid is not None:
-        auction.winner_user_id = top_bid.user_id
-        winner_user = await session.scalar(select(User).where(User.id == top_bid.user_id))
-    else:
-        auction.winner_user_id = None
+    finalized: FinalizeResult | None = await _finalize_auction_locked(
+        session, auction, status=AuctionStatus.ENDED
+    )
 
-    now = datetime.now(UTC)
-    auction.status = AuctionStatus.ENDED
-    auction.ends_at = now
-    auction.updated_at = now
-
-    seller = await session.scalar(select(User).where(User.id == auction.seller_user_id))
     await _log_action(
         session,
         actor_user_id=actor_user_id,
@@ -358,12 +351,16 @@ async def end_auction(
         auction_id=auction.id,
     )
 
+    if finalized is None:
+        return ModerationResult(True, "Аукцион завершен модератором", auction_id=auction.id)
+
     return ModerationResult(
         True,
         "Аукцион завершен модератором",
-        auction_id=auction.id,
-        seller_tg_user_id=seller.tg_user_id if seller else None,
-        winner_tg_user_id=winner_user.tg_user_id if winner_user else None,
+        auction_id=finalized.auction_id,
+        seller_tg_user_id=finalized.seller_tg_user_id,
+        winner_tg_user_id=finalized.winner_tg_user_id,
+        finalize_result=finalized,
     )
 
 

--- a/app/services/notification_copy_service.py
+++ b/app/services/notification_copy_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 import uuid
 
 
@@ -86,3 +87,145 @@ def moderation_winner_text(auction_id: uuid.UUID) -> str:
 
 def moderation_bid_removed_text() -> str:
     return "Модерация: ваша ставка по лоту была снята."
+
+
+def _truncate(text: str, max_len: int = 80) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "…"
+
+
+def _format_price(amount: int) -> str:
+    return f"{amount:,} ₽".replace(",", " ")
+
+
+def seller_completion_text(
+    *,
+    auction_id: uuid.UUID,
+    description: str,
+    final_price: int,
+    counterparty_mention: str,
+    counterparty_role: str,
+    is_buyout: bool = False,
+    is_mod_action: bool = False,
+) -> str:
+    prefix = "Модерация: " if is_mod_action else ""
+    buyout_label = " выкупом" if is_buyout else ""
+    return (
+        f"🏆 {prefix}Аукцион завершён{buyout_label}!\n\n"
+        f"<b>Лот:</b> {short_auction_ref(auction_id)}\n"
+        f"<b>Описание:</b> {html.escape(_truncate(description))}\n"
+        f"<b>Финальная цена:</b> {_format_price(final_price)}\n"
+        f"<b>Победитель:</b> {counterparty_mention}\n\n"
+        f"📋 <b>Следующие шаги:</b>\n"
+        f"1. Нажмите «Написать победителю» — откроется топик сделки\n"
+        f"2. Договоритесь о способе передачи товара и оплаты\n"
+        f"3. После завершения — оставьте отзыв\n\n"
+        f"🛡 <b>Гарант — ваша безопасность</b>\n"
+        f"Если сумма сделки значительная или вы впервые работаете с {counterparty_role}ом — "
+        f"запросите гаранта. Гарант выступит посредником и обеспечит защиту обеих сторон.\n"
+        f"<i>Стоимость: бесплатно для участников с репутацией 50+</i>"
+    )
+
+
+def winner_completion_text(
+    *,
+    auction_id: uuid.UUID,
+    description: str,
+    final_price: int,
+    counterparty_mention: str,
+    counterparty_role: str,
+    is_buyout: bool = False,
+    is_mod_action: bool = False,
+) -> str:
+    prefix = "Модерация: " if is_mod_action else ""
+    buyout_label = " (выкуп)" if is_buyout else ""
+    return (
+        f"🎉 {prefix}Вы выиграли аукцион{buyout_label}!\n\n"
+        f"<b>Лот:</b> {short_auction_ref(auction_id)}\n"
+        f"<b>Описание:</b> {html.escape(_truncate(description))}\n"
+        f"<b>Ваша цена:</b> {_format_price(final_price)}\n"
+        f"<b>Продавец:</b> {counterparty_mention}\n\n"
+        f"📋 <b>Что дальше:</b>\n"
+        f"1. Нажмите «Написать продавцу» — откроется топик сделки\n"
+        f"2. Договоритесь о способе получения товара и оплаты\n"
+        f"3. После завершения — оставьте отзыв\n\n"
+        f"🛡 <b>Гарант — ваша безопасность</b>\n"
+        f"Если сумма сделки значительная или вы впервые работаете с {counterparty_role}ом — "
+        f"запросите гаранта. Гарант выступит посредником и обеспечит защиту обеих сторон.\n"
+        f"<i>Стоимость: бесплатно для участников с репутацией 50+</i>"
+    )
+
+
+def seller_no_bids_text(
+    *,
+    auction_id: uuid.UUID,
+    description: str,
+    start_price: int,
+) -> str:
+    return (
+        f"⏰ Аукцион завершён без ставок\n\n"
+        f"<b>Лот:</b> {short_auction_ref(auction_id)}\n"
+        f"<b>Описание:</b> {html.escape(_truncate(description))}\n"
+        f"<b>Стартовая цена:</b> {_format_price(start_price)}\n"
+        f"<b>Ставок:</b> 0\n\n"
+        f"💡 <b>Совет:</b> Попробуйте изменить стартовую цену или описание "
+        f"и опубликуйте лот заново."
+    )
+
+
+def deal_topic_intro_text(
+    *,
+    auction_id: uuid.UUID,
+    description: str,
+    final_price: int,
+    seller_mention: str,
+    winner_mention: str,
+) -> str:
+    return (
+        f"🤝 <b>Топик сделки создан</b>\n\n"
+        f"Лот: {short_auction_ref(auction_id)} — {html.escape(_truncate(description))}\n"
+        f"Цена: {_format_price(final_price)}\n"
+        f"Участники: {seller_mention} (продавец) и {winner_mention} (победитель)\n\n"
+        f"Все сообщения здесь будут пересылаться вашему контрагенту.\n"
+        f"Будьте вежливы и обсуждайте только сделку.\n\n"
+        f"🛡 <b>Совет по безопасности</b>\n"
+        f"Для защиты обеих сторон вы можете запросить гаранта — нажав кнопку ниже."
+    )
+
+
+def moderation_completion_text(
+    *,
+    auction_id: uuid.UUID,
+    description: str,
+    final_price: int,
+    bid_count: int,
+    seller_mention: str,
+    winner_mention: str,
+    seller_reputation: int,
+    winner_reputation: int,
+    has_deal_topic: bool,
+    has_guarantor: bool,
+    reason: str,
+) -> str:
+    deal_label = "создан автоматически" if has_deal_topic else "не создан"
+    guarantor_label = "запрошен" if has_guarantor else "не запрошен"
+    return (
+        f"🏁 Лот {short_auction_ref(auction_id)} завершён {reason}\n\n"
+        f"<b>Описание:</b> {html.escape(_truncate(description))}\n"
+        f"<b>Финальная цена:</b> {_format_price(final_price)}\n"
+        f"<b>Ставок:</b> {bid_count}\n\n"
+        f"<b>Продавец:</b> {seller_mention}\n"
+        f"<b>Победитель:</b> {winner_mention}\n"
+        f"<b>Репутация продавца:</b> {seller_reputation}\n"
+        f"<b>Репутация победителя:</b> {winner_reputation}\n\n"
+        f"🤝 <b>Топик сделки:</b> {deal_label}\n"
+        f"🛡 <b>Гарант:</b> {guarantor_label}"
+    )
+
+
+def format_user_mention(*, username: str | None, first_name: str | None, tg_user_id: int) -> str:
+    if username:
+        return f"@{html.escape(username)}"
+    display = html.escape(first_name or "Пользователь")
+    return f'<a href="tg://user?id={tg_user_id}">{display}</a>'

--- a/app/services/publish_gate_service.py
+++ b/app/services/publish_gate_service.py
@@ -5,11 +5,11 @@ from dataclasses import dataclass
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.models import Bid, BlacklistEntry, Complaint, FraudSignal, User
+from app.db.enums import AuctionStatus, ReputationTier
+from app.db.models import Auction
 from app.services.guarantor_service import has_assigned_guarantor_request
-from app.services.risk_eval_service import evaluate_user_risk_snapshot, format_risk_reason_label
+from app.services.reputation_service import get_or_create_reputation
 from app.services.runtime_settings_service import resolve_runtime_setting_value
-from app.services.verification_service import is_user_verified
 
 
 @dataclass(slots=True, frozen=True)
@@ -21,103 +21,96 @@ class SellerPublishGateResult:
     block_message: str | None = None
 
 
-def _build_block_message(*, risk_score: int, risk_reasons: tuple[str, ...]) -> str:
-    factors = ", ".join(format_risk_reason_label(code) for code in risk_reasons) if risk_reasons else "без детализации"
-    return (
-        "Публикация лота временно ограничена: высокий риск-профиль продавца "
-        f"(score={risk_score}). Факторы: {factors}.\n"
-        "Для публикации нужен назначенный гарант. Отправьте /guarant в личном чате с ботом."
-    )
-
-
 async def evaluate_seller_publish_gate(
     session: AsyncSession,
     *,
     seller_user_id: int,
 ) -> SellerPublishGateResult:
-    complaints_against = int(
-        await session.scalar(select(func.count(Complaint.id)).where(Complaint.target_user_id == seller_user_id))
-        or 0
-    )
-    open_fraud_signals = int(
-        await session.scalar(
-            select(func.count(FraudSignal.id)).where(
-                FraudSignal.user_id == seller_user_id,
-                FraudSignal.status == "OPEN",
-            )
-        )
-        or 0
-    )
-    has_active_blacklist = (
-        await session.scalar(
-            select(BlacklistEntry.id).where(
-                BlacklistEntry.user_id == seller_user_id,
-                BlacklistEntry.is_active.is_(True),
-            )
-        )
-        is not None
-    )
-    removed_bids = int(
-        await session.scalar(
-            select(func.count(Bid.id)).where(
-                Bid.user_id == seller_user_id,
-                Bid.is_removed.is_(True),
-            )
-        )
-        or 0
-    )
-    seller = await session.scalar(select(User).where(User.id == seller_user_id))
-    seller_verified = False
-    if seller is not None:
-        seller_verified = await is_user_verified(session, tg_user_id=seller.tg_user_id)
+    reputation = await get_or_create_reputation(session, seller_user_id)
+    tier = reputation.tier
+    score = reputation.score
 
-    risk = evaluate_user_risk_snapshot(
-        complaints_against=complaints_against,
-        open_fraud_signals=open_fraud_signals,
-        has_active_blacklist=has_active_blacklist,
-        removed_bids=removed_bids,
-        is_verified_user=seller_verified,
-    )
-
-    publish_requires_guarantor = bool(
-        await resolve_runtime_setting_value(session, "publish_high_risk_requires_guarantor")
-    )
-    if not publish_requires_guarantor:
+    if tier in {ReputationTier.PLATINUM, ReputationTier.GOLD, ReputationTier.SILVER}:
         return SellerPublishGateResult(
             allowed=True,
-            risk_level=risk.level,
-            risk_score=risk.score,
-            risk_reasons=risk.reasons,
+            risk_level=tier,
+            risk_score=score,
+            risk_reasons=(),
         )
 
-    if risk.level != "HIGH":
+    if tier == ReputationTier.BRONZE:
+        has_assigned = await has_assigned_guarantor_request(
+            session,
+            submitter_user_id=seller_user_id,
+            max_age_days=max(
+                int(await resolve_runtime_setting_value(session, "publish_guarantor_assignment_max_age_days")),
+                0,
+            ),
+        )
+        if has_assigned:
+            return SellerPublishGateResult(
+                allowed=True,
+                risk_level=tier,
+                risk_score=score,
+                risk_reasons=(),
+            )
         return SellerPublishGateResult(
-            allowed=True,
-            risk_level=risk.level,
-            risk_score=risk.score,
-            risk_reasons=risk.reasons,
+            allowed=False,
+            risk_level=tier,
+            risk_score=score,
+            risk_reasons=("no_guarantor",),
+            block_message=(
+                f"Публикация ограничена. Ваш уровень: BRONZE (score: {score}).\n"
+                "Для публикации нужен назначенный гарант → /guarant\n"
+                "Повысить уровень: завершите сделки без жалоб."
+            ),
         )
 
     has_assigned = await has_assigned_guarantor_request(
         session,
         submitter_user_id=seller_user_id,
-        max_age_days=max(
-            int(await resolve_runtime_setting_value(session, "publish_guarantor_assignment_max_age_days")),
-            0,
-        ),
+        max_age_days=365,
     )
-    if has_assigned:
+    completed_statuses = (AuctionStatus.ENDED, AuctionStatus.BOUGHT_OUT)
+    completed_count = int(
+        await session.scalar(
+            select(func.count(Auction.id)).where(
+                Auction.seller_user_id == seller_user_id,
+                Auction.status.in_(completed_statuses),
+            )
+        )
+        or 0
+    )
+    won_count = int(
+        await session.scalar(
+            select(func.count(Auction.id)).where(
+                Auction.winner_user_id == seller_user_id,
+                Auction.status.in_(completed_statuses),
+            )
+        )
+        or 0
+    )
+    total_deals = completed_count + won_count
+
+    if has_assigned and total_deals >= 1:
         return SellerPublishGateResult(
             allowed=True,
-            risk_level=risk.level,
-            risk_score=risk.score,
-            risk_reasons=risk.reasons,
+            risk_level=tier,
+            risk_score=score,
+            risk_reasons=(),
         )
+
+    parts = [f"Публикация ограничена. Ваш уровень: NEW (score: {score})."]
+    if not has_assigned:
+        parts.append("Для публикации нужен гарант → /guarant")
+    if total_deals < 1:
+        parts.append("Нужна хотя бы 1 завершённая сделка (проданный или выигранный аукцион).")
+    parts.append("Повысить уровень: завершите сделки без жалоб.")
 
     return SellerPublishGateResult(
         allowed=False,
-        risk_level=risk.level,
-        risk_score=risk.score,
-        risk_reasons=risk.reasons,
-        block_message=_build_block_message(risk_score=risk.score, risk_reasons=risk.reasons),
+        risk_level=tier,
+        risk_score=score,
+        risk_reasons=("new_tier",),
+        block_message="\n".join(parts),
     )

--- a/app/services/reputation_service.py
+++ b/app/services/reputation_service.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta
 
+from aiogram import Bot
 from sqlalchemy import desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -15,7 +17,10 @@ from app.db.models import (
     UserReputationEvent,
 )
 from app.services.guarantor_service import has_assigned_guarantor_request
+from app.services.private_topics_service import PrivateTopicPurpose, send_user_topic_message
 from app.services.verification_service import is_user_verified
+
+logger = logging.getLogger(__name__)
 
 _INITIAL_BASE_NEW = 10
 _INITIAL_BASE_ESTABLISHED = 25
@@ -353,3 +358,40 @@ async def run_reputation_decay(session: AsyncSession) -> int:
 
     await session.flush()
     return affected
+
+
+TIER_LABELS = {
+    ReputationTier.NEW: "NEW 🆕",
+    ReputationTier.BRONZE: "BRONZE 🥉",
+    ReputationTier.SILVER: "SILVER 🥈",
+    ReputationTier.GOLD: "GOLD 🥇",
+    ReputationTier.PLATINUM: "PLATINUM 💎",
+}
+
+_TIER_RANK = {
+    ReputationTier.NEW: 0,
+    ReputationTier.BRONZE: 1,
+    ReputationTier.SILVER: 2,
+    ReputationTier.GOLD: 3,
+    ReputationTier.PLATINUM: 4,
+}
+
+
+async def notify_tier_change(
+    bot: Bot, tg_user_id: int, old_tier: str, new_tier: str, score: int
+) -> None:
+    old_label = TIER_LABELS.get(old_tier, old_tier)
+    new_label = TIER_LABELS.get(new_tier, new_tier)
+    if _TIER_RANK.get(old_tier, 0) < _TIER_RANK.get(new_tier, 0):
+        text = f"🎉 Ваш уровень повышен: {old_label} → {new_label} (score: {score})"
+    else:
+        text = f"⚠️ Ваш уровень понижен: {old_label} → {new_label} (score: {score})"
+    try:
+        await send_user_topic_message(
+            bot,
+            tg_user_id=tg_user_id,
+            purpose=PrivateTopicPurpose.NOTIFICATIONS,
+            text=text,
+        )
+    except Exception:
+        logger.warning("Failed to send tier change notification to tg_user_id=%s", tg_user_id)

--- a/app/services/reputation_service.py
+++ b/app/services/reputation_service.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.enums import AuctionStatus, ReputationEventReason, ReputationTier
+from app.db.models import (
+    Auction,
+    Complaint,
+    FraudSignal,
+    User,
+    UserReputation,
+    UserReputationEvent,
+)
+from app.services.guarantor_service import has_assigned_guarantor_request
+from app.services.verification_service import is_user_verified
+
+_INITIAL_BASE_NEW = 10
+_INITIAL_BASE_ESTABLISHED = 25
+
+_DELTA_SELLER_COMPLETED = 5
+_MAX_SELLER_COMPLETED = 30
+_DELTA_BUYER_WON = 3
+_MAX_BUYER_WON = 30
+_DELTA_COMPLAINT = -10
+_MAX_COMPLAINT = -30
+_DELTA_FRAUD_CONFIRMED = -20
+_MAX_FRAUD_CONFIRMED = -40
+_DELTA_VERIFIED = 15
+_MAX_VERIFIED = 15
+_DELTA_GUARANTOR = 10
+_MAX_GUARANTOR = 10
+
+_DAILY_POSITIVE_CAP = 15
+_DAILY_NEGATIVE_CAP = -40
+_DECAY_FLOOR = 10
+_DECAY_INTERVAL_DAYS = 30
+_DECAY_DELTA = -2
+
+_TIER_THRESHOLDS: list[tuple[int, str]] = [
+    (81, ReputationTier.PLATINUM),
+    (61, ReputationTier.GOLD),
+    (41, ReputationTier.SILVER),
+    (21, ReputationTier.BRONZE),
+    (0, ReputationTier.NEW),
+]
+
+
+def _score_to_tier(score: int) -> str:
+    for threshold, tier in _TIER_THRESHOLDS:
+        if score >= threshold:
+            return tier
+    return ReputationTier.NEW
+
+
+async def _calculate_initial_score(session: AsyncSession, user: User) -> int:
+    now = datetime.now(UTC)
+    base = (
+        _INITIAL_BASE_NEW
+        if (now - user.created_at) < timedelta(hours=24)
+        else _INITIAL_BASE_ESTABLISHED
+    )
+
+    completed_statuses = (AuctionStatus.ENDED, AuctionStatus.BOUGHT_OUT)
+
+    seller_count = await session.scalar(
+        select(func.count(Auction.id)).where(
+            Auction.seller_user_id == user.id,
+            Auction.status.in_(completed_statuses),
+        )
+    )
+    seller_bonus = min(seller_count * _DELTA_SELLER_COMPLETED, _MAX_SELLER_COMPLETED)
+
+    buyer_count = await session.scalar(
+        select(func.count(Auction.id)).where(
+            Auction.winner_user_id == user.id,
+            Auction.status.in_(completed_statuses),
+        )
+    )
+    buyer_bonus = min(buyer_count * _DELTA_BUYER_WON, _MAX_BUYER_WON)
+
+    complaint_count = await session.scalar(
+        select(func.count(Complaint.id)).where(
+            Complaint.target_user_id == user.id,
+        )
+    )
+    complaint_penalty = max(complaint_count * _DELTA_COMPLAINT, _MAX_COMPLAINT)
+
+    fraud_count = await session.scalar(
+        select(func.count(FraudSignal.id)).where(
+            FraudSignal.user_id == user.id,
+            FraudSignal.status == "CONFIRMED",
+        )
+    )
+    fraud_penalty = max(fraud_count * _DELTA_FRAUD_CONFIRMED, _MAX_FRAUD_CONFIRMED)
+
+    verified_bonus = 0
+    if await is_user_verified(session, tg_user_id=user.tg_user_id):
+        verified_bonus = _DELTA_VERIFIED
+
+    guarantor_bonus = 0
+    if await has_assigned_guarantor_request(
+        session, submitter_user_id=user.id, max_age_days=365
+    ):
+        guarantor_bonus = _DELTA_GUARANTOR
+
+    raw = (
+        base
+        + seller_bonus
+        + buyer_bonus
+        + complaint_penalty
+        + fraud_penalty
+        + verified_bonus
+        + guarantor_bonus
+    )
+    return max(0, min(raw, 100))
+
+
+async def get_or_create_reputation(
+    session: AsyncSession, user_id: int
+) -> UserReputation:
+    rep = await session.scalar(
+        select(UserReputation).where(UserReputation.user_id == user_id)
+    )
+    if rep is not None:
+        return rep
+
+    user = await session.scalar(select(User).where(User.id == user_id))
+    if user is None:
+        raise ValueError(f"User {user_id} not found")
+
+    score = await _calculate_initial_score(session, user)
+    now = datetime.now(UTC)
+    rep = UserReputation(
+        user_id=user_id,
+        score=score,
+        tier=_score_to_tier(score),
+        last_event_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(rep)
+
+    event = UserReputationEvent(
+        user_id=user_id,
+        delta=score,
+        reason="initial",
+        source_id=None,
+        created_at=now,
+    )
+    session.add(event)
+    await session.flush()
+
+    rep.last_event_at = now
+    rep.updated_at = now
+    return rep
+
+
+async def recalculate_user_reputation(
+    session: AsyncSession, user_id: int
+) -> UserReputation:
+    rep = await get_or_create_reputation(session, user_id)
+    user = await session.scalar(select(User).where(User.id == user_id))
+    if user is None:
+        return rep
+
+    score = await _calculate_initial_score(session, user)
+
+    event_delta = await session.scalar(
+        select(func.coalesce(func.sum(UserReputationEvent.delta), 0)).where(
+            UserReputationEvent.user_id == user_id,
+            UserReputationEvent.reason != "initial",
+            UserReputationEvent.reason != ReputationEventReason.DECAY,
+        )
+    )
+    score = max(0, min(score + (event_delta or 0), 100))
+
+    old_tier = rep.tier
+    new_tier = _score_to_tier(score)
+    rep.score = score
+    rep.tier = new_tier
+    rep.updated_at = datetime.now(UTC)
+    if old_tier != new_tier:
+        rep._tier_changed = True
+        rep._old_tier = old_tier
+
+    await session.flush()
+    return rep
+
+
+async def _daily_delta_used(session: AsyncSession, user_id: int) -> tuple[int, int]:
+    cutoff = datetime.now(UTC) - timedelta(hours=24)
+    row = await session.execute(
+        select(
+            func.coalesce(
+                func.sum(
+                    UserReputationEvent.delta
+                ).filter(
+                    UserReputationEvent.delta > 0
+                ),
+                0,
+            ),
+            func.coalesce(
+                func.sum(
+                    UserReputationEvent.delta
+                ).filter(
+                    UserReputationEvent.delta < 0
+                ),
+                0,
+            ),
+        ).where(
+            UserReputationEvent.user_id == user_id,
+            UserReputationEvent.created_at >= cutoff,
+        )
+    )
+    positive_used, negative_used = row.one()
+    return positive_used, negative_used
+
+
+async def adjust_reputation(
+    session: AsyncSession,
+    user_id: int,
+    delta: int,
+    reason: str,
+    source_id: int | None = None,
+) -> UserReputation | None:
+    rep = await session.scalar(
+        select(UserReputation).where(UserReputation.user_id == user_id)
+    )
+    if rep is None:
+        return None
+
+    now = datetime.now(UTC)
+
+    if reason == ReputationEventReason.PERM_BAN:
+        actual_delta = -rep.score
+        rep.score = 0
+    else:
+        positive_used, negative_used = await _daily_delta_used(session, user_id)
+
+        if delta > 0:
+            remaining = _DAILY_POSITIVE_CAP - positive_used
+            if remaining <= 0:
+                return None
+            actual_delta = min(delta, remaining)
+        elif delta < 0:
+            remaining = _DAILY_NEGATIVE_CAP - negative_used
+            if remaining >= 0:
+                return None
+            actual_delta = max(delta, remaining)
+        else:
+            return None
+
+        rep.score = max(0, min(rep.score + actual_delta, 100))
+
+    old_tier = rep.tier
+    new_tier = _score_to_tier(rep.score)
+    rep.tier = new_tier
+    rep.last_event_at = now
+    rep.updated_at = now
+
+    if old_tier != new_tier:
+        rep._tier_changed = True
+        rep._old_tier = old_tier
+
+    event = UserReputationEvent(
+        user_id=user_id,
+        delta=actual_delta,
+        reason=reason,
+        source_id=source_id,
+        created_at=now,
+    )
+    session.add(event)
+    await session.flush()
+    return rep
+
+
+async def get_user_tier(session: AsyncSession, user_id: int) -> str:
+    rep = await session.scalar(
+        select(UserReputation).where(UserReputation.user_id == user_id)
+    )
+    if rep is not None:
+        return rep.tier
+    return ReputationTier.NEW
+
+
+async def get_reputation_history(
+    session: AsyncSession, user_id: int, limit: int = 20
+) -> list[UserReputationEvent]:
+    result = await session.execute(
+        select(UserReputationEvent)
+        .where(UserReputationEvent.user_id == user_id)
+        .order_by(desc(UserReputationEvent.created_at))
+        .limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def run_reputation_decay(session: AsyncSession) -> int:
+    cutoff = datetime.now(UTC) - timedelta(days=_DECAY_INTERVAL_DAYS)
+    result = await session.execute(
+        select(UserReputation).where(
+            UserReputation.last_event_at.is_not(None),
+            UserReputation.last_event_at < cutoff,
+            UserReputation.score > _DECAY_FLOOR,
+        )
+    )
+    reps = list(result.scalars().all())
+    if not reps:
+        return 0
+
+    now = datetime.now(UTC)
+    affected = 0
+
+    for rep in reps:
+        last = rep.last_event_at
+        if last is None:
+            continue
+
+        elapsed = now - last
+        gaps = elapsed.days // _DECAY_INTERVAL_DAYS
+        if gaps <= 0:
+            continue
+
+        decay_amount = gaps * _DECAY_DELTA
+        new_score = max(_DECAY_FLOOR, rep.score + decay_amount)
+        if new_score == rep.score:
+            continue
+
+        actual_delta = new_score - rep.score
+        old_tier = rep.tier
+
+        rep.score = new_score
+        rep.tier = _score_to_tier(new_score)
+        rep.last_event_at = now
+        rep.updated_at = now
+
+        if old_tier != rep.tier:
+            rep._tier_changed = True
+            rep._old_tier = old_tier
+
+        event = UserReputationEvent(
+            user_id=rep.user_id,
+            delta=actual_delta,
+            reason=ReputationEventReason.DECAY,
+            source_id=None,
+            created_at=now,
+        )
+        session.add(event)
+        affected += 1
+
+    await session.flush()
+    return affected

--- a/app/services/verification_service.py
+++ b/app/services/verification_service.py
@@ -8,6 +8,7 @@ from aiogram.exceptions import TelegramAPIError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.db.enums import ReputationEventReason
 from app.db.models import TelegramChatVerification, TelegramUserVerification, User
 
 
@@ -113,6 +114,13 @@ async def set_user_verification(
     row.custom_description = description if verify else None
     row.updated_by_user_id = actor_user_id
     row.updated_at = now
+
+    if verify:
+        from app.services.reputation_service import adjust_reputation
+
+        target_user = await session.scalar(select(User).where(User.tg_user_id == target_tg_user_id))
+        if target_user is not None:
+            await adjust_reputation(session, target_user.id, 15, ReputationEventReason.USER_VERIFIED)
 
     return VerificationUpdateResult(
         True,

--- a/app/web/main.py
+++ b/app/web/main.py
@@ -133,7 +133,7 @@ logger = logging.getLogger(__name__)
 _DENSE_ALLOWED_DENSITIES = frozenset({"compact", "standard", "comfortable"})
 _QUEUE_ALLOWED_COLUMNS: dict[str, tuple[str, ...]] = {
     "complaints": ("id", "auction", "reporter", "status", "reason", "created", "sla", "deadline"),
-    "signals": ("id", "auction", "user", "risk", "score", "status", "created"),
+    "signals": ("id", "auction", "user", "risk", "score", "status", "created", "sla"),
     "trade_feedback": (
         "id",
         "auction",
@@ -2297,11 +2297,17 @@ async def signals(
     page: int = 0,
     density: str | None = None,
     telemetry_preset_id: int | None = None,
+    sla_health: str = "all",
+    aging: str = "all",
 ) -> Response:
     response, auth = _auth_context_or_unauthorized(request)
     if response is not None:
         return response
     page = max(page, 0)
+    sla_health_value = _parse_signal_sla_health_filter(sla_health)
+    aging_value = _parse_signal_aging_bucket_filter(aging)
+    now = datetime.now(UTC)
+    signal_sla_thresholds = SLA_THRESHOLDS_BY_CONTEXT["risk"]
     page_size = 30
     offset = page * page_size
 
@@ -2347,11 +2353,15 @@ async def signals(
         status_value: str,
         density_value: str | None = None,
         telemetry_preset_id_value: int | None = telemetry_preset_id,
+        sla_health_value: str | None = sla_health_value,
+        aging_value: str | None = aging_value,
     ) -> str:
         query = {
             "status": status_value,
             "page": str(page_value),
             "density": density_value or dense_config.density,
+            "sla_health": sla_health_value or "all",
+            "aging": aging_value or "all",
         }
         if telemetry_preset_id_value is not None and telemetry_preset_id_value > 0:
             query["telemetry_preset_id"] = str(telemetry_preset_id_value)
@@ -2366,6 +2376,17 @@ async def signals(
             signal_priority = "urgent"
         elif int(item.score) >= 50:
             signal_priority = "high"
+        signal_deadline = item.created_at + signal_sla_thresholds.warning_window if item.created_at else None
+        sla_decision = decide_queue_sla_health(
+            queue_context="risk",
+            status=item.status,
+            created_at=item.created_at,
+            deadline_at=signal_deadline,
+            now=now,
+        )
+        if sla_decision.health_state in ("critical", "overdue"):
+            signal_priority = "urgent"
+        sla_hint = f"SLA:{sla_decision.health_state} | age:{sla_decision.aging_bucket}"
         row_context_attrs = _triage_row_context_attrs(
             risk_level=signal_risk_level,
             priority_level=signal_priority,
@@ -2381,11 +2402,12 @@ async def signals(
             f"<td data-col='score'>{item.score}</td>"
             f"<td data-col='status' data-status-cell='1'>{escape(item.status)}</td>"
             f"<td data-col='created'>{escape(_fmt_ts(item.created_at))}</td>"
+            f"<td data-col='sla' data-sla-health='{escape(sla_decision.health_state)}' data-aging-bucket='{escape(sla_decision.aging_bucket)}'><small>{escape(sla_hint)}</small></td>"
             "</tr>"
         )
         table_rows += _triage_detail_row(
             item.id,
-            col_count=8,
+            col_count=9,
             title=f"Signal #{item.id}",
             subtitle=f"Auction {item.auction_id} / user {item.user_id} / score {item.score}",
         )
@@ -2434,7 +2456,20 @@ async def signals(
         f"<a class='chip' href='{escape(_path_with_auth(request, status_open_path))}'>OPEN</a>"
         f"<a class='chip' href='{escape(_path_with_auth(request, status_resolved_path))}'>RESOLVED</a>"
         "</div>"
-        f"<div class='table-wrap dense-list-shell' data-dense-list='{escape(dense_config.table_id)}' data-density='{escape(dense_config.density)}'><table id='{escape(dense_config.table_id)}'><thead><tr><th>Pick</th><th data-col='id'>ID</th><th data-col='auction'>Auction</th><th data-col='user'>User ID</th><th data-col='risk'>User Risk</th><th data-col='score'>Score</th><th data-col='status'>Status</th><th data-col='created'>Created</th></tr></thead>"
+        "<div class='toolbar'><span>SLA health:</span>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _signals_path(page_value=0, status_value=status, sla_health_value='all')))}'>Все</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _signals_path(page_value=0, status_value=status, sla_health_value='healthy')))}'>В норме</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _signals_path(page_value=0, status_value=status, sla_health_value='warning')))}'>Внимание</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _signals_path(page_value=0, status_value=status, sla_health_value='critical')))}'>Критично</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _signals_path(page_value=0, status_value=status, sla_health_value='overdue')))}'>Просрочена</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _signals_path(page_value=0, status_value=status, sla_health_value='no_sla')))}'>Без SLA</a></div>"
+        "<div class='toolbar'><span>Возраст:</span>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _signals_path(page_value=0, status_value=status, aging_value='all')))}'>Все</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _signals_path(page_value=0, status_value=status, aging_value='fresh')))}'>Свежие</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _signals_path(page_value=0, status_value=status, aging_value='aging')))}'>Aging</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _signals_path(page_value=0, status_value=status, aging_value='stale')))}'>Stale</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _signals_path(page_value=0, status_value=status, aging_value='critical')))}'>Critical</a></div>"
+        f"<div class='table-wrap dense-list-shell' data-dense-list='{escape(dense_config.table_id)}' data-density='{escape(dense_config.density)}'><table id='{escape(dense_config.table_id)}'><thead><tr><th>Pick</th><th data-col='id'>ID</th><th data-col='auction'>Auction</th><th data-col='user'>User ID</th><th data-col='risk'>User Risk</th><th data-col='score'>Score</th><th data-col='status'>Status</th><th data-col='created'>Created</th><th data-col='sla'>SLA</th></tr></thead>"
         f"<tbody>{table_rows}</tbody></table></div>"
         f"{_pager_html(prev_link, next_link)}"
         f"{render_dense_list_script(dense_config)}"

--- a/app/web/main.py
+++ b/app/web/main.py
@@ -656,6 +656,120 @@ async def _render_appeal_detail_section(
     return {"ok": True, "html": html}
 
 
+async def _render_complaint_detail_section(
+    session: AsyncSession,
+    *,
+    row_id: int,
+    section: str,
+    request: Request,
+) -> dict[str, object]:
+    complaint = await session.scalar(select(Complaint).where(Complaint.id == row_id))
+    if complaint is None:
+        return {"ok": False, "message": "Complaint not found"}
+
+    reporter = await session.scalar(select(User).where(User.id == complaint.reporter_user_id))
+    target = None
+    if complaint.target_user_id is not None:
+        target = await session.scalar(select(User).where(User.id == complaint.target_user_id))
+    resolver = None
+    if complaint.resolved_by_user_id is not None:
+        resolver = await session.scalar(select(User).where(User.id == complaint.resolved_by_user_id))
+
+    mod_logs = (
+        await session.execute(
+            select(ModerationLog)
+            .where(
+                ModerationLog.auction_id == complaint.auction_id,
+                ModerationLog.created_at >= complaint.created_at,
+            )
+            .order_by(ModerationLog.created_at.asc(), ModerationLog.id.asc())
+        )
+    ).scalars().all()
+
+    actor_ids = {log_row.actor_user_id for log_row in mod_logs}
+    actors_by_id: dict[int, User] = {}
+    if actor_ids:
+        actors = (await session.execute(select(User).where(User.id.in_(actor_ids)))).scalars().all()
+        actors_by_id = {item.id: item for item in actors}
+
+    if section == "primary":
+        timeline_events: list[tuple[datetime, str, str]] = []
+        _append_timeline_event(
+            timeline_events,
+            happened_at=complaint.created_at,
+            title="Complaint created",
+            details=f"reporter={_user_label(reporter, complaint.reporter_user_id)}, target={_user_label(target, complaint.target_user_id)}, reason={complaint.reason[:120]}",
+        )
+        _append_timeline_event(
+            timeline_events,
+            happened_at=complaint.resolved_at,
+            title=f"Complaint finalized: {complaint.status}",
+            details=f"resolver={_user_label(resolver, complaint.resolved_by_user_id)}, note={complaint.resolution_note or '-'}",
+        )
+        for log_row in mod_logs:
+            _append_timeline_event(
+                timeline_events,
+                happened_at=log_row.created_at,
+                title=f"Moderation action: {str(log_row.action)}",
+                details=f"actor={_user_label(actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id)}",
+            )
+
+        timeline_events.sort(key=lambda item: item[0])
+        timeline_html = _render_inline_timeline_html(timeline_events)
+        source_line = f"<p><b>Evidence timeline:</b> complaint #{complaint.id}</p>"
+        auction_link = f"<p class='section-note'><a href='{escape(_path_with_auth(request, f'/timeline/auction/{complaint.auction_id}'))}'>Open full auction timeline</a></p>"
+        return {
+            "ok": True,
+            "html": f"<div data-detail-state='loaded'>{source_line}{timeline_html}{auction_link}</div>",
+        }
+
+    if section == "secondary":
+        source_bits: list[str] = [
+            f"<p><b>Source evidence:</b> complaint #{complaint.id}, status={escape(str(complaint.status))}</p>",
+            f"<p class='section-note'>auction={escape(str(complaint.auction_id))}, reporter={escape(_user_label(reporter, complaint.reporter_user_id))}, target={escape(_user_label(target, complaint.target_user_id))}</p>",
+        ]
+        if complaint.resolution_note:
+            source_bits.append(f"<p class='section-note'>resolution={escape(complaint.resolution_note[:200])}</p>")
+
+        artifact_items: list[str] = []
+        for log_row in mod_logs:
+            payload = log_row.payload or {}
+            artifact = payload.get("rationale_artifact") if isinstance(payload, dict) else None
+            if not isinstance(artifact, dict):
+                continue
+            actor_label = _user_label(actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id)
+            summary = str(artifact.get("summary") or "-")
+            recorded_at = str(artifact.get("recorded_at") or _fmt_ts(log_row.created_at))
+            source_value = str(artifact.get("source") or "web")
+            artifact_items.append(
+                f"<li><b>{escape(str(log_row.action))}</b> - {escape(summary)}"
+                f"<div class='section-note'>actor={escape(actor_label)}, recorded_at={escape(recorded_at)}, source={escape(source_value)}</div></li>"
+            )
+        if artifact_items:
+            source_bits.append(f"<p><b>Rationale artifacts:</b></p><ul>{''.join(artifact_items)}</ul>")
+        else:
+            source_bits.append("<p class='section-note'>No rationale artifacts yet.</p>")
+
+        return {
+            "ok": True,
+            "html": f"<div data-detail-state='loaded'>{''.join(source_bits)}</div>",
+        }
+
+    audit_items = [
+        f"<li>complaint_id={complaint.id}</li>",
+        f"<li>created_at={escape(_fmt_ts(complaint.created_at))}</li>",
+        f"<li>status={escape(str(complaint.status))}</li>",
+        f"<li>resolver={escape(_user_label(resolver, complaint.resolved_by_user_id))}</li>",
+        "<li>record_policy=append_only</li>",
+    ]
+    for log_row in mod_logs:
+        audit_items.append(
+            f"<li>log#{log_row.id} {escape(str(log_row.action))} at {escape(_fmt_ts(log_row.created_at))} by {escape(_user_label(actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id))}</li>"
+        )
+    html = f"<div data-detail-state='loaded'><p><b>Audit trail (immutable)</b></p><ul>{''.join(audit_items)}</ul></div>"
+    return {"ok": True, "html": html}
+
+
 async def _load_user_risk_snapshot_map(
     session,
     *,
@@ -4750,6 +4864,16 @@ async def action_triage_detail_section(
             "</div>"
         )
         return {"ok": True, "html": collapsed_html, **metadata}
+
+    if queue_value == "complaints":
+        async with SessionFactory() as session:
+            detail_payload = await _render_complaint_detail_section(
+                session,
+                row_id=row_id,
+                section=section_value,
+                request=request,
+            )
+        return {**detail_payload, **metadata}
 
     if queue_value == "appeals":
         async with SessionFactory() as session:

--- a/app/web/main.py
+++ b/app/web/main.py
@@ -132,7 +132,7 @@ logger = logging.getLogger(__name__)
 
 _DENSE_ALLOWED_DENSITIES = frozenset({"compact", "standard", "comfortable"})
 _QUEUE_ALLOWED_COLUMNS: dict[str, tuple[str, ...]] = {
-    "complaints": ("id", "auction", "reporter", "status", "reason", "created"),
+    "complaints": ("id", "auction", "reporter", "status", "reason", "created", "sla", "deadline"),
     "signals": ("id", "auction", "user", "risk", "score", "status", "created"),
     "trade_feedback": (
         "id",
@@ -2128,11 +2128,17 @@ async def complaints(
     page: int = 0,
     density: str | None = None,
     telemetry_preset_id: int | None = None,
+    sla_health: str = "all",
+    aging: str = "all",
 ) -> Response:
     response, auth = _auth_context_or_unauthorized(request)
     if response is not None:
         return response
     page = max(page, 0)
+    sla_health_value = _parse_complaint_sla_health_filter(sla_health)
+    aging_value = _parse_complaint_aging_bucket_filter(aging)
+    now = datetime.now(UTC)
+    complaint_sla_thresholds = SLA_THRESHOLDS_BY_CONTEXT["moderation"]
     page_size = 30
     offset = page * page_size
 
@@ -2168,11 +2174,15 @@ async def complaints(
         status_value: str,
         density_value: str | None = None,
         telemetry_preset_id_value: int | None = telemetry_preset_id,
+        sla_health_value: str | None = sla_health_value,
+        aging_value: str | None = aging_value,
     ) -> str:
         query = {
             "status": status_value,
             "page": str(page_value),
             "density": density_value or dense_config.density,
+            "sla_health": sla_health_value or "all",
+            "aging": aging_value or "all",
         }
         if telemetry_preset_id_value is not None and telemetry_preset_id_value > 0:
             query["telemetry_preset_id"] = str(telemetry_preset_id_value)
@@ -2181,6 +2191,17 @@ async def complaints(
     table_rows = ""
     for item in rows:
         complaint_priority = "high" if str(item.status).upper() == "OPEN" else "normal"
+        complaint_deadline = item.created_at + complaint_sla_thresholds.warning_window if item.created_at else None
+        sla_decision = decide_queue_sla_health(
+            queue_context="moderation",
+            status=item.status,
+            created_at=item.created_at,
+            deadline_at=complaint_deadline,
+            now=now,
+        )
+        if sla_decision.health_state in ("critical", "overdue"):
+            complaint_priority = "urgent"
+        sla_hint = f"SLA:{sla_decision.health_state} | age:{sla_decision.aging_bucket}"
         row_context_attrs = _triage_row_context_attrs(risk_level="low", priority_level=complaint_priority)
         table_rows += (
             f"<tr data-row='{escape(f'{item.id} {item.auction_id} {item.reporter_user_id} {item.status} {item.reason}')}' "
@@ -2192,16 +2213,18 @@ async def complaints(
             f"<td data-col='status' data-status-cell='1'>{escape(item.status)}</td>"
             f"<td data-col='reason'>{escape(item.reason[:120])}</td>"
             f"<td data-col='created'>{escape(_fmt_ts(item.created_at))}</td>"
+            f"<td data-col='sla' data-sla-health='{escape(sla_decision.health_state)}' data-aging-bucket='{escape(sla_decision.aging_bucket)}'><small>{escape(sla_hint)}</small></td>"
+            f"<td data-col='deadline'>{escape(_fmt_ts(complaint_deadline))}</td>"
             "</tr>"
         )
         table_rows += _triage_detail_row(
             item.id,
-            col_count=7,
+            col_count=9,
             title=f"Complaint #{item.id}",
             subtitle=f"Auction {item.auction_id} / reporter {item.reporter_user_id}",
         )
     if not table_rows:
-        table_rows = "<tr><td colspan='7'><span class='empty-state'>Нет записей</span></td></tr>"
+        table_rows = "<tr><td colspan='9'><span class='empty-state'>Нет записей</span></td></tr>"
 
     prev_link = (
         f"<a href='{escape(_path_with_auth(request, _complaints_path(page_value=page-1, status_value=status)))}'>← Назад</a>"
@@ -2245,7 +2268,20 @@ async def complaints(
         f"<a class='chip' href='{escape(_path_with_auth(request, status_open_path))}'>OPEN</a>"
         f"<a class='chip' href='{escape(_path_with_auth(request, status_resolved_path))}'>RESOLVED</a>"
         "</div>"
-        f"<div class='table-wrap dense-list-shell' data-dense-list='{escape(dense_config.table_id)}' data-density='{escape(dense_config.density)}'><table id='{escape(dense_config.table_id)}'><thead><tr><th>Pick</th><th data-col='id'>ID</th><th data-col='auction'>Auction</th><th data-col='reporter'>Reporter UID</th><th data-col='status'>Status</th><th data-col='reason'>Reason</th><th data-col='created'>Created</th></tr></thead>"
+        "<div class='toolbar'><span>SLA health:</span>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _complaints_path(page_value=0, status_value=status, sla_health_value='all')))}'>Все</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _complaints_path(page_value=0, status_value=status, sla_health_value='healthy')))}'>В норме</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _complaints_path(page_value=0, status_value=status, sla_health_value='warning')))}'>Внимание</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _complaints_path(page_value=0, status_value=status, sla_health_value='critical')))}'>Критично</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _complaints_path(page_value=0, status_value=status, sla_health_value='overdue')))}'>Просрочена</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _complaints_path(page_value=0, status_value=status, sla_health_value='no_sla')))}'>Без SLA</a></div>"
+        "<div class='toolbar'><span>Возраст:</span>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _complaints_path(page_value=0, status_value=status, aging_value='all')))}'>Все</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _complaints_path(page_value=0, status_value=status, aging_value='fresh')))}'>Свежие</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _complaints_path(page_value=0, status_value=status, aging_value='aging')))}'>Aging</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _complaints_path(page_value=0, status_value=status, aging_value='stale')))}'>Stale</a>"
+        f"<a class='chip' href='{escape(_path_with_auth(request, _complaints_path(page_value=0, status_value=status, aging_value='critical')))}'>Critical</a></div>"
+        f"<div class='table-wrap dense-list-shell' data-dense-list='{escape(dense_config.table_id)}' data-density='{escape(dense_config.density)}'><table id='{escape(dense_config.table_id)}'><thead><tr><th>Pick</th><th data-col='id'>ID</th><th data-col='auction'>Auction</th><th data-col='reporter'>Reporter UID</th><th data-col='status'>Status</th><th data-col='reason'>Reason</th><th data-col='created'>Created</th><th data-col='sla'>SLA</th><th data-col='deadline'>Deadline</th></tr></thead>"
         f"<tbody>{table_rows}</tbody></table></div>"
         f"{_pager_html(prev_link, next_link)}"
         f"{render_dense_list_script(dense_config)}"

--- a/app/web/main.py
+++ b/app/web/main.py
@@ -770,6 +770,118 @@ async def _render_complaint_detail_section(
     return {"ok": True, "html": html}
 
 
+async def _render_signal_detail_section(
+    session: AsyncSession,
+    *,
+    row_id: int,
+    section: str,
+    request: Request,
+) -> dict[str, object]:
+    signal = await session.scalar(select(FraudSignal).where(FraudSignal.id == row_id))
+    if signal is None:
+        return {"ok": False, "message": "Signal not found"}
+
+    signal_user = await session.scalar(select(User).where(User.id == signal.user_id))
+    resolver = None
+    if signal.resolved_by_user_id is not None:
+        resolver = await session.scalar(select(User).where(User.id == signal.resolved_by_user_id))
+
+    mod_logs = (
+        await session.execute(
+            select(ModerationLog)
+            .where(
+                ModerationLog.auction_id == signal.auction_id,
+                ModerationLog.created_at >= signal.created_at,
+            )
+            .order_by(ModerationLog.created_at.asc(), ModerationLog.id.asc())
+        )
+    ).scalars().all()
+
+    actor_ids = {log_row.actor_user_id for log_row in mod_logs}
+    actors_by_id: dict[int, User] = {}
+    if actor_ids:
+        actors = (await session.execute(select(User).where(User.id.in_(actor_ids)))).scalars().all()
+        actors_by_id = {item.id: item for item in actors}
+
+    if section == "primary":
+        timeline_events: list[tuple[datetime, str, str]] = []
+        _append_timeline_event(
+            timeline_events,
+            happened_at=signal.created_at,
+            title="Fraud signal created",
+            details=f"user={_user_label(signal_user, signal.user_id)}, score={signal.score}, status={signal.status}",
+        )
+        _append_timeline_event(
+            timeline_events,
+            happened_at=signal.resolved_at,
+            title=f"Signal finalized: {signal.status}",
+            details=f"resolver={_user_label(resolver, signal.resolved_by_user_id)}, note={signal.resolution_note or '-'}",
+        )
+        for log_row in mod_logs:
+            _append_timeline_event(
+                timeline_events,
+                happened_at=log_row.created_at,
+                title=f"Moderation action: {str(log_row.action)}",
+                details=f"actor={_user_label(actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id)}",
+            )
+
+        timeline_events.sort(key=lambda item: item[0])
+        timeline_html = _render_inline_timeline_html(timeline_events)
+        source_line = f"<p><b>Evidence timeline:</b> fraud signal #{signal.id}</p>"
+        auction_link = f"<p class='section-note'><a href='{escape(_path_with_auth(request, f'/timeline/auction/{signal.auction_id}'))}'>Open full auction timeline</a></p>"
+        return {
+            "ok": True,
+            "html": f"<div data-detail-state='loaded'>{source_line}{timeline_html}{auction_link}</div>",
+        }
+
+    if section == "secondary":
+        source_bits: list[str] = [
+            f"<p><b>Source evidence:</b> signal #{signal.id}, score={signal.score}, status={escape(str(signal.status))}</p>",
+            f"<p class='section-note'>auction={escape(str(signal.auction_id))}, user={escape(_user_label(signal_user, signal.user_id))}</p>",
+        ]
+        if signal.resolution_note:
+            source_bits.append(f"<p class='section-note'>resolution={escape(signal.resolution_note[:200])}</p>")
+
+        artifact_items: list[str] = []
+        for log_row in mod_logs:
+            payload = log_row.payload or {}
+            artifact = payload.get("rationale_artifact") if isinstance(payload, dict) else None
+            if not isinstance(artifact, dict):
+                continue
+            actor_label = _user_label(actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id)
+            summary = str(artifact.get("summary") or "-")
+            recorded_at = str(artifact.get("recorded_at") or _fmt_ts(log_row.created_at))
+            source_value = str(artifact.get("source") or "web")
+            artifact_items.append(
+                f"<li><b>{escape(str(log_row.action))}</b> - {escape(summary)}"
+                f"<div class='section-note'>actor={escape(actor_label)}, recorded_at={escape(recorded_at)}, source={escape(source_value)}</div></li>"
+            )
+        if artifact_items:
+            source_bits.append(f"<p><b>Rationale artifacts:</b></p><ul>{''.join(artifact_items)}</ul>")
+        else:
+            source_bits.append("<p class='section-note'>No rationale artifacts yet.</p>")
+
+        return {
+            "ok": True,
+            "html": f"<div data-detail-state='loaded'>{''.join(source_bits)}</div>",
+        }
+
+    audit_items = [
+        f"<li>signal_id={signal.id}</li>",
+        f"<li>created_at={escape(_fmt_ts(signal.created_at))}</li>",
+        f"<li>score={signal.score}</li>",
+        f"<li>status={escape(str(signal.status))}</li>",
+        f"<li>resolver={escape(_user_label(resolver, signal.resolved_by_user_id))}</li>",
+        "<li>record_policy=append_only</li>",
+    ]
+    for log_row in mod_logs:
+        audit_items.append(
+            f"<li>log#{log_row.id} {escape(str(log_row.action))} at {escape(_fmt_ts(log_row.created_at))} by {escape(_user_label(actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id))}</li>"
+        )
+    html = f"<div data-detail-state='loaded'><p><b>Audit trail (immutable)</b></p><ul>{''.join(audit_items)}</ul></div>"
+    return {"ok": True, "html": html}
+
+
 async def _load_user_risk_snapshot_map(
     session,
     *,
@@ -4864,6 +4976,16 @@ async def action_triage_detail_section(
             "</div>"
         )
         return {"ok": True, "html": collapsed_html, **metadata}
+
+    if queue_value == "signals":
+        async with SessionFactory() as session:
+            detail_payload = await _render_signal_detail_section(
+                session,
+                row_id=row_id,
+                section=section_value,
+                request=request,
+            )
+        return {**detail_payload, **metadata}
 
     if queue_value == "complaints":
         async with SessionFactory() as session:

--- a/app/web/main.py
+++ b/app/web/main.py
@@ -255,6 +255,34 @@ def _parse_appeal_aging_bucket_filter(raw: str) -> str:
     raise HTTPException(status_code=400, detail="Invalid appeals aging filter")
 
 
+def _parse_complaint_sla_health_filter(raw: str) -> str:
+    value = raw.strip().lower()
+    if value in {"all", "healthy", "warning", "critical", "overdue", "no_sla"}:
+        return value
+    raise HTTPException(status_code=400, detail="Invalid complaints SLA health filter")
+
+
+def _parse_complaint_aging_bucket_filter(raw: str) -> str:
+    value = raw.strip().lower()
+    if value in {"all", "fresh", "aging", "stale", "critical", "overdue", "unknown"}:
+        return value
+    raise HTTPException(status_code=400, detail="Invalid complaints aging filter")
+
+
+def _parse_signal_sla_health_filter(raw: str) -> str:
+    value = raw.strip().lower()
+    if value in {"all", "healthy", "warning", "critical", "overdue", "no_sla"}:
+        return value
+    raise HTTPException(status_code=400, detail="Invalid signals SLA health filter")
+
+
+def _parse_signal_aging_bucket_filter(raw: str) -> str:
+    value = raw.strip().lower()
+    if value in {"all", "fresh", "aging", "stale", "critical", "overdue", "unknown"}:
+        return value
+    raise HTTPException(status_code=400, detail="Invalid signals aging filter")
+
+
 def _parse_trade_feedback_status(raw: str) -> str:
     value = raw.strip().lower()
     if value in {"all", "visible", "hidden"}:

--- a/app/web/main.py
+++ b/app/web/main.py
@@ -22,7 +22,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from app.config import settings
-from app.db.enums import AppealSourceType, AppealStatus, AuctionStatus, ModerationAction, PointsEventType, UserRole
+from app.db.enums import (
+    AppealSourceType,
+    AppealStatus,
+    AuctionStatus,
+    ModerationAction,
+    PointsEventType,
+    UserRole,
+)
 from app.db.models import (
     Appeal,
     Auction,
@@ -103,7 +110,11 @@ from app.services.points_service import (
     list_user_points_entries,
 )
 from app.services.queue_sla_health_service import SLA_THRESHOLDS_BY_CONTEXT, decide_queue_sla_health
-from app.services.risk_eval_service import UserRiskSnapshot, evaluate_user_risk_snapshot, format_risk_reason_label
+from app.services.risk_eval_service import (
+    UserRiskSnapshot,
+    evaluate_user_risk_snapshot,
+    format_risk_reason_label,
+)
 from app.services.runtime_settings_service import (
     build_runtime_settings_snapshot,
     delete_runtime_setting_override,
@@ -160,7 +171,17 @@ _QUEUE_ALLOWED_COLUMNS: dict[str, tuple[str, ...]] = {
         "created",
         "manage",
     ),
-    "violators": ("id", "tg_user_id", "username", "status", "reason", "actor", "created", "expires", "actions"),
+    "violators": (
+        "id",
+        "tg_user_id",
+        "username",
+        "status",
+        "reason",
+        "actor",
+        "created",
+        "expires",
+        "actions",
+    ),
     "appeals": (
         "id",
         "reference",
@@ -473,18 +494,22 @@ async def _render_appeal_detail_section(
         signal = await session.scalar(select(FraudSignal).where(FraudSignal.id == appeal.source_id))
 
     moderation_logs = (
-        await session.execute(
-            select(ModerationLog)
-            .where(
-                ModerationLog.action.in_(
-                    (ModerationAction.RESOLVE_APPEAL, ModerationAction.REJECT_APPEAL)
-                ),
-                ModerationLog.target_user_id == appeal.appellant_user_id,
-                ModerationLog.created_at >= appeal.created_at,
+        (
+            await session.execute(
+                select(ModerationLog)
+                .where(
+                    ModerationLog.action.in_(
+                        (ModerationAction.RESOLVE_APPEAL, ModerationAction.REJECT_APPEAL)
+                    ),
+                    ModerationLog.target_user_id == appeal.appellant_user_id,
+                    ModerationLog.created_at >= appeal.created_at,
+                )
+                .order_by(ModerationLog.created_at.asc(), ModerationLog.id.asc())
             )
-            .order_by(ModerationLog.created_at.asc(), ModerationLog.id.asc())
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
     filtered_logs: list[ModerationLog] = []
     for log_row in moderation_logs:
@@ -502,9 +527,7 @@ async def _render_appeal_detail_section(
     actor_ids = {item.actor_user_id for item in filtered_logs}
     actors_by_id: dict[int, User] = {}
     if actor_ids:
-        actors = (
-            await session.execute(select(User).where(User.id.in_(actor_ids)))
-        ).scalars().all()
+        actors = (await session.execute(select(User).where(User.id.in_(actor_ids)))).scalars().all()
         actors_by_id = {item.id: item for item in actors}
 
     if section == "primary":
@@ -558,15 +581,11 @@ async def _render_appeal_detail_section(
         auction_link = ""
         if related_auction_id is not None:
             auction_path = _path_with_auth(request, f"/timeline/auction/{related_auction_id}")
-            auction_link = (
-                f"<p class='section-note'><a href='{escape(auction_path)}'>Open full auction timeline</a></p>"
-            )
+            auction_link = f"<p class='section-note'><a href='{escape(auction_path)}'>Open full auction timeline</a></p>"
         return {
             "ok": True,
             "html": (
-                "<div data-detail-state='loaded'>"
-                f"{source_line}{timeline_html}{auction_link}"
-                "</div>"
+                f"<div data-detail-state='loaded'>{source_line}{timeline_html}{auction_link}</div>"
             ),
         }
 
@@ -606,7 +625,9 @@ async def _render_appeal_detail_section(
             artifact = payload.get("rationale_artifact") if isinstance(payload, dict) else None
             if not isinstance(artifact, dict):
                 continue
-            actor_label = _user_label(actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id)
+            actor_label = _user_label(
+                actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id
+            )
             summary = str(artifact.get("summary") or "-")
             recorded_at = str(artifact.get("recorded_at") or _fmt_ts(log_row.created_at))
             source_value = str(artifact.get("source") or "web")
@@ -673,18 +694,24 @@ async def _render_complaint_detail_section(
         target = await session.scalar(select(User).where(User.id == complaint.target_user_id))
     resolver = None
     if complaint.resolved_by_user_id is not None:
-        resolver = await session.scalar(select(User).where(User.id == complaint.resolved_by_user_id))
+        resolver = await session.scalar(
+            select(User).where(User.id == complaint.resolved_by_user_id)
+        )
 
     mod_logs = (
-        await session.execute(
-            select(ModerationLog)
-            .where(
-                ModerationLog.auction_id == complaint.auction_id,
-                ModerationLog.created_at >= complaint.created_at,
+        (
+            await session.execute(
+                select(ModerationLog)
+                .where(
+                    ModerationLog.auction_id == complaint.auction_id,
+                    ModerationLog.created_at >= complaint.created_at,
+                )
+                .order_by(ModerationLog.created_at.asc(), ModerationLog.id.asc())
             )
-            .order_by(ModerationLog.created_at.asc(), ModerationLog.id.asc())
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
     actor_ids = {log_row.actor_user_id for log_row in mod_logs}
     actors_by_id: dict[int, User] = {}
@@ -729,7 +756,9 @@ async def _render_complaint_detail_section(
             f"<p class='section-note'>auction={escape(str(complaint.auction_id))}, reporter={escape(_user_label(reporter, complaint.reporter_user_id))}, target={escape(_user_label(target, complaint.target_user_id))}</p>",
         ]
         if complaint.resolution_note:
-            source_bits.append(f"<p class='section-note'>resolution={escape(complaint.resolution_note[:200])}</p>")
+            source_bits.append(
+                f"<p class='section-note'>resolution={escape(complaint.resolution_note[:200])}</p>"
+            )
 
         artifact_items: list[str] = []
         for log_row in mod_logs:
@@ -737,7 +766,9 @@ async def _render_complaint_detail_section(
             artifact = payload.get("rationale_artifact") if isinstance(payload, dict) else None
             if not isinstance(artifact, dict):
                 continue
-            actor_label = _user_label(actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id)
+            actor_label = _user_label(
+                actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id
+            )
             summary = str(artifact.get("summary") or "-")
             recorded_at = str(artifact.get("recorded_at") or _fmt_ts(log_row.created_at))
             source_value = str(artifact.get("source") or "web")
@@ -746,7 +777,9 @@ async def _render_complaint_detail_section(
                 f"<div class='section-note'>actor={escape(actor_label)}, recorded_at={escape(recorded_at)}, source={escape(source_value)}</div></li>"
             )
         if artifact_items:
-            source_bits.append(f"<p><b>Rationale artifacts:</b></p><ul>{''.join(artifact_items)}</ul>")
+            source_bits.append(
+                f"<p><b>Rationale artifacts:</b></p><ul>{''.join(artifact_items)}</ul>"
+            )
         else:
             source_bits.append("<p class='section-note'>No rationale artifacts yet.</p>")
 
@@ -787,15 +820,19 @@ async def _render_signal_detail_section(
         resolver = await session.scalar(select(User).where(User.id == signal.resolved_by_user_id))
 
     mod_logs = (
-        await session.execute(
-            select(ModerationLog)
-            .where(
-                ModerationLog.auction_id == signal.auction_id,
-                ModerationLog.created_at >= signal.created_at,
+        (
+            await session.execute(
+                select(ModerationLog)
+                .where(
+                    ModerationLog.auction_id == signal.auction_id,
+                    ModerationLog.created_at >= signal.created_at,
+                )
+                .order_by(ModerationLog.created_at.asc(), ModerationLog.id.asc())
             )
-            .order_by(ModerationLog.created_at.asc(), ModerationLog.id.asc())
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
     actor_ids = {log_row.actor_user_id for log_row in mod_logs}
     actors_by_id: dict[int, User] = {}
@@ -840,7 +877,9 @@ async def _render_signal_detail_section(
             f"<p class='section-note'>auction={escape(str(signal.auction_id))}, user={escape(_user_label(signal_user, signal.user_id))}</p>",
         ]
         if signal.resolution_note:
-            source_bits.append(f"<p class='section-note'>resolution={escape(signal.resolution_note[:200])}</p>")
+            source_bits.append(
+                f"<p class='section-note'>resolution={escape(signal.resolution_note[:200])}</p>"
+            )
 
         artifact_items: list[str] = []
         for log_row in mod_logs:
@@ -848,7 +887,9 @@ async def _render_signal_detail_section(
             artifact = payload.get("rationale_artifact") if isinstance(payload, dict) else None
             if not isinstance(artifact, dict):
                 continue
-            actor_label = _user_label(actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id)
+            actor_label = _user_label(
+                actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id
+            )
             summary = str(artifact.get("summary") or "-")
             recorded_at = str(artifact.get("recorded_at") or _fmt_ts(log_row.created_at))
             source_value = str(artifact.get("source") or "web")
@@ -857,7 +898,9 @@ async def _render_signal_detail_section(
                 f"<div class='section-note'>actor={escape(actor_label)}, recorded_at={escape(recorded_at)}, source={escape(source_value)}</div></li>"
             )
         if artifact_items:
-            source_bits.append(f"<p><b>Rationale artifacts:</b></p><ul>{''.join(artifact_items)}</ul>")
+            source_bits.append(
+                f"<p><b>Rationale artifacts:</b></p><ul>{''.join(artifact_items)}</ul>"
+            )
         else:
             source_bits.append("<p class='section-note'>No rationale artifacts yet.</p>")
 
@@ -936,10 +979,15 @@ async def _load_user_risk_snapshot_map(
                 select(BlacklistEntry.user_id).where(
                     BlacklistEntry.user_id.in_(unique_user_ids),
                     BlacklistEntry.is_active.is_(True),
-                    (BlacklistEntry.expires_at.is_(None) | (BlacklistEntry.expires_at > current_time)),
+                    (
+                        BlacklistEntry.expires_at.is_(None)
+                        | (BlacklistEntry.expires_at > current_time)
+                    ),
                 )
             )
-        ).scalars().all()
+        )
+        .scalars()
+        .all()
     )
     verified_user_ids = await load_verified_user_ids(session, user_ids=unique_user_ids)
 
@@ -1348,12 +1396,7 @@ def _dashboard_preset_toolbar(request: Request, active_preset: str) -> str:
             f"href='{escape(_path_with_auth(request, f'/?preset={preset_key}'))}' "
             f"title='{escape(hint)}'>{escape(label)}</a>"
         )
-    return (
-        "<div class='toolbar'>"
-        "<b>Режим экрана:</b>"
-        f"{''.join(chips)}"
-        "</div>"
-    )
+    return f"<div class='toolbar'><b>Режим экрана:</b>{''.join(chips)}</div>"
 
 
 def _dashboard_preset_script(default_preset: str = "incident") -> str:
@@ -1511,20 +1554,28 @@ def _render_workflow_preset_telemetry_panel(
             avg_time = item.get("avg_time_to_action_ms")
             avg_time_value = float(avg_time) if isinstance(avg_time, (int, float)) else None
             reopen_rate_raw = item.get("reopen_rate")
-            reopen_rate = float(reopen_rate_raw) if isinstance(reopen_rate_raw, (int, float)) else 0.0
+            reopen_rate = (
+                float(reopen_rate_raw) if isinstance(reopen_rate_raw, (int, float)) else 0.0
+            )
             avg_churn_raw = item.get("avg_filter_churn_count")
             avg_churn = float(avg_churn_raw) if isinstance(avg_churn_raw, (int, float)) else 0.0
             trend_guardrail = bool(item.get("trend_low_sample_guardrail"))
             trend_min_sample_raw = item.get("trend_min_sample_size")
-            trend_min_sample = int(trend_min_sample_raw) if isinstance(trend_min_sample_raw, int) else 0
+            trend_min_sample = (
+                int(trend_min_sample_raw) if isinstance(trend_min_sample_raw, int) else 0
+            )
             prev_events_raw = item.get("trend_previous_events_total")
             prev_events = int(prev_events_raw) if isinstance(prev_events_raw, int) else 0
             time_delta_raw = item.get("time_to_action_delta_ms")
             time_delta = float(time_delta_raw) if isinstance(time_delta_raw, (int, float)) else None
             reopen_delta_raw = item.get("reopen_rate_delta")
-            reopen_delta = float(reopen_delta_raw) if isinstance(reopen_delta_raw, (int, float)) else None
+            reopen_delta = (
+                float(reopen_delta_raw) if isinstance(reopen_delta_raw, (int, float)) else None
+            )
             churn_delta_raw = item.get("filter_churn_delta")
-            churn_delta = float(churn_delta_raw) if isinstance(churn_delta_raw, (int, float)) else None
+            churn_delta = (
+                float(churn_delta_raw) if isinstance(churn_delta_raw, (int, float)) else None
+            )
 
             trend_time = _format_preset_telemetry_time_delta(time_delta)
             trend_reopen = _format_preset_telemetry_rate_delta(reopen_delta)
@@ -1632,7 +1683,9 @@ async def _load_dense_list_config(
             active_preset_id = int(active["id"])
             active_preset_name = str(active["name"])
         preset_notice = str(preset_state.get("notice") or "")
-        preset_items = tuple((str(item["id"]), str(item["name"])) for item in preset_state["presets"])
+        preset_items = tuple(
+            (str(item["id"]), str(item["name"])) for item in preset_state["presets"]
+        )
     else:
         preference = await load_admin_list_preference(
             session,
@@ -1646,7 +1699,9 @@ async def _load_dense_list_config(
 
     return DenseListConfig(
         queue_key=queue_key,
-        density=_resolve_dense_density(requested=requested_density, persisted=preference["density"]),
+        density=_resolve_dense_density(
+            requested=requested_density, persisted=preference["density"]
+        ),
         table_id=table_id,
         quick_filter_placeholder=quick_filter_placeholder,
         columns_order=tuple(columns["order"]),
@@ -1693,7 +1748,9 @@ def _normalize_workflow_preset_telemetry_payload(payload: object) -> dict[str, o
     return normalized
 
 
-def _resolve_workflow_preset_telemetry_preset_id(*, action: str, payload: dict[str, object], result: dict[str, object]) -> int | None:
+def _resolve_workflow_preset_telemetry_preset_id(
+    *, action: str, payload: dict[str, object], result: dict[str, object]
+) -> int | None:
     if action in {"save", "update", "select"}:
         preset_meta = result.get("preset")
         if isinstance(preset_meta, dict):
@@ -1860,7 +1917,9 @@ def _triage_shortcut_hint() -> str:
     )
 
 
-def _require_scope_permission(request: Request, scope: str) -> tuple[Response | None, AdminAuthContext]:
+def _require_scope_permission(
+    request: Request, scope: str
+) -> tuple[Response | None, AdminAuthContext]:
     response, auth = _auth_context_or_unauthorized(request)
     if response is not None:
         return response, auth
@@ -1900,7 +1959,9 @@ async def _resolve_actor_user_id(auth: AdminAuthContext) -> int:
     if tg_user_id is None:
         admin_ids = settings.parsed_admin_user_ids()
         if not admin_ids:
-            raise HTTPException(status_code=500, detail="ADMIN_USER_IDS is required for web actions")
+            raise HTTPException(
+                status_code=500, detail="ADMIN_USER_IDS is required for web actions"
+            )
         tg_user_id = admin_ids[0]
 
     async with SessionFactory() as session:
@@ -1954,10 +2015,7 @@ async def login_page(request: Request) -> Response:
 
     fallback = ""
     if settings.admin_panel_token.strip():
-        fallback = (
-            "<p>Также можно открыть панель по ссылке с токеном: "
-            "<code>/?token=...</code></p>"
-        )
+        fallback = "<p>Также можно открыть панель по ссылке с токеном: <code>/?token=...</code></p>"
 
     body = (
         "<h1>LiteAuction Admin Login</h1>"
@@ -2022,29 +2080,35 @@ async def dashboard(request: Request) -> Response:
         snapshot.users_with_engagement - snapshot.users_engaged_without_private_start,
         0,
     )
-    global_daily_limit_line = "<div class='kpi'><b>Global redemption daily limit:</b> unlimited</div>"
+    global_daily_limit_line = (
+        "<div class='kpi'><b>Global redemption daily limit:</b> unlimited</div>"
+    )
     if settings.points_redemption_daily_limit > 0:
-        global_daily_limit_line = (
-            f"<div class='kpi'><b>Global redemption daily limit:</b> {settings.points_redemption_daily_limit}/day</div>"
-        )
-    global_weekly_limit_line = "<div class='kpi'><b>Global redemption weekly limit:</b> unlimited</div>"
+        global_daily_limit_line = f"<div class='kpi'><b>Global redemption daily limit:</b> {settings.points_redemption_daily_limit}/day</div>"
+    global_weekly_limit_line = (
+        "<div class='kpi'><b>Global redemption weekly limit:</b> unlimited</div>"
+    )
     if settings.points_redemption_weekly_limit > 0:
-        global_weekly_limit_line = (
-            f"<div class='kpi'><b>Global redemption weekly limit:</b> {settings.points_redemption_weekly_limit}/week</div>"
-        )
-    global_daily_spend_cap_line = "<div class='kpi'><b>Global redemption daily spend cap:</b> unlimited</div>"
+        global_weekly_limit_line = f"<div class='kpi'><b>Global redemption weekly limit:</b> {settings.points_redemption_weekly_limit}/week</div>"
+    global_daily_spend_cap_line = (
+        "<div class='kpi'><b>Global redemption daily spend cap:</b> unlimited</div>"
+    )
     if settings.points_redemption_daily_spend_cap > 0:
         global_daily_spend_cap_line = (
             "<div class='kpi'><b>Global redemption daily spend cap:</b> "
             f"{settings.points_redemption_daily_spend_cap} points/day</div>"
         )
-    global_weekly_spend_cap_line = "<div class='kpi'><b>Global redemption weekly spend cap:</b> unlimited</div>"
+    global_weekly_spend_cap_line = (
+        "<div class='kpi'><b>Global redemption weekly spend cap:</b> unlimited</div>"
+    )
     if settings.points_redemption_weekly_spend_cap > 0:
         global_weekly_spend_cap_line = (
             "<div class='kpi'><b>Global redemption weekly spend cap:</b> "
             f"{settings.points_redemption_weekly_spend_cap} points/week</div>"
         )
-    global_monthly_spend_cap_line = "<div class='kpi'><b>Global redemption monthly spend cap:</b> unlimited</div>"
+    global_monthly_spend_cap_line = (
+        "<div class='kpi'><b>Global redemption monthly spend cap:</b> unlimited</div>"
+    )
     if settings.points_redemption_monthly_spend_cap > 0:
         global_monthly_spend_cap_line = (
             "<div class='kpi'><b>Global redemption monthly spend cap:</b> "
@@ -2053,9 +2117,7 @@ async def dashboard(request: Request) -> Response:
 
     owner_settings_link = ""
     if auth.role == "owner":
-        owner_settings_link = (
-            f"<a class='link-tile' href='{escape(_path_with_auth(request, '/settings'))}'>Runtime settings</a>"
-        )
+        owner_settings_link = f"<a class='link-tile' href='{escape(_path_with_auth(request, '/settings'))}'>Runtime settings</a>"
 
     overview_cards = _kpi_grid(
         [
@@ -2086,7 +2148,9 @@ async def dashboard(request: Request) -> Response:
             _kpi_card("Пользователи со ставками", str(snapshot.users_with_bid_activity)),
             _kpi_card("Пользователи с жалобами", str(snapshot.users_with_report_activity)),
             _kpi_card("Уникально вовлеченные", str(snapshot.users_with_engagement)),
-            _kpi_card("Вовлеченные без private /start", str(snapshot.users_engaged_without_private_start)),
+            _kpi_card(
+                "Вовлеченные без private /start", str(snapshot.users_engaged_without_private_start)
+            ),
             _kpi_card(
                 "Вовлеченные с private /start",
                 f"{engaged_with_private} ({_pct(engaged_with_private, snapshot.users_with_engagement)})",
@@ -2096,14 +2160,23 @@ async def dashboard(request: Request) -> Response:
     points_core_cards = _kpi_grid(
         [
             _kpi_card("Активные points-пользователи (7д)", str(snapshot.points_active_users_7d)),
-            _kpi_card("Пользователи с положительным балансом", str(snapshot.points_users_with_positive_balance)),
+            _kpi_card(
+                "Пользователи с положительным балансом",
+                str(snapshot.points_users_with_positive_balance),
+            ),
             _kpi_card(
                 "Редимеры points (7д)",
                 f"{snapshot.points_redeemers_7d} ({_pct(snapshot.points_redeemers_7d, snapshot.points_users_with_positive_balance)})",
             ),
-            _kpi_card("Редимеры фидбек-буста (7д)", str(snapshot.points_feedback_boost_redeemers_7d)),
-            _kpi_card("Редимеры буста гаранта (7д)", str(snapshot.points_guarantor_boost_redeemers_7d)),
-            _kpi_card("Редимеры буста апелляции (7д)", str(snapshot.points_appeal_boost_redeemers_7d)),
+            _kpi_card(
+                "Редимеры фидбек-буста (7д)", str(snapshot.points_feedback_boost_redeemers_7d)
+            ),
+            _kpi_card(
+                "Редимеры буста гаранта (7д)", str(snapshot.points_guarantor_boost_redeemers_7d)
+            ),
+            _kpi_card(
+                "Редимеры буста апелляции (7д)", str(snapshot.points_appeal_boost_redeemers_7d)
+            ),
         ]
     )
     points_24h_cards = _kpi_grid(
@@ -2150,7 +2223,10 @@ async def dashboard(request: Request) -> Response:
             global_daily_spend_cap_line,
             global_weekly_spend_cap_line,
             global_monthly_spend_cap_line,
-            _kpi_card("Min balance after redemption", f"{max(settings.points_redemption_min_balance, 0)} points"),
+            _kpi_card(
+                "Min balance after redemption",
+                f"{max(settings.points_redemption_min_balance, 0)} points",
+            ),
             _kpi_card(
                 "Min account age for redemption",
                 f"{max(settings.points_redemption_min_account_age_seconds, 0)}s",
@@ -2159,7 +2235,10 @@ async def dashboard(request: Request) -> Response:
                 "Min earned points for redemption",
                 f"{max(settings.points_redemption_min_earned_points, 0)} points",
             ),
-            _kpi_card("Global redemption cooldown", f"{max(settings.points_redemption_cooldown_seconds, 0)}s"),
+            _kpi_card(
+                "Global redemption cooldown",
+                f"{max(settings.points_redemption_cooldown_seconds, 0)}s",
+            ),
         ]
     )
     points_summary = (
@@ -2217,7 +2296,7 @@ async def dashboard(request: Request) -> Response:
         f"{_panel('Быстрые действия', quick_actions, eyebrow='navigation', note='Основные сценарии оператора')}"
         f"{_panel('Воронка онбординга / soft-gate', onboarding_collapsed, eyebrow='growth')}"
         f"{_panel('Активность пользователей', activity_collapsed, eyebrow='engagement')}"
-        f"{_panel('Points utility', points_cards, eyebrow='rewards') }"
+        f"{_panel('Points utility', points_cards, eyebrow='rewards')}"
         f"{_dashboard_preset_script()}"
     )
     return HTMLResponse(_render_page("LiteAuction Admin", body))
@@ -2417,7 +2496,9 @@ async def complaints(
     table_rows = ""
     for item in rows:
         complaint_priority = "high" if str(item.status).upper() == "OPEN" else "normal"
-        complaint_deadline = item.created_at + complaint_sla_thresholds.warning_window if item.created_at else None
+        complaint_deadline = (
+            item.created_at + complaint_sla_thresholds.warning_window if item.created_at else None
+        )
         sla_decision = decide_queue_sla_health(
             queue_context="moderation",
             status=item.status,
@@ -2428,7 +2509,9 @@ async def complaints(
         if sla_decision.health_state in ("critical", "overdue"):
             complaint_priority = "urgent"
         sla_hint = f"SLA:{sla_decision.health_state} | age:{sla_decision.aging_bucket}"
-        row_context_attrs = _triage_row_context_attrs(risk_level="low", priority_level=complaint_priority)
+        row_context_attrs = _triage_row_context_attrs(
+            risk_level="low", priority_level=complaint_priority
+        )
         table_rows += (
             f"<tr data-row='{escape(f'{item.id} {item.auction_id} {item.reporter_user_id} {item.status} {item.reason}')}' "
             f"data-triage-row='1' data-row-id='{item.id}' tabindex='0'{row_context_attrs}>"
@@ -2453,12 +2536,12 @@ async def complaints(
         table_rows = "<tr><td colspan='9'><span class='empty-state'>Нет записей</span></td></tr>"
 
     prev_link = (
-        f"<a href='{escape(_path_with_auth(request, _complaints_path(page_value=page-1, status_value=status)))}'>← Назад</a>"
+        f"<a href='{escape(_path_with_auth(request, _complaints_path(page_value=page - 1, status_value=status)))}'>← Назад</a>"
         if page > 0
         else ""
     )
     next_link = (
-        f"<a href='{escape(_path_with_auth(request, _complaints_path(page_value=page+1, status_value=status)))}'>Вперед →</a>"
+        f"<a href='{escape(_path_with_auth(request, _complaints_path(page_value=page + 1, status_value=status)))}'>Вперед →</a>"
         if has_next
         else ""
     )
@@ -2484,7 +2567,7 @@ async def complaints(
     )
 
     body = (
-        f"{_render_app_header('Жалобы', auth, f'Статус: {status}') }"
+        f"{_render_app_header('Жалобы', auth, f'Статус: {status}')}"
         "<div class='section-card'>"
         f"<p class='page-links'><a href='{escape(_path_with_auth(request, '/'))}'>На главную</a></p>"
         f"{dense_toolbar}"
@@ -2602,7 +2685,9 @@ async def signals(
             signal_priority = "urgent"
         elif int(item.score) >= 50:
             signal_priority = "high"
-        signal_deadline = item.created_at + signal_sla_thresholds.warning_window if item.created_at else None
+        signal_deadline = (
+            item.created_at + signal_sla_thresholds.warning_window if item.created_at else None
+        )
         sla_decision = decide_queue_sla_health(
             queue_context="risk",
             status=item.status,
@@ -2641,12 +2726,12 @@ async def signals(
         table_rows = "<tr><td colspan='8'><span class='empty-state'>Нет записей</span></td></tr>"
 
     prev_link = (
-        f"<a href='{escape(_path_with_auth(request, _signals_path(page_value=page-1, status_value=status)))}'>← Назад</a>"
+        f"<a href='{escape(_path_with_auth(request, _signals_path(page_value=page - 1, status_value=status)))}'>← Назад</a>"
         if page > 0
         else ""
     )
     next_link = (
-        f"<a href='{escape(_path_with_auth(request, _signals_path(page_value=page+1, status_value=status)))}'>Вперед →</a>"
+        f"<a href='{escape(_path_with_auth(request, _signals_path(page_value=page + 1, status_value=status)))}'>Вперед →</a>"
         if has_next
         else ""
     )
@@ -2672,7 +2757,7 @@ async def signals(
     )
 
     body = (
-        f"{_render_app_header('Фрод-сигналы', auth, f'Статус: {status}') }"
+        f"{_render_app_header('Фрод-сигналы', auth, f'Статус: {status}')}"
         "<div class='section-card'>"
         f"<p class='page-links'><a href='{escape(_path_with_auth(request, '/'))}'>На главную</a></p>"
         f"{dense_toolbar}"
@@ -2854,7 +2939,9 @@ async def trade_feedback(
         moderator_label = "-"
         moderator_cell = "-"
         if moderator is not None:
-            moderator_label = f"@{moderator.username}" if moderator.username else str(moderator.tg_user_id)
+            moderator_label = (
+                f"@{moderator.username}" if moderator.username else str(moderator.tg_user_id)
+            )
             moderator_cell = (
                 f"<a href='{escape(_path_with_auth(request, _trade_feedback_path(page_value=0, moderator_tg=str(moderator.tg_user_id))))}'>"
                 f"{escape(moderator_label)}</a>"
@@ -2902,7 +2989,7 @@ async def trade_feedback(
             )
 
         table_rows += (
-            f"<tr data-row='{escape(f"{item.id} {auction.id} {author_label} {target_label} {item.status} {item.rating} {item.comment or ''} {item.moderation_note or ''}")}' "
+            f"<tr data-row='{escape(f'{item.id} {auction.id} {author_label} {target_label} {item.status} {item.rating} {item.comment or ""} {item.moderation_note or ""}')}' "
             f"data-triage-row='1' data-row-id='{item.id}' tabindex='0'{row_context_attrs}>"
             f"<td>{_triage_controls_cell(item.id)}</td>"
             f"<td data-col='id'>{item.id}</td>"
@@ -3028,14 +3115,18 @@ async def auctions(
 
     async with SessionFactory() as session:
         rows = (
-            await session.execute(
-                select(Auction)
-                .where(Auction.status == status)
-                .order_by(Auction.created_at.desc())
-                .offset(offset)
-                .limit(page_size + 1)
+            (
+                await session.execute(
+                    select(Auction)
+                    .where(Auction.status == status)
+                    .order_by(Auction.created_at.desc())
+                    .offset(offset)
+                    .limit(page_size + 1)
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
         has_next = len(rows) > page_size
         rows = rows[:page_size]
@@ -3059,7 +3150,10 @@ async def auctions(
         has_active_blacklist=False,
         removed_bids=0,
     )
-    def _auctions_path(*, page_value: int, status_value: str, density_value: str | None = None) -> str:
+
+    def _auctions_path(
+        *, page_value: int, status_value: str, density_value: str | None = None
+    ) -> str:
         query = {
             "status": status_value,
             "page": str(page_value),
@@ -3071,7 +3165,7 @@ async def auctions(
     for item in rows:
         seller_risk = seller_risk_map.get(item.seller_user_id, default_risk_snapshot)
         table_rows += (
-            f"<tr data-row='{escape(f"{item.id} {item.seller_user_id} {item.status} {item.start_price} {item.buyout_price or ''}")}'>"
+            f"<tr data-row='{escape(f'{item.id} {item.seller_user_id} {item.status} {item.start_price} {item.buyout_price or ""}')}'>"
             f"<td data-col='id'><a href='{escape(_path_with_auth(request, f'/timeline/auction/{item.id}'))}'>{escape(str(item.id))}</a></td>"
             f"<td data-col='seller'>{item.seller_user_id}</td>"
             f"<td data-col='risk'>{_risk_snapshot_inline_html(seller_risk)}</td>"
@@ -3086,12 +3180,12 @@ async def auctions(
         table_rows = "<tr><td colspan='8'><span class='empty-state'>Нет записей</span></td></tr>"
 
     prev_link = (
-        f"<a href='{escape(_path_with_auth(request, _auctions_path(page_value=page-1, status_value=status)))}'>← Назад</a>"
+        f"<a href='{escape(_path_with_auth(request, _auctions_path(page_value=page - 1, status_value=status)))}'>← Назад</a>"
         if page > 0
         else ""
     )
     next_link = (
-        f"<a href='{escape(_path_with_auth(request, _auctions_path(page_value=page+1, status_value=status)))}'>Вперед →</a>"
+        f"<a href='{escape(_path_with_auth(request, _auctions_path(page_value=page + 1, status_value=status)))}'>Вперед →</a>"
         if has_next
         else ""
     )
@@ -3110,7 +3204,7 @@ async def auctions(
     )
 
     body = (
-        f"{_render_app_header('Аукционы', auth, f'Статус: {status}') }"
+        f"{_render_app_header('Аукционы', auth, f'Статус: {status}')}"
         "<div class='section-card'>"
         f"<p class='page-links'><a href='{escape(_path_with_auth(request, '/'))}'>На главную</a></p>"
         f"{dense_toolbar}"
@@ -3263,7 +3357,9 @@ async def manage_auction(request: Request, auction_id: str) -> Response:
 
     timeline_page = _parse_non_negative_int(request.query_params.get("timeline_page"))
     timeline_limit = _parse_non_negative_int(request.query_params.get("timeline_limit"))
-    _, timeline_source = _normalize_timeline_source_query(request.query_params.get("timeline_source"))
+    _, timeline_source = _normalize_timeline_source_query(
+        request.query_params.get("timeline_source")
+    )
 
     async with SessionFactory() as session:
         auction = await session.scalar(select(Auction).where(Auction.id == auction_uuid))
@@ -3337,7 +3433,7 @@ async def manage_auction(request: Request, auction_id: str) -> Response:
 
     bids_table = (
         "<table><thead><tr><th>Bid ID</th><th>Amount</th><th>TG UID</th><th>Username</th><th>Created</th><th>Removed</th><th>Action</th></tr></thead>"
-        f"<tbody>{''.join(bid_rows) if bid_rows else '<tr><td colspan=7><span class=\"empty-state\">Нет ставок</span></td></tr>'}</tbody></table>"
+        f"<tbody>{''.join(bid_rows) if bid_rows else '<tr><td colspan=7><span class="empty-state">Нет ставок</span></td></tr>'}</tbody></table>"
     )
 
     body = (
@@ -3412,7 +3508,9 @@ async def manage_user(
             or 0
         )
         fraud_total = int(
-            await session.scalar(select(func.count(FraudSignal.id)).where(FraudSignal.user_id == user.id))
+            await session.scalar(
+                select(func.count(FraudSignal.id)).where(FraudSignal.user_id == user.id)
+            )
             or 0
         )
         fraud_open = int(
@@ -3426,21 +3524,29 @@ async def manage_user(
         )
 
         recent_complaints_against = (
-            await session.execute(
-                select(Complaint)
-                .where(Complaint.target_user_id == user.id)
-                .order_by(Complaint.created_at.desc())
-                .limit(10)
+            (
+                await session.execute(
+                    select(Complaint)
+                    .where(Complaint.target_user_id == user.id)
+                    .order_by(Complaint.created_at.desc())
+                    .limit(10)
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         recent_fraud_signals = (
-            await session.execute(
-                select(FraudSignal)
-                .where(FraudSignal.user_id == user.id)
-                .order_by(FraudSignal.created_at.desc())
-                .limit(10)
+            (
+                await session.execute(
+                    select(FraudSignal)
+                    .where(FraudSignal.user_id == user.id)
+                    .order_by(FraudSignal.created_at.desc())
+                    .limit(10)
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
         points_summary = await get_user_points_summary(session, user_id=user.id)
         points_total_items = await count_user_points_entries(
@@ -3488,7 +3594,9 @@ async def manage_user(
         )
         boost_guarantor_points_spent_total = int(
             await session.scalar(
-                select(func.coalesce(func.sum(GuarantorRequest.priority_boost_points_spent), 0)).where(
+                select(
+                    func.coalesce(func.sum(GuarantorRequest.priority_boost_points_spent), 0)
+                ).where(
                     GuarantorRequest.submitter_user_id == user.id,
                     GuarantorRequest.priority_boosted_at.is_not(None),
                 )
@@ -3551,8 +3659,12 @@ async def manage_user(
         )
 
         trade_feedback_summary = await get_trade_feedback_summary(session, target_user_id=user.id)
-        trade_feedback_received = await list_received_trade_feedback(session, target_user_id=user.id, limit=10)
-        verification_status = await get_user_verification_status(session, tg_user_id=user.tg_user_id)
+        trade_feedback_received = await list_received_trade_feedback(
+            session, target_user_id=user.id, limit=10
+        )
+        verification_status = await get_user_verification_status(
+            session, tg_user_id=user.tg_user_id
+        )
 
     can_ban_users = auth.can(SCOPE_USER_BAN)
     can_manage_roles = auth.can(SCOPE_ROLE_MANAGE)
@@ -3633,7 +3745,9 @@ async def manage_user(
     )
     risk_reasons_text = "-"
     if risk_snapshot.reasons:
-        risk_reasons_text = ", ".join(format_risk_reason_label(code) for code in risk_snapshot.reasons)
+        risk_reasons_text = ", ".join(
+            format_risk_reason_label(code) for code in risk_snapshot.reasons
+        )
 
     complaints_rows = "".join(
         "<tr>"
@@ -3646,7 +3760,9 @@ async def manage_user(
         for item in recent_complaints_against
     )
     if not complaints_rows:
-        complaints_rows = "<tr><td colspan='5'><span class='empty-state'>Нет записей</span></td></tr>"
+        complaints_rows = (
+            "<tr><td colspan='5'><span class='empty-state'>Нет записей</span></td></tr>"
+        )
 
     signal_rows = "".join(
         "<tr>"
@@ -3686,7 +3802,9 @@ async def manage_user(
         for view in trade_feedback_received
     )
     if not trade_feedback_rows:
-        trade_feedback_rows = "<tr><td colspan='7'><span class='empty-state'>Нет отзывов</span></td></tr>"
+        trade_feedback_rows = (
+            "<tr><td colspan='7'><span class='empty-state'>Нет отзывов</span></td></tr>"
+        )
 
     average_trade_rating_text = "-"
     if trade_feedback_summary.average_visible_rating is not None:
@@ -3753,14 +3871,14 @@ async def manage_user(
     global_daily_remaining = max(global_daily_limit - redemptions_used_today, 0)
     global_daily_limit_text = "без ограничений"
     if global_daily_limit > 0:
-        global_daily_limit_text = f"{redemptions_used_today}/{global_daily_limit} (осталось {global_daily_remaining})"
+        global_daily_limit_text = (
+            f"{redemptions_used_today}/{global_daily_limit} (осталось {global_daily_remaining})"
+        )
     global_weekly_limit = max(settings.points_redemption_weekly_limit, 0)
     global_weekly_remaining = max(global_weekly_limit - redemptions_used_this_week, 0)
     global_weekly_limit_text = "без ограничений"
     if global_weekly_limit > 0:
-        global_weekly_limit_text = (
-            f"{redemptions_used_this_week}/{global_weekly_limit} (осталось {global_weekly_remaining})"
-        )
+        global_weekly_limit_text = f"{redemptions_used_this_week}/{global_weekly_limit} (осталось {global_weekly_remaining})"
     global_daily_spend_cap = max(settings.points_redemption_daily_spend_cap, 0)
     global_daily_spend_remaining = max(global_daily_spend_cap - redemptions_spent_today, 0)
     global_daily_spend_text = "без ограничений"
@@ -3811,9 +3929,15 @@ async def manage_user(
             _kpi_card("Ставок", str(bids_total)),
             _kpi_card("Снято ставок", str(bids_removed), tone="warn" if bids_removed > 0 else ""),
             _kpi_card("Жалоб создано", str(complaints_created)),
-            _kpi_card("Жалоб на пользователя", str(complaints_against), tone="warn" if complaints_against > 0 else ""),
+            _kpi_card(
+                "Жалоб на пользователя",
+                str(complaints_against),
+                tone="warn" if complaints_against > 0 else "",
+            ),
             _kpi_card("Фрод-сигналов", str(fraud_total)),
-            _kpi_card("Открытых сигналов", str(fraud_open), tone="critical" if fraud_open > 0 else ""),
+            _kpi_card(
+                "Открытых сигналов", str(fraud_open), tone="critical" if fraud_open > 0 else ""
+            ),
             _kpi_card("Риск-уровень", risk_snapshot.level, tone=risk_tone),
             _kpi_card("Риск-скор", str(risk_snapshot.score)),
         ]
@@ -3856,16 +3980,25 @@ async def manage_user(
                     f"cooldown {max(settings.appeal_priority_boost_cooldown_seconds, 0)}s"
                 ),
             ),
-            _kpi_card("Глобальная политика редимпшенов", "on" if settings.points_redemption_enabled else "off"),
+            _kpi_card(
+                "Глобальная политика редимпшенов",
+                "on" if settings.points_redemption_enabled else "off",
+            ),
             _kpi_card("Глобальный дневной лимит редимпшена", global_daily_limit_text),
             _kpi_card("Глобальный недельный лимит редимпшена", global_weekly_limit_text),
             _kpi_card("Глобальный лимит списания на бусты", global_daily_spend_text),
             _kpi_card("Глобальный недельный лимит списания на бусты", global_weekly_spend_text),
             _kpi_card("Глобальный месячный лимит списания на бусты", global_monthly_spend_text),
-            _kpi_card("Минимальный остаток после буста", f"{max(settings.points_redemption_min_balance, 0)} points"),
+            _kpi_card(
+                "Минимальный остаток после буста",
+                f"{max(settings.points_redemption_min_balance, 0)} points",
+            ),
             _kpi_card("Мин. возраст аккаунта для буста", min_account_age_text),
             _kpi_card("Мин. начислено points для буста", min_earned_points_text),
-            _kpi_card("Глобальный кулдаун редимпшена", f"{max(settings.points_redemption_cooldown_seconds, 0)} сек"),
+            _kpi_card(
+                "Глобальный кулдаун редимпшена",
+                f"{max(settings.points_redemption_cooldown_seconds, 0)} сек",
+            ),
         ]
     )
     trade_cards = _kpi_grid(
@@ -3943,7 +4076,9 @@ async def manage_users(
     now = datetime.now(UTC)
     admin_ids = set(settings.parsed_admin_user_ids())
 
-    def _manage_users_path(*, page_value: int, q_value: str | None = None, density_value: str | None = None) -> str:
+    def _manage_users_path(
+        *, page_value: int, q_value: str | None = None, density_value: str | None = None
+    ) -> str:
         query = {
             "page": str(page_value),
             "q": q_value if q_value is not None else query_value,
@@ -3974,10 +4109,14 @@ async def manage_users(
             quick_filter_placeholder="id / tg / username",
         )
         users = (
-            await session.execute(
-                stmt.offset(offset).limit(page_size + 1),
+            (
+                await session.execute(
+                    stmt.offset(offset).limit(page_size + 1),
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
         has_next = len(users) > page_size
         users = users[:page_size]
@@ -3999,7 +4138,9 @@ async def manage_users(
                             ),
                         )
                     )
-                ).scalars().all()
+                )
+                .scalars()
+                .all()
             )
             banned_user_ids = set(
                 (
@@ -4007,10 +4148,15 @@ async def manage_users(
                         select(BlacklistEntry.user_id).where(
                             BlacklistEntry.user_id.in_(user_ids),
                             BlacklistEntry.is_active.is_(True),
-                            (BlacklistEntry.expires_at.is_(None) | (BlacklistEntry.expires_at > now)),
+                            (
+                                BlacklistEntry.expires_at.is_(None)
+                                | (BlacklistEntry.expires_at > now)
+                            ),
                         )
                     )
-                ).scalars().all()
+                )
+                .scalars()
+                .all()
             )
 
     rows = []
@@ -4023,13 +4169,15 @@ async def manage_users(
     for user in users:
         is_allowlist_mod = user.tg_user_id in admin_ids
         is_dynamic_mod = user.id in role_user_ids
-        moderator_text = "yes (allowlist)" if is_allowlist_mod else ("yes" if is_dynamic_mod else "no")
+        moderator_text = (
+            "yes (allowlist)" if is_allowlist_mod else ("yes" if is_dynamic_mod else "no")
+        )
         banned_text = "yes" if user.id in banned_user_ids else "no"
         verified_text = "yes" if user.id in verified_user_ids else "no"
         risk_snapshot = risk_by_user_id.get(user.id, default_risk_snapshot)
 
         rows.append(
-            f"<tr data-row='{escape(f"{user.id} {user.tg_user_id} {user.username or ''} {moderator_text} {banned_text} {verified_text}")}'>"
+            f"<tr data-row='{escape(f'{user.id} {user.tg_user_id} {user.username or ""} {moderator_text} {banned_text} {verified_text}')}'>"
             f"<td data-col='id'>{user.id}</td>"
             f"<td data-col='tg_user_id'>{user.tg_user_id}</td>"
             f"<td data-col='username'>{escape(user.username or '-')}</td>"
@@ -4043,12 +4191,12 @@ async def manage_users(
         )
 
     prev_link = (
-        f"<a href='{escape(_path_with_auth(request, _manage_users_path(page_value=page-1)))}'>← Назад</a>"
+        f"<a href='{escape(_path_with_auth(request, _manage_users_path(page_value=page - 1)))}'>← Назад</a>"
         if page > 0
         else ""
     )
     next_link = (
-        f"<a href='{escape(_path_with_auth(request, _manage_users_path(page_value=page+1)))}'>Вперед →</a>"
+        f"<a href='{escape(_path_with_auth(request, _manage_users_path(page_value=page + 1)))}'>Вперед →</a>"
         if has_next
         else ""
     )
@@ -4085,10 +4233,10 @@ async def manage_users(
         "<button type='submit'>Поиск</button>"
         "</form>"
         "</div>"
-        f"{_kpi_grid([_kpi_card('Пользователей на странице', str(len(users))), _kpi_card('Страница', str(page + 1)), _kpi_card('Поисковый запрос', escape(query_value) if query_value else '-')] )}"
+        f"{_kpi_grid([_kpi_card('Пользователей на странице', str(len(users))), _kpi_card('Страница', str(page + 1)), _kpi_card('Поисковый запрос', escape(query_value) if query_value else '-')])}"
         f"{moderator_grant_form}"
         f"<div class='table-wrap dense-list-shell' data-dense-list='{escape(dense_config.table_id)}' data-density='{escape(dense_config.density)}'><table id='{escape(dense_config.table_id)}'><thead><tr><th data-col='id'>ID</th><th data-col='tg_user_id'>TG User ID</th><th data-col='username'>Username</th><th data-col='moderator'>Moderator</th><th data-col='banned'>Banned</th><th data-col='verified'>Verified</th><th data-col='risk'>Risk</th><th data-col='created'>Created</th><th data-col='manage'>Manage</th></tr></thead>"
-        f"<tbody>{''.join(rows) if rows else '<tr><td colspan=9><span class=\"empty-state\">Нет записей</span></td></tr>'}</tbody></table></div>"
+        f"<tbody>{''.join(rows) if rows else '<tr><td colspan=9><span class="empty-state">Нет записей</span></td></tr>'}</tbody></table></div>"
         f"{_pager_html(prev_link, next_link)}"
         f"{render_dense_list_script(dense_config)}"
         "</div>"
@@ -4125,7 +4273,11 @@ async def violators(
     created_from_dt = _parse_ymd_filter(created_from_value, field_name="created_from")
     created_to_dt = _parse_ymd_filter(created_to_value, field_name="created_to")
     created_to_exclusive = created_to_dt + timedelta(days=1) if created_to_dt is not None else None
-    if created_from_dt is not None and created_to_exclusive is not None and created_from_dt >= created_to_exclusive:
+    if (
+        created_from_dt is not None
+        and created_to_exclusive is not None
+        and created_from_dt >= created_to_exclusive
+    ):
         raise HTTPException(status_code=400, detail="Invalid violators date range")
 
     actor_user = aliased(User)
@@ -4173,11 +4325,7 @@ async def violators(
         else:
             stmt = stmt.where(actor_user.username.ilike(f"%{moderator_value}%"))
 
-    stmt = (
-        stmt.order_by(BlacklistEntry.created_at.desc())
-        .offset(offset)
-        .limit(page_size + 1)
-    )
+    stmt = stmt.order_by(BlacklistEntry.created_at.desc()).offset(offset).limit(page_size + 1)
 
     async with SessionFactory() as session:
         dense_config = await _load_dense_list_config(
@@ -4239,7 +4387,7 @@ async def violators(
             )
 
         table_rows += (
-            f"<tr data-row='{escape(f"{entry.id} {target_user.tg_user_id} {target_user.username or ''} {entry.reason} {actor_label}")}'>"
+            f"<tr data-row='{escape(f'{entry.id} {target_user.tg_user_id} {target_user.username or ""} {entry.reason} {actor_label}')}'>"
             f"<td data-col='id'>{entry.id}</td>"
             f"<td data-col='tg_user_id'><a href='{escape(_path_with_auth(request, f'/manage/user/{target_user.id}'))}'>{target_user.tg_user_id}</a></td>"
             f"<td data-col='username'>{escape(target_label)}</td>"
@@ -4406,9 +4554,17 @@ async def appeals(
     if aging_value == "fresh":
         stmt = stmt.where(Appeal.created_at.is_not(None), Appeal.created_at >= fresh_cutoff)
     elif aging_value == "aging":
-        stmt = stmt.where(Appeal.created_at.is_not(None), Appeal.created_at < fresh_cutoff, Appeal.created_at >= aging_cutoff)
+        stmt = stmt.where(
+            Appeal.created_at.is_not(None),
+            Appeal.created_at < fresh_cutoff,
+            Appeal.created_at >= aging_cutoff,
+        )
     elif aging_value == "stale":
-        stmt = stmt.where(Appeal.created_at.is_not(None), Appeal.created_at < aging_cutoff, Appeal.created_at >= stale_cutoff)
+        stmt = stmt.where(
+            Appeal.created_at.is_not(None),
+            Appeal.created_at < aging_cutoff,
+            Appeal.created_at >= stale_cutoff,
+        )
     elif aging_value == "critical":
         stmt = stmt.where(Appeal.created_at.is_not(None), Appeal.created_at < stale_cutoff)
     elif aging_value == "overdue":
@@ -4444,7 +4600,11 @@ async def appeals(
             )
 
     stmt = (
-        stmt.order_by(Appeal.priority_boosted_at.desc().nullslast(), Appeal.created_at.desc(), Appeal.id.desc())
+        stmt.order_by(
+            Appeal.priority_boosted_at.desc().nullslast(),
+            Appeal.created_at.desc(),
+            Appeal.id.desc(),
+        )
         .offset(offset)
         .limit(page_size + 1)
     )
@@ -4531,11 +4691,15 @@ async def appeals(
 
     for appeal, appellant, resolver in rows:
         source_label = _appeal_source_label(AppealSourceType(appeal.source_type), appeal.source_id)
-        appellant_label = f"@{appellant.username}" if appellant.username else str(appellant.tg_user_id)
+        appellant_label = (
+            f"@{appellant.username}" if appellant.username else str(appellant.tg_user_id)
+        )
         appellant_risk = appellant_risk_map.get(appellant.id, default_risk_snapshot)
         resolver_label = "-"
         if resolver is not None:
-            resolver_label = f"@{resolver.username}" if resolver.username else str(resolver.tg_user_id)
+            resolver_label = (
+                f"@{resolver.username}" if resolver.username else str(resolver.tg_user_id)
+            )
 
         actions = "-"
         appeal_status = AppealStatus(appeal.status)
@@ -4599,7 +4763,7 @@ async def appeals(
             actions = "".join(action_forms)
 
         table_rows += (
-            f"<tr data-row='{escape(f"{appeal.id} {appeal.appeal_ref} {source_label} {appellant_label} {appeal.status} {appeal.resolution_note or ''}")}' "
+            f"<tr data-row='{escape(f'{appeal.id} {appeal.appeal_ref} {source_label} {appellant_label} {appeal.status} {appeal.resolution_note or ""}')}' "
             f"data-triage-row='1' data-row-id='{appeal.id}' tabindex='0'{row_context_attrs}>"
             f"<td>{_triage_controls_cell(appeal.id)}</td>"
             f"<td data-col='id'>{appeal.id}</td>"
@@ -4629,12 +4793,12 @@ async def appeals(
         table_rows = "<tr><td colspan='15'><span class='empty-state'>Нет записей</span></td></tr>"
 
     prev_link = (
-        f"<a href='{escape(_path_with_auth(request, _appeals_path(page_value=page-1)))}'>← Назад</a>"
+        f"<a href='{escape(_path_with_auth(request, _appeals_path(page_value=page - 1)))}'>← Назад</a>"
         if page > 0
         else ""
     )
     next_link = (
-        f"<a href='{escape(_path_with_auth(request, _appeals_path(page_value=page+1)))}'>Вперед →</a>"
+        f"<a href='{escape(_path_with_auth(request, _appeals_path(page_value=page + 1)))}'>Вперед →</a>"
         if has_next
         else ""
     )
@@ -4818,8 +4982,12 @@ async def action_workflow_presets(request: Request) -> dict[str, object]:
                         density=str(payload.get("density") or ""),
                         columns_payload=payload.get("columns") or {},
                         allowed_columns=allowed_columns,
-                        filters_payload=payload.get("filters") if isinstance(payload.get("filters"), dict) else {},
-                        sort_payload=payload.get("sort") if isinstance(payload.get("sort"), dict) else {},
+                        filters_payload=payload.get("filters")
+                        if isinstance(payload.get("filters"), dict)
+                        else {},
+                        sort_payload=payload.get("sort")
+                        if isinstance(payload.get("sort"), dict)
+                        else {},
                         admin_token=token,
                         overwrite=bool(payload.get("overwrite")),
                     )
@@ -4835,8 +5003,12 @@ async def action_workflow_presets(request: Request) -> dict[str, object]:
                         density=str(payload.get("density") or ""),
                         columns_payload=payload.get("columns") or {},
                         allowed_columns=allowed_columns,
-                        filters_payload=payload.get("filters") if isinstance(payload.get("filters"), dict) else {},
-                        sort_payload=payload.get("sort") if isinstance(payload.get("sort"), dict) else {},
+                        filters_payload=payload.get("filters")
+                        if isinstance(payload.get("filters"), dict)
+                        else {},
+                        sort_payload=payload.get("sort")
+                        if isinstance(payload.get("sort"), dict)
+                        else {},
                         admin_token=token,
                     )
                 elif action == "select":
@@ -5078,7 +5250,14 @@ async def action_triage_bulk(request: Request) -> dict[str, object]:
                 if queue_key == "complaints":
                     item = await session.scalar(select(Complaint).where(Complaint.id == row_id))
                     if item is None:
-                        results.append({"id": row_id, "ok": False, "reason_code": "missing", "message": "not found"})
+                        results.append(
+                            {
+                                "id": row_id,
+                                "ok": False,
+                                "reason_code": "missing",
+                                "message": "not found",
+                            }
+                        )
                         continue
                     if bulk_action == "resolve":
                         item.status = "RESOLVED"
@@ -5093,11 +5272,25 @@ async def action_triage_bulk(request: Request) -> dict[str, object]:
                         item.resolved_at = now
                         results.append({"id": row_id, "ok": True, "next_status": "DISMISSED"})
                     else:
-                        results.append({"id": row_id, "ok": False, "reason_code": "unsupported", "message": "unsupported action"})
+                        results.append(
+                            {
+                                "id": row_id,
+                                "ok": False,
+                                "reason_code": "unsupported",
+                                "message": "unsupported action",
+                            }
+                        )
                 elif queue_key == "signals":
                     item = await session.scalar(select(FraudSignal).where(FraudSignal.id == row_id))
                     if item is None:
-                        results.append({"id": row_id, "ok": False, "reason_code": "missing", "message": "not found"})
+                        results.append(
+                            {
+                                "id": row_id,
+                                "ok": False,
+                                "reason_code": "missing",
+                                "message": "not found",
+                            }
+                        )
                         continue
                     if bulk_action == "confirm":
                         item.status = "CONFIRMED"
@@ -5112,10 +5305,24 @@ async def action_triage_bulk(request: Request) -> dict[str, object]:
                         item.resolved_at = now
                         results.append({"id": row_id, "ok": True, "next_status": "DISMISSED"})
                     else:
-                        results.append({"id": row_id, "ok": False, "reason_code": "unsupported", "message": "unsupported action"})
+                        results.append(
+                            {
+                                "id": row_id,
+                                "ok": False,
+                                "reason_code": "unsupported",
+                                "message": "unsupported action",
+                            }
+                        )
                 elif queue_key == "trade_feedback":
                     if bulk_action not in {"hide", "unhide"}:
-                        results.append({"id": row_id, "ok": False, "reason_code": "unsupported", "message": "unsupported action"})
+                        results.append(
+                            {
+                                "id": row_id,
+                                "ok": False,
+                                "reason_code": "unsupported",
+                                "message": "unsupported action",
+                            }
+                        )
                         continue
                     action_result = await set_trade_feedback_visibility(
                         session,
@@ -5128,10 +5335,24 @@ async def action_triage_bulk(request: Request) -> dict[str, object]:
                         next_status = "VISIBLE" if bulk_action == "unhide" else "HIDDEN"
                         results.append({"id": row_id, "ok": True, "next_status": next_status})
                     else:
-                        results.append({"id": row_id, "ok": False, "reason_code": "service_error", "message": action_result.message})
+                        results.append(
+                            {
+                                "id": row_id,
+                                "ok": False,
+                                "reason_code": "service_error",
+                                "message": action_result.message,
+                            }
+                        )
                 else:
                     if bulk_action not in {"in_review", "resolve", "reject"}:
-                        results.append({"id": row_id, "ok": False, "reason_code": "unsupported", "message": "unsupported action"})
+                        results.append(
+                            {
+                                "id": row_id,
+                                "ok": False,
+                                "reason_code": "unsupported",
+                                "message": "unsupported action",
+                            }
+                        )
                         continue
                     if bulk_action == "in_review":
                         action_result = await mark_appeal_in_review(
@@ -5163,7 +5384,14 @@ async def action_triage_bulk(request: Request) -> dict[str, object]:
                             }
                         )
                     else:
-                        results.append({"id": row_id, "ok": False, "reason_code": "service_error", "message": action_result.message})
+                        results.append(
+                            {
+                                "id": row_id,
+                                "ok": False,
+                                "reason_code": "service_error",
+                                "message": action_result.message,
+                            }
+                        )
 
     return {"ok": True, "results": results}
 
@@ -5910,7 +6138,9 @@ async def action_adjust_user_points(
     dedupe_key = ""
     async with SessionFactory() as session:
         async with session.begin():
-            target_user = await session.scalar(select(User).where(User.tg_user_id == target_tg_user_id).with_for_update())
+            target_user = await session.scalar(
+                select(User).where(User.tg_user_id == target_tg_user_id).with_for_update()
+            )
             if target_user is None:
                 return _action_error_page(request, "User not found", back_to=target)
 

--- a/docs/superpowers/plans/2026-04-11-command-reorganization.md
+++ b/docs/superpowers/plans/2026-04-11-command-reorganization.md
@@ -1,0 +1,320 @@
+# Command Reorganization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reorganize bot commands into a hub-and-spoke model with `/start` as the main navigation hub, hiding secondary commands from Telegram menu while keeping all handlers functional.
+
+**Architecture:** Expand the existing `start_private_keyboard` with new buttons (Гарант, Уведомления), add 2 new callback handlers in `start.py`, and update Telegram bot menu via `set_my_commands`. No deletions.
+
+**Tech Stack:** Python 3.12, aiogram 3.x, existing codebase patterns.
+
+---
+
+### Task 1: Update `start_private_keyboard` — add buttons, remove Баланс
+
+**Files:**
+- Modify: `app/bot/keyboards/auction.py:48-91`
+
+- [ ] **Step 1: Edit `start_private_keyboard` function**
+
+Replace the function body with:
+
+```python
+def start_private_keyboard(*, show_moderation_button: bool) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = [
+        [
+            styled_button(
+                text="Создать лот",
+                callback_data="create:new",
+                style="primary",
+                icon_custom_emoji_id=_icon(settings.ui_emoji_create_auction_id),
+            )
+        ],
+        [
+            styled_button(
+                text="Мои лоты",
+                callback_data="dash:my_auctions",
+                style="primary",
+            )
+        ],
+        [
+            styled_button(
+                text="Гарант",
+                callback_data="dash:guarant",
+            ),
+            styled_button(
+                text="Уведомления",
+                callback_data="dash:notifications",
+            ),
+        ],
+        [
+            styled_button(
+                text="Настройки",
+                callback_data="dash:settings",
+            )
+        ],
+    ]
+
+    if show_moderation_button:
+        rows.append(
+            [
+                styled_button(
+                    text="Модерация",
+                    callback_data="mod:panel",
+                    style="success",
+                    icon_custom_emoji_id=_icon(settings.ui_emoji_mod_panel_id),
+                )
+            ]
+        )
+
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+```
+
+Key changes:
+- "Создать аукцион" → "Создать лот"
+- "Мои аукционы" → "Мои лоты"
+- "Баланс" button removed entirely
+- "Гарант" button added (`dash:guarant`)
+- "Уведомления" button added (`dash:notifications`)
+- "Мод-панель" → "Модерация"
+- Гарант + Уведомления on same row (2 buttons per row)
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `docker compose exec bot python -c "from app.bot.keyboards.auction import start_private_keyboard; kb = start_private_keyboard(show_moderation_button=False); print('OK:', len(kb.inline_keyboard), 'rows')"`
+
+Expected: `OK: 4 rows` (5 rows with `show_moderation_button=True`)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/bot/keyboards/auction.py
+git commit -m "feat: reorganize start keyboard — add guarant/notifications, remove balance"
+```
+
+---
+
+### Task 2: Add `dash:guarant` callback handler
+
+**Files:**
+- Modify: `app/bot/handlers/start.py` (add new callback handler after `dash:home` handler around line 988)
+
+This callback reuses the guarantor intake flow. When user taps "Гарант", it starts the same FSM as `/guarant`.
+
+- [ ] **Step 1: Add the callback handler**
+
+Insert after the `callback_dashboard_home` handler (after line 988):
+
+```python
+@router.callback_query(F.data == "dash:guarant")
+async def callback_dashboard_guarant(callback: CallbackQuery, state: FSMContext, bot: Bot) -> None:
+    if callback.from_user is None:
+        return
+    if callback.message is None or not isinstance(callback.message, Message):
+        await callback.answer("Не удалось открыть раздел «Гарант»", show_alert=True)
+        return
+
+    await callback.answer()
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            user = await upsert_user(session, callback.from_user, mark_private_started=True)
+            if not await enforce_callback_topic(
+                callback,
+                bot=bot,
+                session=session,
+                user=user,
+                purpose=PrivateTopicPurpose.SUPPORT,
+                command_hint="/guarant",
+            ):
+                return
+
+    await state.set_state(GuarantorIntakeStates.waiting_request_text)
+    if isinstance(callback.message.message_thread_id, int):
+        await state.update_data(expected_thread_id=callback.message.message_thread_id)
+    await callback.message.answer("Опишите запрос на гаранта одним сообщением. Для отмены используйте /cancel")
+```
+
+- [ ] **Step 2: Add required imports at top of `start.py`**
+
+Add to the existing imports:
+
+```python
+from aiogram.fsm.context import FSMContext
+from app.bot.states.guarantor_intake import GuarantorIntakeStates
+```
+
+Note: `enforce_callback_topic` and `PrivateTopicPurpose` are already imported. `SessionFactory`, `upsert_user` are already imported.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `docker compose exec bot python -c "from app.bot.handlers.start import router; print('OK')"`
+
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/bot/handlers/start.py
+git commit -m "feat: add dash:guarant callback handler for hub navigation"
+```
+
+---
+
+### Task 3: Add `dash:notifications` callback handler
+
+**Files:**
+- Modify: `app/bot/handlers/start.py` (add after the new guarant handler)
+
+This callback shows the notification settings card — same view as `dash:settings` but focused only on notifications.
+
+- [ ] **Step 1: Add the callback handler**
+
+```python
+@router.callback_query(F.data == "dash:notifications")
+async def callback_dashboard_notifications(callback: CallbackQuery) -> None:
+    if callback.from_user is None:
+        return
+    if callback.message is None or not isinstance(callback.message, Message):
+        await callback.answer("Не удалось открыть уведомления", show_alert=True)
+        return
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            user = await upsert_user(session, callback.from_user, mark_private_started=True)
+            snapshot = await load_notification_settings(session, user_id=user.id)
+            snoozes = await list_active_auction_notification_snoozes(session, user_id=user.id)
+
+    if snapshot is None:
+        await callback.answer("Настройки уведомлений недоступны", show_alert=True)
+        return
+
+    text = _render_settings_text(snapshot, snoozes=snoozes)
+    keyboard = _settings_keyboard(snapshot, snoozes=snoozes)
+    await callback.answer()
+    try:
+        await callback.message.edit_text(text, reply_markup=keyboard, disable_web_page_preview=True)
+        return
+    except TelegramBadRequest:
+        pass
+
+    await callback.message.answer(text, reply_markup=keyboard, disable_web_page_preview=True)
+```
+
+Note: All imports (`_render_settings_text`, `_settings_keyboard`, `load_notification_settings`, `list_active_auction_notification_snoozes`, `TelegramBadRequest`) are already present in the file.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `docker compose exec bot python -c "from app.bot.handlers.start import router; print('OK')"`
+
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/bot/handlers/start.py
+git commit -m "feat: add dash:notifications callback handler for hub navigation"
+```
+
+---
+
+### Task 4: Update Telegram bot menu commands via `set_my_commands`
+
+**Files:**
+- Modify: `app/bot/handlers/start.py` or add a startup hook
+
+The bot should register only 5 commands in its Telegram menu. This is best done at startup.
+
+- [ ] **Step 1: Check if there is an existing startup hook or `set_my_commands` call**
+
+Search for `set_my_commands` in the codebase. If found, modify it. If not, add it.
+
+Run: `grep -rn "set_my_commands" app/`
+
+- [ ] **Step 2: Add or update `set_my_commands` in startup**
+
+Find the bot startup location (likely `app/bot/__init__.py` or `app/main.py`). Add this after bot initialization:
+
+```python
+from aiogram.types import BotCommand
+
+await bot.set_my_commands([
+    BotCommand(command="start", description="Главное меню"),
+    BotCommand(command="newauction", description="Создать лот"),
+    BotCommand(command="guarant", description="Запрос гаранта"),
+    BotCommand(command="publish", description="Опубликовать лот (в чате торговли)"),
+    BotCommand(command="cancel", description="Отменить действие"),
+])
+```
+
+For group/supergroup scope, register only `/publish`:
+
+```python
+from aiogram.types import BotCommand, BotCommandScopeAllGroupChats
+
+await bot.set_my_commands(
+    [
+        BotCommand(command="publish", description="Опубликовать лот"),
+    ],
+    scope=BotCommandScopeAllGroupChats(),
+)
+```
+
+- [ ] **Step 3: Verify commands registered**
+
+Run: `docker compose exec bot python -c "import asyncio; from app.config import settings; from aiogram import Bot; from aiogram.types import BotCommand; bot = Bot(token=settings.bot_token); cmds = asyncio.run(bot.get_my_commands()); print([c.command for c in cmds])"`
+
+Expected: `['start', 'newauction', 'guarant', 'publish', 'cancel']`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/
+git commit -m "feat: register only hub commands in Telegram menu via set_my_commands"
+```
+
+---
+
+### Task 5: End-to-end verification
+
+- [ ] **Step 1: Restart bot**
+
+Run: `docker compose restart bot`
+
+- [ ] **Step 2: Check logs for clean startup**
+
+Run: `docker compose logs bot --tail=20`
+
+Expected: No errors, "Start polling" message visible.
+
+- [ ] **Step 3: Verify keyboard structure**
+
+Run: `docker compose exec bot python -c "
+from app.bot.keyboards.auction import start_private_keyboard
+kb = start_private_keyboard(show_moderation_button=False)
+for row in kb.inline_keyboard:
+    for btn in row:
+        print(f'{btn.text} -> {btn.callback_data}')
+print('---')
+kb_mod = start_private_keyboard(show_moderation_button=True)
+for row in kb_mod.inline_keyboard:
+    for btn in row:
+        print(f'{btn.text} -> {btn.callback_data}')
+"`
+
+Expected (without mod):
+```
+Создать лот -> create:new
+Мои лоты -> dash:my_auctions
+Гарант -> dash:guarant | Уведомления -> dash:notifications
+Настройки -> dash:settings
+```
+
+Expected (with mod): same + `Модерация -> mod:panel`
+
+- [ ] **Step 4: Final commit (if any remaining fixes)**
+
+```bash
+git add -A
+git commit -m "chore: finalize command reorganization"
+```

--- a/docs/superpowers/plans/2026-04-11-post-auction-ux.md
+++ b/docs/superpowers/plans/2026-04-11-post-auction-ux.md
@@ -1,0 +1,1848 @@
+# Post-Auction UX Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace minimal post-auction notifications with rich messages containing deal info, next-step instructions, guarantor memo, and action buttons; add a deal topic system for mediated seller-winner communication.
+
+**Architecture:** Extend `FinalizeResult` to carry rich data, replace notification copy functions with rich templates, add `DealTopic` model + service for brokered messaging, new `post_auction` handler for inline button callbacks, FSM flows for feedback and guarantor requests triggered from inline buttons.
+
+**Tech Stack:** Python 3.12, aiogram 3.x, SQLAlchemy 2.x (async), Alembic, PostgreSQL
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `app/db/enums.py` | Modify | Add `DealTopicStatus` enum |
+| `app/db/models.py` | Modify | Add `DealTopic` model, add `auction_id` to `GuarantorRequest` |
+| `app/db/base.py` | No change | Already imports all models |
+| `alembic/versions/xxx_add_deal_topics_and_guarantor_auction.py` | Create | Migration for new table + column |
+| `app/services/notification_copy_service.py` | Modify | Add rich completion message functions |
+| `app/bot/keyboards/auction.py` | Modify | Add new keyboard builders |
+| `app/services/deal_topic_service.py` | Create | DealTopic CRUD, message forwarding |
+| `app/bot/handlers/post_auction.py` | Create | Callback handlers for all deal buttons |
+| `app/bot/states/post_auction.py` | Create | FSM states for feedback + guarantor from inline |
+| `app/services/auction_service.py` | Modify | Extend `FinalizeResult`, update notification calls |
+| `app/bot/handlers/bid_actions.py` | Modify | Use rich notifications in `_notify_auction_finish` |
+| `app/bot/handlers/__init__.py` | Modify | Register `post_auction_router` |
+| `app/bot/handlers/moderation.py` | Modify | Use `_finalize_auction_locked` in `mod_end` |
+| `app/bot/handlers/guarantor.py` | Modify | Accept pre-filled `auction_id` |
+| `app/bot/handlers/trade_feedback.py` | Modify | Support inline-triggered FSM |
+| `tests/test_notification_copy_rich.py` | Create | Unit tests for rich copy |
+| `tests/test_deal_topic_service.py` | Create | Unit tests for deal topic service |
+| `tests/test_post_auction_keyboards.py` | Create | Unit tests for keyboards |
+| `tests/test_post_auction_callbacks.py` | Create | Unit tests for callback handlers |
+| `tests/integration/test_deal_topic_flow.py` | Create | Integration test for full deal topic flow |
+
+---
+
+### Task 1: Add `DealTopicStatus` enum
+
+**Files:**
+- Modify: `app/db/enums.py`
+
+- [ ] **Step 1: Add the enum**
+
+In `app/db/enums.py`, add after the existing `GuarantorRequestStatus` enum (around line 81):
+
+```python
+class DealTopicStatus(StrEnum):
+    ACTIVE = "ACTIVE"
+    CLOSED = "CLOSED"
+```
+
+- [ ] **Step 2: Verify lint passes**
+
+Run: `python -m ruff check app/db/enums.py`
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/db/enums.py
+git commit -m "feat: add DealTopicStatus enum for post-auction deal topics"
+```
+
+---
+
+### Task 2: Add `DealTopic` model and extend `GuarantorRequest`
+
+**Files:**
+- Modify: `app/db/models.py`
+
+- [ ] **Step 1: Add `DealTopic` model**
+
+In `app/db/models.py`, add after the `GuarantorRequest` class (after line ~823). Import `DealTopicStatus` at the top of the file alongside other enum imports:
+
+```python
+from app.db.enums import (
+    AuctionStatus,
+    BidStatus,
+    ComplaintStatus,
+    DealTopicStatus,
+    GuarantorRequestStatus,
+    ModerationEventType,
+    ModerationQueueStatus,
+    ReputationEventReason,
+    VerificationStatus,
+)
+```
+
+Add the model:
+
+```python
+class DealTopic(Base, TimestampMixin):
+    __tablename__ = "deal_topics"
+    __table_args__ = (
+        Index("ix_deal_topics_auction_id", "auction_id"),
+        Index("ix_deal_topics_status", "status"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    auction_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("auctions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    seller_topic_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    winner_topic_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    status: Mapped[DealTopicStatus] = mapped_column(
+        Enum(DealTopicStatus, name="deal_topic_status"),
+        nullable=False,
+        default=DealTopicStatus.ACTIVE,
+        server_default=text("'ACTIVE'"),
+    )
+    closed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+```
+
+- [ ] **Step 2: Add `auction_id` nullable column to `GuarantorRequest`**
+
+In the `GuarantorRequest` class, add after the `details` field (around line 806):
+
+```python
+    auction_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("auctions.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+```
+
+- [ ] **Step 3: Verify lint passes**
+
+Run: `python -m ruff check app/db/models.py`
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/db/models.py
+git commit -m "feat: add DealTopic model, add auction_id to GuarantorRequest"
+```
+
+---
+
+### Task 3: Generate Alembic migration
+
+**Files:**
+- Create: `alembic/versions/xxx_add_deal_topics_and_guarantor_auction.py`
+
+- [ ] **Step 1: Generate migration**
+
+Run: `alembic revision --autogenerate -m "add_deal_topics_and_guarantor_auction_id"`
+
+- [ ] **Step 2: Review the generated migration**
+
+Open the generated file and verify it contains:
+- `CREATE TABLE deal_topics` with columns: `id`, `auction_id`, `seller_topic_id`, `winner_topic_id`, `status`, `closed_at`, `created_at`, `updated_at`
+- `ADD COLUMN auction_id` to `guarantor_requests` (nullable)
+- Indexes on `deal_topics.auction_id` and `deal_topics.status`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add alembic/versions/
+git commit -m "feat: alembic migration for deal_topics table and guarantor auction_id"
+```
+
+---
+
+### Task 4: Extend `FinalizeResult` with rich data
+
+**Files:**
+- Modify: `app/services/auction_service.py`
+
+- [ ] **Step 1: Extend the dataclass**
+
+Replace the `FinalizeResult` dataclass (lines 79-84) with:
+
+```python
+@dataclass(slots=True)
+class FinalizeResult:
+    auction_id: uuid.UUID
+    winner_tg_user_id: int | None
+    seller_tg_user_id: int
+    final_price: int | None = None
+    description: str | None = None
+    winner_username: str | None = None
+    winner_first_name: str | None = None
+    seller_username: str | None = None
+    seller_first_name: str | None = None
+    had_bids: bool = True
+```
+
+- [ ] **Step 2: Update `_finalize_auction_locked` to populate rich data**
+
+Modify the return statement at the end of `_finalize_auction_locked` (around line 525). After computing `winner_tg_user_id`, also extract `winner_username`, `winner_first_name`. The `seller` object is already fetched. Change the return to:
+
+```python
+    winner_username: str | None = None
+    winner_first_name: str | None = None
+    if winner_user_id is not None:
+        winner = await session.scalar(select(User).where(User.id == winner_user_id))
+        winner_tg_user_id = winner.tg_user_id if winner is not None else None
+        if winner is not None:
+            winner_username = winner.username
+            winner_first_name = winner.first_name
+
+    if seller is None:
+        return None
+
+    await adjust_reputation(session, auction.seller_user_id, 3, ReputationEventReason.AUCTION_COMPLETED)
+    if winner_user_id is not None:
+        await adjust_reputation(session, winner_user_id, 2, ReputationEventReason.BID_WON)
+
+    top_bids = await _top_bids_for_auction(session, auction.id, limit=1)
+    had_bids = len(top_bids) > 0
+
+    return FinalizeResult(
+        auction_id=auction.id,
+        winner_tg_user_id=winner_tg_user_id,
+        seller_tg_user_id=seller.tg_user_id,
+        final_price=auction.start_price if had_bids and top_bids else None,
+        description=auction.description,
+        winner_username=winner_username,
+        winner_first_name=winner_first_name,
+        seller_username=seller.username,
+        seller_first_name=seller.first_name,
+        had_bids=had_bids,
+    )
+```
+
+Note: `final_price` should use `top_bids[0].amount` if available. Update:
+
+```python
+    final_price = top_bids[0].amount if top_bids else auction.start_price
+```
+
+And in the FinalizeResult construction:
+```python
+        final_price=final_price if had_bids else None,
+```
+
+- [ ] **Step 3: Verify lint passes**
+
+Run: `python -m ruff check app/services/auction_service.py`
+Expected: no errors
+
+- [ ] **Step 4: Run existing tests**
+
+Run: `python -m pytest tests/test_auction_service_resilience.py tests/test_auction_caption_render.py -q`
+Expected: all pass (FinalizeResult consumers access fields that still exist)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/auction_service.py
+git commit -m "feat: extend FinalizeResult with rich auction data for post-auction notifications"
+```
+
+---
+
+### Task 5: Add rich notification copy functions
+
+**Files:**
+- Modify: `app/services/notification_copy_service.py`
+- Create: `tests/test_notification_copy_rich.py`
+
+- [ ] **Step 1: Write tests for rich copy functions**
+
+Create `tests/test_notification_copy_rich.py`:
+
+```python
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.services.notification_copy_service import (
+    seller_completion_text,
+    winner_completion_text,
+    seller_no_bids_text,
+    deal_topic_intro_text,
+    moderation_completion_text,
+)
+
+
+@pytest.fixture
+def auction_id() -> uuid.UUID:
+    return uuid.UUID("a1b2c3d4-5678-9012-abcd-ef1234567890")
+
+
+def test_seller_completion_text_basic(auction_id: uuid.UUID) -> None:
+    text = seller_completion_text(
+        auction_id=auction_id,
+        description="iPhone 15 Pro Max",
+        final_price=15000,
+        counterparty_mention="@winner",
+        counterparty_role="победитель",
+    )
+    assert "#a1b2c3d4" in text
+    assert "15 000" in text
+    assert "@winner" in text
+    assert "аукцион" in text.lower() or "завершён" in text.lower() or "завершен" in text.lower()
+
+
+def test_winner_completion_text_basic(auction_id: uuid.UUID) -> None:
+    text = winner_completion_text(
+        auction_id=auction_id,
+        description="iPhone 15 Pro Max",
+        final_price=15000,
+        counterparty_mention="@seller",
+        counterparty_role="продавец",
+    )
+    assert "#a1b2c3d4" in text
+    assert "15 000" in text
+    assert "@seller" in text
+    assert "выиграл" in text.lower() or "выиграли" in text.lower()
+
+
+def test_seller_no_bids_text_basic(auction_id: uuid.UUID) -> None:
+    text = seller_no_bids_text(
+        auction_id=auction_id,
+        description="iPhone 15 Pro Max",
+        start_price=10000,
+    )
+    assert "#a1b2c3d4" in text
+    assert "10 000" in text
+    assert "0" in text
+
+
+def test_deal_topic_intro_text_basic(auction_id: uuid.UUID) -> None:
+    text = deal_topic_intro_text(
+        auction_id=auction_id,
+        description="iPhone 15 Pro Max",
+        final_price=15000,
+        seller_mention="@seller",
+        winner_mention="@winner",
+    )
+    assert "#a1b2c3d4" in text
+    assert "@seller" in text
+    assert "@winner" in text
+
+
+def test_moderation_completion_text_basic(auction_id: uuid.UUID) -> None:
+    text = moderation_completion_text(
+        auction_id=auction_id,
+        description="iPhone 15 Pro Max",
+        final_price=15000,
+        bid_count=7,
+        seller_mention="@seller (tg: 123)",
+        winner_mention="@winner (tg: 456)",
+        seller_reputation=42,
+        winner_reputation=15,
+        has_deal_topic=True,
+        has_guarantor=False,
+        reason="по таймеру",
+    )
+    assert "#a1b2c3d4" in text
+    assert "15 000" in text
+    assert "7" in text
+    assert "создан" in text.lower()
+    assert "не запрошен" in text.lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_notification_copy_rich.py -q`
+Expected: FAIL — functions not defined
+
+- [ ] **Step 3: Implement rich copy functions**
+
+Add these functions to `app/services/notification_copy_service.py`:
+
+```python
+def _truncate(text: str, max_len: int = 80) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "…"
+
+
+def _format_price(amount: int) -> str:
+    return f"{amount:,} ₽".replace(",", " ")
+
+
+def seller_completion_text(
+    *,
+    auction_id: uuid.UUID,
+    description: str,
+    final_price: int,
+    counterparty_mention: str,
+    counterparty_role: str,
+    is_buyout: bool = False,
+    is_mod_action: bool = False,
+) -> str:
+    prefix = "Модерация: " if is_mod_action else ""
+    buyout_label = " выкупом" if is_buyout else ""
+    return (
+        f"🏆 {prefix}Аукцион завершён{buyout_label}!\n\n"
+        f"<b>Лот:</b> {short_auction_ref(auction_id)}\n"
+        f"<b>Описание:</b> {html.escape(_truncate(description))}\n"
+        f"<b>Финальная цена:</b> {_format_price(final_price)}\n"
+        f"<b>Победитель:</b> {counterparty_mention}\n\n"
+        f"📋 <b>Следующие шаги:</b>\n"
+        f"1. Нажмите «Написать победителю» — откроется топик сделки\n"
+        f"2. Договоритесь о способе передачи товара и оплаты\n"
+        f"3. После завершения — оставьте отзыв\n\n"
+        f"🛡 <b>Гарант — ваша безопасность</b>\n"
+        f"Если сумма сделки значительная или вы впервые работаете с {counterparty_role}ом — "
+        f"запросите гаранта. Гарант выступит посредником и обеспечит защиту обеих сторон.\n"
+        f"<i>Стоимость: бесплатно для участников с репутацией 50+</i>"
+    )
+
+
+def winner_completion_text(
+    *,
+    auction_id: uuid.UUID,
+    description: str,
+    final_price: int,
+    counterparty_mention: str,
+    counterparty_role: str,
+    is_buyout: bool = False,
+    is_mod_action: bool = False,
+) -> str:
+    prefix = "Модерация: " if is_mod_action else ""
+    buyout_label = " (выкуп)" if is_buyout else ""
+    return (
+        f"🎉 {prefix}Вы выиграли аукцион{buyout_label}!\n\n"
+        f"<b>Лот:</b> {short_auction_ref(auction_id)}\n"
+        f"<b>Описание:</b> {html.escape(_truncate(description))}\n"
+        f"<b>Ваша цена:</b> {_format_price(final_price)}\n"
+        f"<b>Продавец:</b> {counterparty_mention}\n\n"
+        f"📋 <b>Что дальше:</b>\n"
+        f"1. Нажмите «Написать продавцу» — откроется топик сделки\n"
+        f"2. Договоритесь о способе получения товара и оплаты\n"
+        f"3. После завершения — оставьте отзыв\n\n"
+        f"🛡 <b>Гарант — ваша безопасность</b>\n"
+        f"Если сумма сделки значительная или вы впервые работаете с {counterparty_role}ом — "
+        f"запросите гаранта. Гарант выступит посредником и обеспечит защиту обеих сторон.\n"
+        f"<i>Стоимость: бесплатно для участников с репутацией 50+</i>"
+    )
+
+
+def seller_no_bids_text(
+    *,
+    auction_id: uuid.UUID,
+    description: str,
+    start_price: int,
+) -> str:
+    return (
+        f"⏰ Аукцион завершён без ставок\n\n"
+        f"<b>Лот:</b> {short_auction_ref(auction_id)}\n"
+        f"<b>Описание:</b> {html.escape(_truncate(description))}\n"
+        f"<b>Стартовая цена:</b> {_format_price(start_price)}\n"
+        f"<b>Ставок:</b> 0\n\n"
+        f"💡 <b>Совет:</b> Попробуйте изменить стартовую цену или описание "
+        f"и опубликуйте лот заново."
+    )
+
+
+def deal_topic_intro_text(
+    *,
+    auction_id: uuid.UUID,
+    description: str,
+    final_price: int,
+    seller_mention: str,
+    winner_mention: str,
+) -> str:
+    return (
+        f"🤝 <b>Топик сделки создан</b>\n\n"
+        f"Лот: {short_auction_ref(auction_id)} — {html.escape(_truncate(description))}\n"
+        f"Цена: {_format_price(final_price)}\n"
+        f"Участники: {seller_mention} (продавец) и {winner_mention} (победитель)\n\n"
+        f"Все сообщения здесь будут пересылаться вашему контрагенту.\n"
+        f"Будьте вежливы и обсуждайте только сделку.\n\n"
+        f"🛡 <b>Совет по безопасности</b>\n"
+        f"Для защиты обеих сторон вы можете запросить гаранта — нажав кнопку ниже."
+    )
+
+
+def moderation_completion_text(
+    *,
+    auction_id: uuid.UUID,
+    description: str,
+    final_price: int,
+    bid_count: int,
+    seller_mention: str,
+    winner_mention: str,
+    seller_reputation: int,
+    winner_reputation: int,
+    has_deal_topic: bool,
+    has_guarantor: bool,
+    reason: str,
+) -> str:
+    deal_label = "создан автоматически" if has_deal_topic else "не создан"
+    guarantor_label = "запрошен" if has_guarantor else "не запрошен"
+    return (
+        f"🏁 Лот {short_auction_ref(auction_id)} завершён {reason}\n\n"
+        f"<b>Описание:</b> {html.escape(_truncate(description))}\n"
+        f"<b>Финальная цена:</b> {_format_price(final_price)}\n"
+        f"<b>Ставок:</b> {bid_count}\n\n"
+        f"<b>Продавец:</b> {seller_mention}\n"
+        f"<b>Победитель:</b> {winner_mention}\n"
+        f"<b>Репутация продавца:</b> {seller_reputation}\n"
+        f"<b>Репутация победителя:</b> {winner_reputation}\n\n"
+        f"🤝 <b>Топик сделки:</b> {deal_label}\n"
+        f"🛡 <b>Гарант:</b> {guarantor_label}"
+    )
+```
+
+Also add `import html` at the top of the file.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_notification_copy_rich.py -q`
+Expected: all pass
+
+- [ ] **Step 5: Run lint**
+
+Run: `python -m ruff check app/services/notification_copy_service.py`
+Expected: no errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/notification_copy_service.py tests/test_notification_copy_rich.py
+git commit -m "feat: add rich post-auction notification copy functions with tests"
+```
+
+---
+
+### Task 6: Add new keyboard builders
+
+**Files:**
+- Modify: `app/bot/keyboards/auction.py`
+- Create: `tests/test_post_auction_keyboards.py`
+
+- [ ] **Step 1: Write keyboard tests**
+
+Create `tests/test_post_auction_keyboards.py`:
+
+```python
+from __future__ import annotations
+
+import uuid
+
+from app.bot.keyboards.auction import (
+    deal_completion_keyboard,
+    no_bids_keyboard,
+    deal_topic_keyboard,
+    moderation_completion_keyboard,
+)
+
+
+def test_deal_completion_keyboard_seller() -> None:
+    kb = deal_completion_keyboard(
+        auction_id="a1b2c3d4",
+        post_url="https://t.me/channel/123",
+        is_seller=True,
+    )
+    buttons = kb.inline_keyboard
+    assert len(buttons) == 3
+    assert "deal:write:a1b2c3d4" in buttons[0][0].callback_data
+    assert "guarantor" not in buttons[0][0].text.lower() or True
+    assert any("открыть" in b[0].text.lower() for b in buttons)
+
+
+def test_deal_completion_keyboard_winner() -> None:
+    kb = deal_completion_keyboard(
+        auction_id="a1b2c3d4",
+        post_url="https://t.me/channel/123",
+        is_seller=False,
+    )
+    buttons = kb.inline_keyboard
+    assert len(buttons) == 3
+
+
+def test_deal_completion_keyboard_no_post_url() -> None:
+    kb = deal_completion_keyboard(
+        auction_id="a1b2c3d4",
+        post_url=None,
+        is_seller=True,
+    )
+    buttons = kb.inline_keyboard
+    assert len(buttons) == 2
+
+
+def test_no_bids_keyboard() -> None:
+    kb = no_bids_keyboard(
+        auction_id="a1b2c3d4",
+        post_url="https://t.me/channel/123",
+    )
+    buttons = kb.inline_keyboard
+    assert len(buttons) == 2
+    assert "deal:republish:a1b2c3d4" in buttons[0][0].callback_data
+
+
+def test_deal_topic_keyboard() -> None:
+    kb = deal_topic_keyboard(auction_id="a1b2c3d4")
+    buttons = kb.inline_keyboard
+    assert len(buttons) == 2
+    assert any("deal:guarant:" in b[0].callback_data for b in buttons)
+    assert any("deal:feedback:" in b[0].callback_data for b in buttons)
+
+
+def test_moderation_completion_keyboard() -> None:
+    kb = moderation_completion_keyboard(
+        auction_id="a1b2c3d4",
+        post_url="https://t.me/channel/123",
+    )
+    buttons = kb.inline_keyboard
+    assert len(buttons) == 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_post_auction_keyboards.py -q`
+Expected: FAIL — functions not defined
+
+- [ ] **Step 3: Implement keyboard builders**
+
+Add to `app/bot/keyboards/auction.py`:
+
+```python
+def deal_completion_keyboard(
+    *,
+    auction_id: str,
+    post_url: str | None,
+    is_seller: bool,
+) -> InlineKeyboardMarkup:
+    write_label = "💬 Написать победителю" if is_seller else "💬 Написать продавцу"
+    rows: list[list[InlineKeyboardButton]] = [
+        [styled_button(text=write_label, callback_data=f"deal:write:{auction_id}", style="primary")],
+        [
+            styled_button(text="🛡 Запросить гаранта", callback_data=f"deal:guarant:{auction_id}", style="success"),
+            styled_button(text="⭐ Оставить отзыв", callback_data=f"deal:feedback:{auction_id}"),
+        ],
+    ]
+    if post_url:
+        rows.append([styled_button(text="📄 Открыть пост лота", url=post_url)])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def no_bids_keyboard(
+    *,
+    auction_id: str,
+    post_url: str | None,
+) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = [
+        [styled_button(text="🔄 Опубликовать заново", callback_data=f"deal:republish:{auction_id}", style="primary")],
+    ]
+    if post_url:
+        rows.append([styled_button(text="📄 Открыть пост лота", url=post_url)])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def deal_topic_keyboard(
+    *,
+    auction_id: str,
+) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                styled_button(text="🛡 Запросить гаранта", callback_data=f"deal:guarant:{auction_id}", style="success"),
+                styled_button(text="⭐ Оставить отзыв", callback_data=f"deal:feedback:{auction_id}"),
+            ],
+            [
+                styled_button(text="⚠ Жалоба", callback_data=f"deal:complaint:{auction_id}"),
+            ],
+        ]
+    )
+
+
+def moderation_completion_keyboard(
+    *,
+    auction_id: str,
+    post_url: str | None,
+) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    if post_url:
+        rows.append([styled_button(text="📄 Открыть пост лота", url=post_url)])
+    rows.append([styled_button(text="⚠ Заморозить", callback_data=f"mod:freeze:{auction_id}", style="danger")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_post_auction_keyboards.py -q`
+Expected: all pass
+
+- [ ] **Step 5: Run lint**
+
+Run: `python -m ruff check app/bot/keyboards/auction.py`
+Expected: no errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/bot/keyboards/auction.py tests/test_post_auction_keyboards.py
+git commit -m "feat: add post-auction keyboard builders with tests"
+```
+
+---
+
+### Task 7: Create `DealTopicService`
+
+**Files:**
+- Create: `app/services/deal_topic_service.py`
+- Create: `tests/test_deal_topic_service.py`
+
+- [ ] **Step 1: Write tests**
+
+Create `tests/test_deal_topic_service.py`:
+
+```python
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.deal_topic_service import (
+    get_or_create_deal_topic,
+    find_active_deal_topic,
+    forward_deal_message,
+)
+
+
+@pytest.fixture
+def auction_id() -> uuid.UUID:
+    return uuid.UUID("a1b2c3d4-5678-9012-abcd-ef1234567890")
+
+
+@pytest.mark.asyncio
+async def test_find_active_deal_topic_returns_none_when_not_exists(auction_id: uuid.UUID) -> None:
+    mock_session = AsyncMock()
+    mock_session.scalar.return_value = None
+    result = await find_active_deal_topic(mock_session, auction_id=auction_id)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_returns_existing(auction_id: uuid.UUID) -> None:
+    mock_session = AsyncMock()
+    existing = MagicMock()
+    existing.status.value = "ACTIVE"
+    existing.seller_topic_id = 100
+    mock_session.scalar.return_value = existing
+
+    mock_bot = AsyncMock()
+
+    result = await get_or_create_deal_topic(
+        mock_session,
+        bot=mock_bot,
+        auction_id=auction_id,
+        seller_tg_id=111,
+        winner_tg_id=222,
+        description="Test",
+        final_price=1000,
+        seller_mention="@s",
+        winner_mention="@w",
+    )
+    assert result is existing
+    mock_session.add.assert_not_called()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_deal_topic_service.py -q`
+Expected: FAIL
+
+- [ ] **Step 3: Implement `DealTopicService`**
+
+Create `app/services/deal_topic_service.py`:
+
+```python
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, UTC
+
+from aiogram import Bot
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.enums import DealTopicStatus
+from app.db.models import DealTopic
+from app.services.notification_copy_service import deal_topic_intro_text
+from app.bot.keyboards.auction import deal_topic_keyboard
+
+
+async def find_active_deal_topic(
+    session: AsyncSession,
+    *,
+    auction_id: uuid.UUID,
+) -> DealTopic | None:
+    return await session.scalar(
+        select(DealTopic).where(
+            DealTopic.auction_id == auction_id,
+            DealTopic.status == DealTopicStatus.ACTIVE,
+        )
+    )
+
+
+async def get_or_create_deal_topic(
+    session: AsyncSession,
+    *,
+    bot: Bot,
+    auction_id: uuid.UUID,
+    seller_tg_id: int,
+    winner_tg_id: int,
+    description: str,
+    final_price: int,
+    seller_mention: str,
+    winner_mention: str,
+) -> DealTopic:
+    existing = await find_active_deal_topic(session, auction_id=auction_id)
+    if existing is not None:
+        return existing
+
+    short_id = str(auction_id)[:8]
+
+    seller_topic = await bot.create_forum_topic(
+        chat_id=seller_tg_id,
+        name=f"🤝 Сделка #{short_id}",
+    )
+
+    intro = deal_topic_intro_text(
+        auction_id=auction_id,
+        description=description,
+        final_price=final_price,
+        seller_mention=seller_mention,
+        winner_mention=winner_mention,
+    )
+    kb = deal_topic_keyboard(auction_id=short_id)
+
+    await bot.send_message(
+        chat_id=seller_tg_id,
+        message_thread_id=seller_topic.message_thread_id,
+        text=intro,
+        reply_markup=kb,
+        parse_mode="HTML",
+    )
+
+    deal = DealTopic(
+        auction_id=auction_id,
+        seller_topic_id=seller_topic.message_thread_id,
+        status=DealTopicStatus.ACTIVE,
+    )
+    session.add(deal)
+    await session.flush()
+
+    return deal
+
+
+async def ensure_winner_topic(
+    session: AsyncSession,
+    *,
+    bot: Bot,
+    deal: DealTopic,
+    winner_tg_id: int,
+    auction_id: uuid.UUID,
+    description: str,
+    final_price: int,
+    seller_mention: str,
+    winner_mention: str,
+) -> None:
+    if deal.winner_topic_id is not None:
+        return
+
+    short_id = str(auction_id)[:8]
+
+    winner_topic = await bot.create_forum_topic(
+        chat_id=winner_tg_id,
+        name=f"🤝 Сделка #{short_id}",
+    )
+
+    intro = deal_topic_intro_text(
+        auction_id=auction_id,
+        description=description,
+        final_price=final_price,
+        seller_mention=seller_mention,
+        winner_mention=winner_mention,
+    )
+    kb = deal_topic_keyboard(auction_id=short_id)
+
+    await bot.send_message(
+        chat_id=winner_tg_id,
+        message_thread_id=winner_topic.message_thread_id,
+        text=intro,
+        reply_markup=kb,
+        parse_mode="HTML",
+    )
+
+    deal.winner_topic_id = winner_topic.message_thread_id
+    await session.flush()
+
+
+async def forward_deal_message(
+    bot: Bot,
+    *,
+    deal: DealTopic,
+    sender_tg_id: int,
+    sender_label: str,
+    recipient_tg_id: int,
+    recipient_topic_id: int,
+    text: str | None = None,
+    photo_file_id: str | None = None,
+) -> None:
+    prefix = f"<b>{sender_label}:</b>\n"
+    if photo_file_id:
+        caption = f"{prefix}{text}" if text else prefix.rstrip(":")
+        await bot.send_photo(
+            chat_id=recipient_tg_id,
+            message_thread_id=recipient_topic_id,
+            photo=photo_file_id,
+            caption=caption,
+            parse_mode="HTML",
+        )
+    elif text:
+        await bot.send_message(
+            chat_id=recipient_tg_id,
+            message_thread_id=recipient_topic_id,
+            text=f"{prefix}{text}",
+            parse_mode="HTML",
+        )
+
+
+async def close_deal_topic(
+    session: AsyncSession,
+    *,
+    deal: DealTopic,
+) -> None:
+    deal.status = DealTopicStatus.CLOSED
+    deal.closed_at = datetime.now(UTC)
+    await session.flush()
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest tests/test_deal_topic_service.py -q`
+Expected: all pass
+
+- [ ] **Step 5: Run lint**
+
+Run: `python -m ruff check app/services/deal_topic_service.py`
+Expected: no errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/deal_topic_service.py tests/test_deal_topic_service.py
+git commit -m "feat: add DealTopicService for deal topic CRUD and message forwarding"
+```
+
+---
+
+### Task 8: Create post-auction FSM states
+
+**Files:**
+- Create: `app/bot/states/post_auction.py`
+
+- [ ] **Step 1: Create FSM states**
+
+Create `app/bot/states/post_auction.py`:
+
+```python
+from __future__ import annotations
+
+from aiogram.fsm.state import State, StatesGroup
+
+
+class FeedbackFSM(StatesGroup):
+    waiting_rating = State()
+    waiting_comment = State()
+
+
+class DealGuarantorFSM(StatesGroup):
+    waiting_details = State()
+```
+
+- [ ] **Step 2: Run lint**
+
+Run: `python -m ruff check app/bot/states/post_auction.py`
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/bot/states/post_auction.py
+git commit -m "feat: add FSM states for post-auction feedback and guarantor flows"
+```
+
+---
+
+### Task 9: Create `post_auction` handler
+
+**Files:**
+- Create: `app/bot/handlers/post_auction.py`
+- Create: `tests/test_post_auction_callbacks.py`
+
+- [ ] **Step 1: Write basic callback tests**
+
+Create `tests/test_post_auction_callbacks.py`:
+
+```python
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.bot.handlers.post_auction import parse_deal_callback
+
+
+def test_parse_deal_callback_write() -> None:
+    action, auction_id = parse_deal_callback("deal:write:a1b2c3d4-5678-9012-abcd-ef1234567890")
+    assert action == "write"
+    assert auction_id == uuid.UUID("a1b2c3d4-5678-9012-abcd-ef1234567890")
+
+
+def test_parse_deal_callback_guarant() -> None:
+    action, auction_id = parse_deal_callback("deal:guarant:a1b2c3d4-5678-9012-abcd-ef1234567890")
+    assert action == "guarant"
+    assert auction_id == uuid.UUID("a1b2c3d4-5678-9012-abcd-ef1234567890")
+
+
+def test_parse_deal_callback_feedback() -> None:
+    action, auction_id = parse_deal_callback("deal:feedback:a1b2c3d4-5678-9012-abcd-ef1234567890")
+    assert action == "feedback"
+
+
+def test_parse_deal_callback_republish() -> None:
+    action, auction_id = parse_deal_callback("deal:republish:a1b2c3d4-5678-9012-abcd-ef1234567890")
+    assert action == "republish"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_post_auction_callbacks.py -q`
+Expected: FAIL
+
+- [ ] **Step 3: Implement the handler**
+
+Create `app/bot/handlers/post_auction.py`:
+
+```python
+from __future__ import annotations
+
+import uuid
+
+from aiogram import Bot, Router, F
+from aiogram.types import CallbackQuery, Message
+from aiogram.fsm.context import FSMContext
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import Auction, DealTopic, User, GuarantorRequest
+from app.db.enums import AuctionStatus, DealTopicStatus
+from app.bot.keyboards.auction import deal_topic_keyboard
+from app.bot.states.post_auction import FeedbackFSM, DealGuarantorFSM
+from app.db.session import SessionFactory
+from app.services.deal_topic_service import (
+    get_or_create_deal_topic,
+    ensure_winner_topic,
+    forward_deal_message,
+    find_active_deal_topic,
+)
+from app.services.notification_copy_service import _format_user_mention, short_auction_ref
+from app.services.trade_feedback_service import submit_trade_feedback
+from app.services.guarantor_service import create_guarantor_request
+
+router = Router(name="post_auction")
+
+
+def parse_deal_callback(data: str) -> tuple[str, uuid.UUID]:
+    parts = data.split(":")
+    return parts[1], uuid.UUID(parts[2])
+
+
+def _format_mention(user: User | None) -> str:
+    if user is None:
+        return "—"
+    if user.username:
+        return f"@{user.username}"
+    display = user.first_name or "Пользователь"
+    return f'<a href="tg://user?id={user.tg_user_id}">{display}</a>'
+
+
+@router.callback_query(F.data.startswith("deal:write:"))
+async def handle_deal_write(callback: CallbackQuery, bot: Bot, state: FSMContext) -> None:
+    await state.clear()
+    action, auction_id = parse_deal_callback(callback.data)
+    assert action == "write"
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            auction = await session.scalar(
+                select(Auction).where(Auction.id == auction_id)
+            )
+            if auction is None:
+                await callback.answer("Аукцион не найден", show_alert=True)
+                return
+
+            seller = await session.scalar(select(User).where(User.id == auction.seller_user_id))
+            winner = await session.scalar(select(User).where(User.id == auction.winner_user_id)) if auction.winner_user_id else None
+
+            if winner is None:
+                await callback.answer("Нет победителя для связи", show_alert=True)
+                return
+
+            caller_tg_id = callback.from_user.id
+            is_seller = caller_tg_id == seller.tg_user_id if seller else False
+
+            deal = await get_or_create_deal_topic(
+                session,
+                bot=bot,
+                auction_id=auction_id,
+                seller_tg_id=seller.tg_user_id,
+                winner_tg_id=winner.tg_user_id,
+                description=auction.description,
+                final_price=auction.start_price,
+                seller_mention=_format_mention(seller),
+                winner_mention=_format_mention(winner),
+            )
+
+            if is_seller:
+                await ensure_winner_topic(
+                    session,
+                    bot=bot,
+                    deal=deal,
+                    winner_tg_id=winner.tg_user_id,
+                    auction_id=auction_id,
+                    description=auction.description,
+                    final_price=auction.start_price,
+                    seller_mention=_format_mention(seller),
+                    winner_mention=_format_mention(winner),
+                )
+
+    await callback.answer("Топик сделки открыт")
+
+
+@router.callback_query(F.data.startswith("deal:feedback:"))
+async def handle_deal_feedback(callback: CallbackQuery, state: FSMContext) -> None:
+    await state.clear()
+    _, auction_id = parse_deal_callback(callback.data)
+
+    await state.update_data(feedback_auction_id=str(auction_id))
+    await state.set_state(FeedbackFSM.waiting_rating)
+
+    rating_kb = _rating_keyboard()
+    await callback.message.answer("⭐ Оцените сделку:", reply_markup=rating_kb)
+    await callback.answer()
+
+
+def _rating_keyboard():
+    from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(text="⭐", callback_data="rate:1"),
+                InlineKeyboardButton(text="⭐⭐", callback_data="rate:2"),
+                InlineKeyboardButton(text="⭐⭐⭐", callback_data="rate:3"),
+            ],
+            [
+                InlineKeyboardButton(text="⭐⭐⭐⭐", callback_data="rate:4"),
+                InlineKeyboardButton(text="⭐⭐⭐⭐⭐", callback_data="rate:5"),
+            ],
+        ]
+    )
+
+
+@router.callback_query(F.data.startswith("rate:"))
+async def handle_rating(callback: CallbackQuery, state: FSMContext) -> None:
+    rating = int(callback.data.split(":")[1])
+    await state.update_data(feedback_rating=rating)
+    await state.set_state(FeedbackFSM.waiting_comment)
+
+    from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+    await callback.message.answer(
+        "Комментарий (необязательно):",
+        reply_markup=InlineKeyboardMarkup(
+            inline_keyboard=[[InlineKeyboardButton(text="Пропустить", callback_data="rate:skip")]]
+        ),
+    )
+    await callback.answer()
+
+
+@router.callback_query(F.data == "rate:skip", FeedbackFSM.waiting_comment)
+async def handle_rating_skip(callback: CallbackQuery, state: FSMContext) -> None:
+    data = await state.get_data()
+    auction_id = uuid.UUID(data["feedback_auction_id"])
+    rating = data["feedback_rating"]
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            user = await session.scalar(
+                select(User).where(User.tg_user_id == callback.from_user.id)
+            )
+            if user is None:
+                await callback.answer("Пользователь не найден", show_alert=True)
+                return
+            result = await submit_trade_feedback(
+                session,
+                auction_id=auction_id,
+                author_user_id=user.id,
+                rating=rating,
+                comment=None,
+            )
+
+    await state.clear()
+    await callback.message.answer(result.message)
+    await callback.answer()
+
+
+@router.message(FeedbackFSM.waiting_comment, F.text)
+async def handle_feedback_comment(message: Message, state: FSMContext) -> None:
+    data = await state.get_data()
+    auction_id = uuid.UUID(data["feedback_auction_id"])
+    rating = data["feedback_rating"]
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            user = await session.scalar(
+                select(User).where(User.tg_user_id == message.from_user.id)
+            )
+            if user is None:
+                await message.answer("Пользователь не найден")
+                return
+            result = await submit_trade_feedback(
+                session,
+                auction_id=auction_id,
+                author_user_id=user.id,
+                rating=rating,
+                comment=message.text,
+            )
+
+    await state.clear()
+    await message.answer(result.message)
+
+
+@router.callback_query(F.data.startswith("deal:guarant:"))
+async def handle_deal_guarant(callback: CallbackQuery, state: FSMContext) -> None:
+    await state.clear()
+    _, auction_id = parse_deal_callback(callback.data)
+
+    await state.update_data(guarant_auction_id=str(auction_id))
+    await state.set_state(DealGuarantorFSM.waiting_details)
+
+    await callback.message.answer("Опишите ваш запрос гаранта:")
+    await callback.answer()
+
+
+@router.message(DealGuarantorFSM.waiting_details, F.text)
+async def handle_guarant_details(message: Message, state: FSMContext) -> None:
+    data = await state.get_data()
+    auction_id = uuid.UUID(data["guarant_auction_id"])
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            user = await session.scalar(
+                select(User).where(User.tg_user_id == message.from_user.id)
+            )
+            if user is None:
+                await message.answer("Пользователь не найден")
+                return
+            await create_guarantor_request(
+                session,
+                submitter_user_id=user.id,
+                details=message.text,
+                auction_id=auction_id,
+            )
+
+    await state.clear()
+    await message.answer("Запрос гаранта отправлен модераторам.")
+
+
+@router.callback_query(F.data.startswith("deal:republish:"))
+async def handle_deal_republish(callback: CallbackQuery, state: FSMContext) -> None:
+    await state.clear()
+    _, auction_id = parse_deal_callback(callback.data)
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            auction = await session.scalar(
+                select(Auction).where(Auction.id == auction_id).with_for_update()
+            )
+            if auction is None:
+                await callback.answer("Аукцион не найден", show_alert=True)
+                return
+            if auction.status != AuctionStatus.ENDED:
+                await callback.answer("Можно переопубликовать только завершённый лот", show_alert=True)
+                return
+
+            from app.db.models import Auction as AuctionModel
+            new_auction = AuctionModel(
+                seller_user_id=auction.seller_user_id,
+                description=auction.description,
+                photo_file_id=auction.photo_file_id,
+                start_price=auction.start_price,
+                buyout_price=auction.buyout_price,
+                min_step=auction.min_step,
+                duration_hours=auction.duration_hours,
+                anti_sniper_enabled=auction.anti_sniper_enabled,
+            )
+            session.add(new_auction)
+
+    await callback.message.answer("Лот скопирован как черновик. Опубликуйте его через /sell.")
+    await callback.answer()
+```
+
+Note: `create_guarantor_request` needs to accept an optional `auction_id` parameter — this will be added in Task 10.
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest tests/test_post_auction_callbacks.py -q`
+Expected: all pass
+
+- [ ] **Step 5: Run lint**
+
+Run: `python -m ruff check app/bot/handlers/post_auction.py`
+Expected: no errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/bot/handlers/post_auction.py tests/test_post_auction_callbacks.py
+git commit -m "feat: add post_auction handler with deal write, feedback, guarant, republish"
+```
+
+---
+
+### Task 10: Update `create_guarantor_request` to accept `auction_id`
+
+**Files:**
+- Modify: `app/services/guarantor_service.py`
+
+- [ ] **Step 1: Update the function signature**
+
+In `app/services/guarantor_service.py`, find the `create_guarantor_request` function (around line 72). Add `auction_id: uuid.UUID | None = None` parameter and pass it when creating the `GuarantorRequest`:
+
+```python
+async def create_guarantor_request(
+    session: AsyncSession,
+    *,
+    submitter_user_id: int,
+    details: str,
+    auction_id: uuid.UUID | None = None,
+) -> GuarantorRequest:
+```
+
+And in the model construction, add `auction_id=auction_id`.
+
+- [ ] **Step 2: Verify lint passes**
+
+Run: `python -m ruff check app/services/guarantor_service.py`
+Expected: no errors
+
+- [ ] **Step 3: Run existing guarantor tests**
+
+Run: `python -m pytest tests/test_guarantor_service.py tests/integration/test_guarantor_service.py -q 2>/dev/null || python -m pytest tests/ -k guarantor -q`
+Expected: all pass (new parameter is optional with default None)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/services/guarantor_service.py
+git commit -m "feat: accept optional auction_id in create_guarantor_request"
+```
+
+---
+
+### Task 11: Register `post_auction` router
+
+**Files:**
+- Modify: `app/bot/handlers/__init__.py`
+
+- [ ] **Step 1: Add import and registration**
+
+In `app/bot/handlers/__init__.py`, add the import:
+
+```python
+from .post_auction import router as post_auction_router
+```
+
+And register before `moderation_router`:
+
+```python
+router.include_router(post_auction_router)
+```
+
+- [ ] **Step 2: Verify lint passes**
+
+Run: `python -m ruff check app/bot/handlers/__init__.py`
+Expected: no errors
+
+- [ ] **Step 3: Run main dispatcher test**
+
+Run: `python -m pytest tests/test_main_dispatcher.py -q`
+Expected: pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/bot/handlers/__init__.py
+git commit -m "feat: register post_auction router in handler root"
+```
+
+---
+
+### Task 12: Update `_notify_auction_finish` in `bid_actions.py`
+
+**Files:**
+- Modify: `app/bot/handlers/bid_actions.py`
+
+- [ ] **Step 1: Update `_notify_auction_finish`**
+
+Replace the function at lines 387-436. The new version accepts rich data and uses new copy + keyboards:
+
+```python
+async def _notify_auction_finish(
+    bot: Bot,
+    *,
+    winner_tg_id: int | None,
+    seller_tg_id: int | None,
+    auction_id: uuid.UUID,
+    post_url: str | None,
+    final_price: int | None = None,
+    description: str | None = None,
+    winner_mention: str | None = None,
+    seller_mention: str | None = None,
+    is_buyout: bool = True,
+    had_bids: bool = True,
+) -> None:
+    resolved_post_url = post_url or await resolve_auction_post_url(bot, auction_id=auction_id)
+    short_id = str(auction_id)[:8]
+
+    if seller_tg_id is not None and had_bids and final_price is not None:
+        from app.services.notification_copy_service import seller_completion_text
+        from app.bot.keyboards.auction import deal_completion_keyboard
+
+        text = seller_completion_text(
+            auction_id=auction_id,
+            description=description or "",
+            final_price=final_price,
+            counterparty_mention=winner_mention or str(winner_tg_id),
+            counterparty_role="победитель",
+            is_buyout=is_buyout,
+        )
+        kb = deal_completion_keyboard(auction_id=short_id, post_url=resolved_post_url, is_seller=True)
+
+        await send_user_topic_message(
+            bot,
+            tg_user_id=seller_tg_id,
+            purpose=PrivateTopicPurpose.AUCTIONS,
+            text=text,
+            reply_markup=kb,
+            message_effect_id=resolve_auction_message_effect_id(AuctionMessageEffectEvent.BUYOUT_SELLER),
+            notification_event=NotificationEventType.AUCTION_FINISH,
+            auction_id=auction_id,
+        )
+    elif seller_tg_id is not None and not had_bids:
+        from app.services.notification_copy_service import seller_no_bids_text
+        from app.bot.keyboards.auction import no_bids_keyboard
+
+        text = seller_no_bids_text(
+            auction_id=auction_id,
+            description=description or "",
+            start_price=final_price or 0,
+        )
+        kb = no_bids_keyboard(auction_id=short_id, post_url=resolved_post_url)
+
+        await send_user_topic_message(
+            bot,
+            tg_user_id=seller_tg_id,
+            purpose=PrivateTopicPurpose.AUCTIONS,
+            text=text,
+            reply_markup=kb,
+            notification_event=NotificationEventType.AUCTION_FINISH,
+            auction_id=auction_id,
+        )
+
+    if winner_tg_id is not None and had_bids and final_price is not None:
+        from app.services.notification_copy_service import winner_completion_text
+        from app.bot.keyboards.auction import deal_completion_keyboard
+
+        text = winner_completion_text(
+            auction_id=auction_id,
+            description=description or "",
+            final_price=final_price,
+            counterparty_mention=seller_mention or str(seller_tg_id),
+            counterparty_role="продавец",
+            is_buyout=is_buyout,
+        )
+        kb = deal_completion_keyboard(auction_id=short_id, post_url=resolved_post_url, is_seller=False)
+
+        await send_user_topic_message(
+            bot,
+            tg_user_id=winner_tg_id,
+            purpose=PrivateTopicPurpose.AUCTIONS,
+            text=text,
+            reply_markup=kb,
+            message_effect_id=resolve_auction_message_effect_id(AuctionMessageEffectEvent.BUYOUT_WINNER),
+            notification_event=NotificationEventType.AUCTION_WIN,
+            auction_id=auction_id,
+        )
+
+    from app.services.notification_copy_service import moderation_completion_text
+    from app.bot.keyboards.auction import moderation_completion_keyboard
+
+    seller_label = seller_mention or (str(seller_tg_id) if seller_tg_id is not None else "нет")
+    winner_label = winner_mention or (str(winner_tg_id) if winner_tg_id is not None else "нет")
+
+    mod_text = moderation_completion_text(
+        auction_id=auction_id,
+        description=description or "",
+        final_price=final_price or 0,
+        bid_count=0,
+        seller_mention=seller_label,
+        winner_mention=winner_label,
+        seller_reputation=0,
+        winner_reputation=0,
+        has_deal_topic=False,
+        has_guarantor=False,
+        reason="выкупом" if is_buyout else "по таймеру",
+    )
+    mod_kb = moderation_completion_keyboard(auction_id=short_id, post_url=resolved_post_url)
+
+    await send_section_message(
+        bot,
+        section=ModerationTopicSection.AUCTIONS_CLOSED,
+        text=mod_text,
+        reply_markup=mod_kb,
+    )
+```
+
+- [ ] **Step 2: Update callers to pass rich data**
+
+Find where `_notify_auction_finish` is called (in `handle_buyout_action` around line 650). Update the call to pass the new parameters from `BidActionResult` / `FinalizeResult`:
+
+```python
+    await _notify_auction_finish(
+        bot,
+        winner_tg_id=result.winner_tg_user_id,
+        seller_tg_id=result.seller_tg_user_id,
+        auction_id=auction_id,
+        post_url=None,
+        final_price=result.final_price if hasattr(result, 'final_price') else None,
+        description=result.description if hasattr(result, 'description') else None,
+        winner_mention=_build_mention(result.winner_username, result.winner_first_name, result.winner_tg_user_id) if result.winner_tg_user_id else None,
+        seller_mention=_build_mention(result.seller_username, result.seller_first_name, result.seller_tg_user_id),
+        is_buyout=True,
+        had_bids=result.had_bids if hasattr(result, 'had_bids') else True,
+    )
+```
+
+Add helper at module level:
+
+```python
+def _build_mention(username: str | None, first_name: str | None, tg_id: int) -> str:
+    if username:
+        return f"@{username}"
+    display = first_name or "Пользователь"
+    return f'<a href="tg://user?id={tg_id}">{display}</a>'
+```
+
+- [ ] **Step 3: Verify lint passes**
+
+Run: `python -m ruff check app/bot/handlers/bid_actions.py`
+Expected: no errors
+
+- [ ] **Step 4: Run existing tests**
+
+Run: `python -m pytest tests/test_bid_actions_alerts.py tests/test_bid_actions_outbid_notifications.py -q`
+Expected: all pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/bot/handlers/bid_actions.py
+git commit -m "feat: use rich notifications in _notify_auction_finish"
+```
+
+---
+
+### Task 13: Update `finalize_expired_auctions` notifications
+
+**Files:**
+- Modify: `app/services/auction_service.py`
+
+- [ ] **Step 1: Update notification section**
+
+In `finalize_expired_auctions` (lines ~830-871), replace the notification loop. After `await _safe_refresh_auction_posts(bot, auction_id)`, the loop over `finalized_results` needs to use the new rich data:
+
+Replace the notification block with:
+
+```python
+    for result in finalized_results:
+        post_url = await resolve_auction_post_url(bot, auction_id=result.auction_id)
+        short_id = str(result.auction_id)[:8]
+
+        winner_mention = _build_result_mention(
+            result.winner_username, result.winner_first_name, result.winner_tg_user_id
+        )
+        seller_mention = _build_result_mention(
+            result.seller_username, result.seller_first_name, result.seller_tg_user_id
+        )
+
+        if result.had_bids and result.final_price is not None:
+            from app.services.notification_copy_service import seller_completion_text
+            from app.bot.keyboards.auction import deal_completion_keyboard
+
+            seller_text = seller_completion_text(
+                auction_id=result.auction_id,
+                description=result.description or "",
+                final_price=result.final_price,
+                counterparty_mention=winner_mention,
+                counterparty_role="победитель",
+                is_buyout=False,
+            )
+            seller_kb = deal_completion_keyboard(auction_id=short_id, post_url=post_url, is_seller=True)
+        else:
+            from app.services.notification_copy_service import seller_no_bids_text
+            from app.bot.keyboards.auction import no_bids_keyboard
+
+            seller_text = seller_no_bids_text(
+                auction_id=result.auction_id,
+                description=result.description or "",
+                start_price=result.final_price or 0,
+            )
+            seller_kb = no_bids_keyboard(auction_id=short_id, post_url=post_url)
+
+        await send_user_topic_message(
+            bot,
+            tg_user_id=result.seller_tg_user_id,
+            purpose=PrivateTopicPurpose.AUCTIONS,
+            text=seller_text,
+            reply_markup=seller_kb,
+            message_effect_id=resolve_auction_message_effect_id(AuctionMessageEffectEvent.ENDED_SELLER),
+            notification_event=NotificationEventType.AUCTION_FINISH,
+            auction_id=result.auction_id,
+        )
+
+        if result.winner_tg_user_id is not None and result.had_bids and result.final_price is not None:
+            from app.services.notification_copy_service import winner_completion_text
+            from app.bot.keyboards.auction import deal_completion_keyboard
+
+            winner_text = winner_completion_text(
+                auction_id=result.auction_id,
+                description=result.description or "",
+                final_price=result.final_price,
+                counterparty_mention=seller_mention,
+                counterparty_role="продавец",
+                is_buyout=False,
+            )
+            winner_kb = deal_completion_keyboard(auction_id=short_id, post_url=post_url, is_seller=False)
+
+            await send_user_topic_message(
+                bot,
+                tg_user_id=result.winner_tg_user_id,
+                purpose=PrivateTopicPurpose.AUCTIONS,
+                text=winner_text,
+                reply_markup=winner_kb,
+                message_effect_id=resolve_auction_message_effect_id(AuctionMessageEffectEvent.ENDED_WINNER),
+                notification_event=NotificationEventType.AUCTION_WIN,
+                auction_id=result.auction_id,
+            )
+
+        from app.services.notification_copy_service import moderation_completion_text
+        from app.bot.keyboards.auction import moderation_completion_keyboard
+
+        mod_text = moderation_completion_text(
+            auction_id=result.auction_id,
+            description=result.description or "",
+            final_price=result.final_price or 0,
+            bid_count=0,
+            seller_mention=seller_mention,
+            winner_mention=winner_mention,
+            seller_reputation=0,
+            winner_reputation=0,
+            has_deal_topic=False,
+            has_guarantor=False,
+            reason="по таймеру",
+        )
+        mod_kb = moderation_completion_keyboard(auction_id=short_id, post_url=post_url)
+
+        await send_section_message(
+            bot,
+            section=ModerationTopicSection.AUCTIONS_CLOSED,
+            text=mod_text,
+            reply_markup=mod_kb,
+        )
+```
+
+Add helper function at module level:
+
+```python
+def _build_result_mention(username: str | None, first_name: str | None, tg_id: int | None) -> str:
+    if tg_id is None:
+        return "нет"
+    if username:
+        return f"@{username}"
+    display = first_name or "Пользователь"
+    return f'<a href="tg://user?id={tg_id}">{display}</a>'
+```
+
+- [ ] **Step 2: Verify lint passes**
+
+Run: `python -m ruff check app/services/auction_service.py`
+Expected: no errors
+
+- [ ] **Step 3: Run existing tests**
+
+Run: `python -m pytest tests/test_auction_service_resilience.py tests/test_auction_caption_render.py -q`
+Expected: all pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/services/auction_service.py
+git commit -m "feat: use rich notifications in finalize_expired_auctions"
+```
+
+---
+
+### Task 14: Fix `mod_end` to use `_finalize_auction_locked`
+
+**Files:**
+- Modify: `app/services/moderation_service.py`
+- Modify: `app/bot/handlers/moderation.py`
+
+- [ ] **Step 1: Update `end_auction` in moderation_service**
+
+In `app/services/moderation_service.py`, replace the `end_auction` function (lines ~325-367) to delegate to `_finalize_auction_locked`:
+
+```python
+async def end_auction(
+    session: AsyncSession,
+    *,
+    auction_id: uuid.UUID,
+) -> FinalizeResult | None:
+    from app.services.auction_service import _finalize_auction_locked, get_auction_by_id
+
+    auction = await get_auction_by_id(session, auction_id, for_update=True)
+    if auction is None:
+        return None
+    return await _finalize_auction_locked(session, auction, status=AuctionStatus.ENDED)
+```
+
+This requires importing `FinalizeResult` and `AuctionStatus` at the top. Also, `_finalize_auction_locked` is a private function — consider making it public or keeping the import as-is (the codebase already uses cross-module private imports).
+
+- [ ] **Step 2: Update `mod_end` handler**
+
+In `app/bot/handlers/moderation.py`, update the `mod_end` handler to use rich notification data from the `FinalizeResult`:
+
+```python
+    result = await end_auction(session, auction_id=target_auction_id)
+    if result is None:
+        await message.reply("Не удалось завершить аукцион.")
+        return
+```
+
+Then after refresh, send rich notifications using the same pattern as Task 13.
+
+- [ ] **Step 3: Verify lint passes**
+
+Run: `python -m ruff check app/services/moderation_service.py app/bot/handlers/moderation.py`
+Expected: no errors
+
+- [ ] **Step 4: Run existing tests**
+
+Run: `python -m pytest tests/ -k moderation -q --timeout=30`
+Expected: all pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/moderation_service.py app/bot/handlers/moderation.py
+git commit -m "fix: mod_end now uses _finalize_auction_locked for consistent reputation awards"
+```
+
+---
+
+### Task 15: Update `_format_user_mention` in `notification_copy_service.py`
+
+**Files:**
+- Modify: `app/services/notification_copy_service.py`
+
+- [ ] **Step 1: Add a public mention formatting function**
+
+Add to `notification_copy_service.py`:
+
+```python
+def format_user_mention(*, username: str | None, first_name: str | None, tg_user_id: int) -> str:
+    if username:
+        return f"@{html.escape(username)}"
+    display = html.escape(first_name or "Пользователь")
+    return f'<a href="tg://user?id={tg_user_id}">{display}</a>'
+```
+
+This provides a reusable mention formatter that doesn't require a full `User` object.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/services/notification_copy_service.py
+git commit -m "feat: add format_user_mention helper to notification_copy_service"
+```
+
+---
+
+### Task 16: Full test suite + lint check
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run full lint**
+
+Run: `python -m ruff check app tests`
+Expected: no errors
+
+- [ ] **Step 2: Run full unit test suite**
+
+Run: `python -m pytest tests/ -q --ignore=tests/integration`
+Expected: all pass
+
+- [ ] **Step 3: Run integration tests (if DB available)**
+
+Run: `RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost/auction_test python -m pytest tests/integration/ -q`
+
+- [ ] **Step 4: Final commit if any fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: address lint and test issues from post-auction UX redesign"
+```
+
+---
+
+## Rollout Notes
+
+1. **Alembic migration** must be applied before deploying new code: `alembic upgrade head`
+2. **Backward-safe:** `GuarantorRequest.auction_id` is nullable, existing rows unaffected
+3. **No breaking changes** to existing notification delivery — old code paths still work for edge cases
+4. **Feature flag not needed** — this is a notification template change, not a behavior toggle
+5. **Rollback:** Revert code + `alembic downgrade -1` drops the `deal_topics` table and `guarantor_requests.auction_id` column

--- a/docs/superpowers/plans/2026-04-11-reputation-score.md
+++ b/docs/superpowers/plans/2026-04-11-reputation-score.md
@@ -1,0 +1,1080 @@
+# Reputation Score Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a reputation score system (0-100) with trust tiers for every user, replacing the current binary risk evaluation with progressive trust levels that gate publishing.
+
+**Architecture:** New SQLAlchemy models (`UserReputation`, `UserReputationEvent`), new `reputation_service.py` as the single source of truth for score calculation, integration hooks in 10 existing service files, updated publish gate, and moderation UI.
+
+**Tech Stack:** Python 3.12, SQLAlchemy 2.x (async), Alembic, PostgreSQL, aiogram 3.x.
+
+---
+
+### Task 1: Add `ReputationTier` enum
+
+**Files:**
+- Modify: `app/db/enums.py` (append after line 81)
+
+- [ ] **Step 1: Add the enum**
+
+Append to `app/db/enums.py`:
+
+```python
+class ReputationTier(StrEnum):
+    NEW = "NEW"
+    BRONZE = "BRONZE"
+    SILVER = "SILVER"
+    GOLD = "GOLD"
+    PLATINUM = "PLATINUM"
+
+
+class ReputationEventReason(StrEnum):
+    AUCTION_COMPLETED = "auction_completed"
+    BID_WON = "bid_won"
+    GUARANTOR_ASSIGNED = "guarantor_assigned"
+    USER_VERIFIED = "user_verified"
+    COMPLAINT_FILED = "complaint_filed"
+    FRAUD_SIGNAL = "fraud_signal"
+    FRAUD_CONFIRMED = "fraud_confirmed"
+    BID_REMOVED = "bid_removed"
+    TEMP_BAN = "temp_ban"
+    PERM_BAN = "perm_ban"
+    MOD_ADJUST = "mod_adjust"
+    DECAY = "decay"
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `docker compose exec bot python -c "from app.db.enums import ReputationTier, ReputationEventReason; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/db/enums.py
+git commit -m "feat: add ReputationTier and ReputationEventReason enums"
+```
+
+---
+
+### Task 2: Add `UserReputation` and `UserReputationEvent` models
+
+**Files:**
+- Modify: `app/db/models.py` (append before the last model or at end of file)
+
+- [ ] **Step 1: Add imports**
+
+At the top of `app/db/models.py`, add to existing imports from `app.db.enums`:
+
+```python
+from app.db.enums import ReputationTier, ReputationEventReason
+```
+
+Note: The file already imports from `app.db.enums` — just add the two new names to that import line.
+
+- [ ] **Step 2: Add `UserReputation` model**
+
+Append at end of `app/db/models.py`:
+
+```python
+class UserReputation(Base):
+    __tablename__ = "user_reputations"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False)
+    score: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    tier: Mapped[str] = mapped_column(String(16), nullable=False, default=ReputationTier.NEW)
+    last_event_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+
+    events: Mapped[list[UserReputationEvent]] = relationship(back_populates="reputation", order_by="desc(UserReputationEvent.created_at)")
+
+
+class UserReputationEvent(Base):
+    __tablename__ = "user_reputation_events"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    delta: Mapped[int] = mapped_column(Integer, nullable=False)
+    reason: Mapped[str] = mapped_column(String(32), nullable=False)
+    source_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    reputation: Mapped[UserReputation] = relationship(back_populates="events")
+```
+
+Note: Use the same import patterns as existing models. `datetime`, `BigInteger`, `Integer`, `String`, `ForeignKey`, `DateTime`, `func`, `relationship`, `Mapped`, `mapped_column` are all already imported in this file. Check that `relationship` is imported from `sqlalchemy.orm` — if not, add it.
+
+Add index for `(user_id, created_at DESC)`:
+```python
+__table_args__ = (
+    Index("ix_reputation_events_user_created", "user_id", descending("created_at")),
+)
+```
+
+Note: `descending` is from `sqlalchemy` — check import. If not available, use `text("created_at DESC")` or create index in migration instead.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `docker compose exec bot python -c "from app.db.models import UserReputation, UserReputationEvent; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/db/models.py
+git commit -m "feat: add UserReputation and UserReputationEvent models"
+```
+
+---
+
+### Task 3: Alembic migration
+
+**Files:**
+- Create: `alembic/versions/0039_user_reputations.py`
+
+- [ ] **Step 1: Generate migration stub**
+
+Run: `docker compose exec bot alembic revision -m "user_reputations" --rev-id 0039_user_reputations`
+Note: Adjust the command if alembic is not in PATH. The project may use `python -m alembic`.
+
+If autogenerate works: `docker compose exec bot python -m alembic revision --autogenerate -m "user_reputations"`
+
+- [ ] **Step 2: Write migration**
+
+Create migration with `down_revision = "0038_workflow_preset_telemetry"`:
+
+```python
+"""user_reputations
+
+Revision ID: 0039_user_reputations
+Revises: 0038_workflow_preset_telemetry
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0039_user_reputations"
+down_revision = "0038_workflow_preset_telemetry"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_reputation_events",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("delta", sa.Integer(), nullable=False),
+        sa.Column("reason", sa.String(32), nullable=False),
+        sa.Column("source_id", sa.BigInteger(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_reputation_events_user_created",
+        "user_reputation_events",
+        ["user_id", sa.text("created_at DESC")],
+    )
+    op.create_foreign_key(
+        "fk_user_reputation_events_user_id",
+        "user_reputation_events",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    op.create_table(
+        "user_reputations",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("score", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("tier", sa.String(16), nullable=False, server_default="NEW"),
+        sa.Column("last_event_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id"),
+    )
+    op.create_foreign_key(
+        "fk_user_reputations_user_id",
+        "user_reputations",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_reputations")
+    op.drop_table("user_reputation_events")
+```
+
+- [ ] **Step 3: Run migration**
+
+Run: `docker compose exec bot python -m alembic upgrade head`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add alembic/versions/0039_user_reputations.py
+git commit -m "feat: add Alembic migration for user_reputations tables"
+```
+
+---
+
+### Task 4: Create `reputation_service.py`
+
+**Files:**
+- Create: `app/services/reputation_service.py`
+
+This is the core service. It provides all reputation operations.
+
+- [ ] **Step 1: Write the service**
+
+```python
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.enums import ReputationEventReason, ReputationTier
+from app.db.models import (
+    AuctionStatus,
+    BlacklistEntry,
+    Complaint,
+    FraudSignal,
+    User,
+    UserReputation,
+    UserReputationEvent,
+)
+
+
+def _score_to_tier(score: int) -> str:
+    if score >= 81:
+        return ReputationTier.PLATINUM
+    if score >= 61:
+        return ReputationTier.GOLD
+    if score >= 41:
+        return ReputationTier.SILVER
+    if score >= 21:
+        return ReputationTier.BRONZE
+    return ReputationTier.NEW
+
+
+def _clamp_score(score: int) -> int:
+    return max(0, min(100, score))
+
+
+async def _count_daily_delta(session: AsyncSession, user_id: int) -> tuple[int, int]:
+    since = datetime.now(UTC) - timedelta(hours=24)
+    events = await session.execute(
+        select(UserReputationEvent.delta).where(
+            UserReputationEvent.user_id == user_id,
+            UserReputationEvent.created_at >= since,
+            UserReputationEvent.reason != ReputationEventReason.PERM_BAN,
+        )
+    )
+    deltas = events.scalars().all()
+    positive = sum(d for d in deltas if d > 0)
+    negative = sum(d for d in deltas if d < 0)
+    return positive, negative
+
+
+async def get_or_create_reputation(
+    session: AsyncSession, user_id: int
+) -> UserReputation:
+    row = await session.scalar(
+        select(UserReputation).where(UserReputation.user_id == user_id)
+    )
+    if row is not None:
+        return row
+    return await recalculate_user_reputation(session, user_id)
+
+
+async def recalculate_user_reputation(
+    session: AsyncSession, user_id: int
+) -> UserReputation:
+    user = await session.scalar(select(User).where(User.id == user_id))
+    base_score = 25
+    if user is not None:
+        account_age = datetime.now(UTC) - (user.created_at or datetime.now(UTC))
+        if account_age < timedelta(hours=24):
+            base_score = 10
+
+    completed_auctions = int(
+        await session.scalar(
+            select(func.count()).select_from(
+                select(1)
+                .where(
+                    UserReputation.__table__.columns if False else True,
+                )
+            )
+        )
+        or 0
+    ) if False else 0
+
+    closed_as_seller = int(
+        await session.scalar(
+            select(func.count()).select_from(
+                __import__("app.db.models", fromlist=["Auction"]).Auction.__table__
+            ).where(
+                __import__("app.db.models", fromlist=["Auction"]).Auction.seller_user_id == user_id,
+                __import__("app.db.models", fromlist=["Auction"]).Auction.status.in_(
+                    {AuctionStatus.ENDED, AuctionStatus.BOUGHT_OUT}
+                ),
+            )
+        )
+        or 0
+    )
+
+    from app.db.models import Auction
+    won_as_buyer = int(
+        await session.scalar(
+            select(func.count(Auction.id)).where(
+                Auction.winner_user_id == user_id,
+                Auction.status.in_({AuctionStatus.ENDED, AuctionStatus.BOUGHT_OUT}),
+            )
+        )
+        or 0
+    )
+
+    complaints_count = int(
+        await session.scalar(
+            select(func.count(Complaint.id)).where(
+                Complaint.target_user_id == user_id
+            )
+        )
+        or 0
+    )
+
+    confirmed_fraud = int(
+        await session.scalar(
+            select(func.count(FraudSignal.id)).where(
+                FraudSignal.user_id == user_id,
+                FraudSignal.status == "CONFIRMED",
+            )
+        )
+        or 0
+    )
+
+    verified = False
+    from app.services.verification_service import is_user_verified
+    if user is not None:
+        verified = await is_user_verified(session, tg_user_id=user.tg_user_id)
+
+    from app.services.guarantor_service import has_assigned_guarantor_request
+    has_guarantor = await has_assigned_guarantor_request(session, submitter_user_id=user_id, max_age_days=365)
+
+    score = base_score
+    score += min(30, closed_as_seller * 5)
+    score += min(30, won_as_buyer * 3)
+    score -= min(30, complaints_count * 10)
+    score -= min(40, confirmed_fraud * 20)
+    if verified:
+        score += 15
+    if has_guarantor:
+        score += 10
+    score = _clamp_score(score)
+    tier = _score_to_tier(score)
+
+    existing = await session.scalar(
+        select(UserReputation).where(UserReputation.user_id == user_id)
+    )
+    if existing is not None:
+        existing.score = score
+        existing.tier = tier
+        existing.updated_at = datetime.now(UTC)
+        await session.flush()
+        return existing
+
+    reputation = UserReputation(
+        user_id=user_id,
+        score=score,
+        tier=tier,
+        last_event_at=datetime.now(UTC),
+    )
+    session.add(reputation)
+    await session.flush()
+    return reputation
+
+
+async def adjust_reputation(
+    session: AsyncSession,
+    user_id: int,
+    delta: int,
+    reason: str,
+    source_id: int | None = None,
+) -> UserReputation | None:
+    if reason == ReputationEventReason.PERM_BAN:
+        reputation = await get_or_create_reputation(session, user_id)
+        actual_delta = -reputation.score
+    else:
+        positive_24h, negative_24h = await _count_daily_delta(session, user_id)
+        if delta > 0 and positive_24h + delta > 15:
+            delta = max(0, 15 - positive_24h)
+        if delta < 0 and negative_24h + delta < -40:
+            delta = max(delta, -40 - negative_24h)
+        if delta == 0:
+            return await get_or_create_reputation(session, user_id)
+        actual_delta = delta
+
+    reputation = await get_or_create_reputation(session, user_id)
+    old_tier = reputation.tier
+    reputation.score = _clamp_score(reputation.score + actual_delta)
+    reputation.tier = _score_to_tier(reputation.score)
+    reputation.last_event_at = datetime.now(UTC)
+    reputation.updated_at = datetime.now(UTC)
+
+    event = UserReputationEvent(
+        user_id=user_id,
+        delta=actual_delta,
+        reason=reason,
+        source_id=source_id,
+    )
+    session.add(event)
+    await session.flush()
+
+    if reputation.tier != old_tier:
+        reputation._tier_changed = True
+        reputation._old_tier = old_tier
+    else:
+        reputation._tier_changed = False
+
+    return reputation
+
+
+async def get_user_tier(session: AsyncSession, user_id: int) -> str:
+    reputation = await get_or_create_reputation(session, user_id)
+    return reputation.tier
+
+
+async def get_reputation_history(
+    session: AsyncSession, user_id: int, limit: int = 20
+) -> list[UserReputationEvent]:
+    result = await session.execute(
+        select(UserReputationEvent)
+        .where(UserReputationEvent.user_id == user_id)
+        .order_by(desc(UserReputationEvent.created_at))
+        .limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def run_reputation_decay(session: AsyncSession) -> int:
+    cutoff = datetime.now(UTC) - timedelta(days=30)
+    stale = await session.execute(
+        select(UserReputation).where(
+            UserReputation.last_event_at < cutoff,
+            UserReputation.score > 10,
+        )
+    )
+    affected = 0
+    for reputation in stale.scalars().all():
+        days_inactive = (datetime.now(UTC) - (reputation.last_event_at or reputation.created_at)).days
+        decay_periods = days_inactive // 30
+        decay_delta = min(decay_periods * 2, reputation.score - 10)
+        if decay_delta <= 0:
+            continue
+        await adjust_reputation(
+            session,
+            user_id=reputation.user_id,
+            delta=-decay_delta,
+            reason=ReputationEventReason.DECAY,
+        )
+        affected += 1
+    return affected
+```
+
+Note: The `recalculate_user_reputation` function has some awkward imports — the implementer should clean this up to use direct `Auction` imports at the top level like all other services in the codebase do. The key logic is correct: base score + adjustments clamped to [0, 100].
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `docker compose exec bot python -c "from app.services.reputation_service import get_or_create_reputation, adjust_reputation, recalculate_user_reputation; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/services/reputation_service.py
+git commit -m "feat: add reputation_service with score calculation and adjust/deCay"
+```
+
+---
+
+### Task 5: Update publish gate to use reputation
+
+**Files:**
+- Modify: `app/services/publish_gate_service.py:33-123`
+
+- [ ] **Step 1: Add import**
+
+Add to imports in `publish_gate_service.py`:
+
+```python
+from app.services.reputation_service import get_or_create_reputation
+```
+
+- [ ] **Step 2: Replace `evaluate_seller_publish_gate`**
+
+Replace the function body (lines 33-123) with:
+
+```python
+async def evaluate_seller_publish_gate(
+    session: AsyncSession, *, seller_user_id: int
+) -> SellerPublishGateResult:
+    reputation = await get_or_create_reputation(session, seller_user_id)
+    tier = reputation.tier
+    score = reputation.score
+
+    if tier in {ReputationTier.PLATINUM, ReputationTier.GOLD, ReputationTier.SILVER}:
+        return SellerPublishGateResult(
+            allowed=True,
+            risk_level=tier,
+            risk_score=score,
+            risk_reasons=(),
+        )
+
+    if tier == ReputationTier.BRONZE:
+        has_assigned = await has_assigned_guarantor_request(
+            session,
+            submitter_user_id=seller_user_id,
+            max_age_days=max(
+                int(await resolve_runtime_setting_value(session, "publish_guarantor_assignment_max_age_days")),
+                0,
+            ),
+        )
+        if has_assigned:
+            return SellerPublishGateResult(
+                allowed=True,
+                risk_level=tier,
+                risk_score=score,
+                risk_reasons=(),
+            )
+        return SellerPublishGateResult(
+            allowed=False,
+            risk_level=tier,
+            risk_score=score,
+            risk_reasons=("no_guarantor",),
+            block_message=(
+                f"Публикация ограничена. Ваш уровень: BRONZE (score: {score}).\n"
+                "Для публикации нужен назначенный гарант → /guarant\n"
+                "Повысить уровень: завершите сделки без жалоб."
+            ),
+        )
+
+    has_assigned = await has_assigned_guarantor_request(
+        session,
+        submitter_user_id=seller_user_id,
+        max_age_days=365,
+    )
+    from app.db.models import Auction
+    from app.db.enums import AuctionStatus
+    completed_count = int(
+        await session.scalar(
+            select(func.count(Auction.id)).where(
+                Auction.seller_user_id == seller_user_id,
+                Auction.status.in_({AuctionStatus.ENDED, AuctionStatus.BOUGHT_OUT}),
+            )
+        )
+        or 0
+    )
+    won_count = int(
+        await session.scalar(
+            select(func.count(Auction.id)).where(
+                Auction.winner_user_id == seller_user_id,
+                Auction.status.in_({AuctionStatus.ENDED, AuctionStatus.BOUGHT_OUT}),
+            )
+        )
+        or 0
+    )
+    total_deals = completed_count + won_count
+
+    if has_assigned and total_deals >= 1:
+        return SellerPublishGateResult(
+            allowed=True,
+            risk_level=tier,
+            risk_score=score,
+            risk_reasons=(),
+        )
+
+    parts = [f"Публикация ограничена. Ваш уровень: NEW (score: {score})."]
+    if not has_assigned:
+        parts.append("Для публикации нужен гарант → /guarant")
+    if total_deals < 1:
+        parts.append("Нужна хотя бы 1 завершённая сделка (проданный или выигранный аукцион).")
+    parts.append("Повысить уровень: завершите сделки без жалоб.")
+
+    return SellerPublishGateResult(
+        allowed=False,
+        risk_level=tier,
+        risk_score=score,
+        risk_reasons=("new_tier",),
+        block_message="\n".join(parts),
+    )
+```
+
+Add required imports at top: `from app.db.enums import ReputationTier, AuctionStatus` and `from sqlalchemy import func, select` and `from app.services.reputation_service import get_or_create_reputation`. Keep existing imports that are still used.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `docker compose exec bot python -c "from app.services.publish_gate_service import evaluate_seller_publish_gate; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/services/publish_gate_service.py
+git commit -m "feat: update publish gate to use reputation tiers"
+```
+
+---
+
+### Task 6: Integration hooks — positive events
+
+**Files:**
+- Modify: `app/services/auction_service.py` (auction close hooks)
+- Modify: `app/services/guarantor_service.py:178-204` (guarantor assigned hook)
+- Modify: `app/services/verification_service.py:87-121` (verification hook)
+
+- [ ] **Step 1: Auction completed (seller) + bid won (buyer)**
+
+In `app/services/auction_service.py`, find `_finalize_auction_locked` (line 486). After line 505 (`auction.updated_at = now`), there's already loading of seller and winner. After the function returns `FinalizeResult`, the callers need to adjust reputation.
+
+The cleanest approach: add reputation adjustment in `finalize_expired_auctions` (line 799) after `_finalize_auction_locked` returns successfully, and in `process_bid_action` lines 540 and 609-630 where `_finalize_auction_locked` is called.
+
+Add at top of `auction_service.py`:
+```python
+from app.services.reputation_service import adjust_reputation
+from app.db.enums import ReputationEventReason
+```
+
+In `finalize_expired_auctions`, after `result = await _finalize_auction_locked(...)` (around line 819), if `result is not None`:
+```python
+if result is not None:
+    await adjust_reputation(session, result.seller_tg_user_id_internal if hasattr(result, 'seller_tg_user_id_internal') else auction.seller_user_id, 3, ReputationEventReason.AUCTION_COMPLETED, str(auction.id)[:8] if False else None)
+```
+
+Note: `FinalizeResult` contains `seller_tg_user_id` and `winner_tg_user_id`. The caller has access to `auction.seller_user_id` and `result.winner_tg_user_id`. The implementer needs to resolve `user_id` from `tg_user_id` or pass `auction.seller_user_id` directly.
+
+**Simpler approach for the implementer:** Add the adjustment in `_finalize_auction_locked` itself, after line 505, using `auction.seller_user_id` and `winner_user_id` parameter. Import `adjust_reputation` and call:
+
+```python
+await adjust_reputation(session, auction.seller_user_id, 3, ReputationEventReason.AUCTION_COMPLETED)
+if winner_user_id is not None:
+    await adjust_reputation(session, winner_user_id, 2, ReputationEventReason.BID_WON)
+```
+
+This is the recommended placement — it fires for ALL finalization paths (expired, bought out, mod-ended).
+
+- [ ] **Step 2: Guarantor assigned**
+
+In `app/services/guarantor_service.py`, in `assign_guarantor_request` (line 198), after `item.status = GuarantorRequestStatus.ASSIGNED`:
+
+Add import at top:
+```python
+from app.services.reputation_service import adjust_reputation
+from app.db.enums import ReputationEventReason
+```
+
+After line 203 (`item.updated_at = now`), add:
+```python
+await adjust_reputation(
+    session,
+    item.submitter_user_id,
+    10,
+    ReputationEventReason.GUARANTOR_ASSIGNED,
+    source_id=item.id,
+)
+```
+
+- [ ] **Step 3: User verified**
+
+In `app/services/verification_service.py`, in `set_user_verification` (line 112), after `row.is_verified = verify`:
+
+Add import at top:
+```python
+from app.services.reputation_service import adjust_reputation
+from app.db.enums import ReputationEventReason
+```
+
+After line 115 (`row.updated_at = now`), add:
+```python
+if verify:
+    target_user = await session.scalar(select(User).where(User.tg_user_id == target_tg_user_id))
+    if target_user is not None:
+        await adjust_reputation(session, target_user.id, 15, ReputationEventReason.USER_VERIFIED)
+```
+
+Import `User` and `select` if not already imported.
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `docker compose exec bot python -c "from app.services.auction_service import process_bid_action; from app.services.guarantor_service import assign_guarantor_request; from app.services.verification_service import set_user_verification; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/auction_service.py app/services/guarantor_service.py app/services/verification_service.py
+git commit -m "feat: integrate positive reputation events (auction, guarantor, verification)"
+```
+
+---
+
+### Task 7: Integration hooks — negative events
+
+**Files:**
+- Modify: `app/services/complaint_service.py:58-67` (complaint filed)
+- Modify: `app/services/fraud_service.py:303-313` (fraud signal created)
+- Modify: `app/services/fraud_service.py:398-413` (fraud signal confirmed)
+- Modify: `app/services/moderation_service.py:370-422` (bid removed)
+- Modify: `app/services/moderation_service.py:425-469` (ban)
+
+- [ ] **Step 1: Complaint filed**
+
+In `complaint_service.py`, after line 67 (`await session.flush()`), add:
+
+```python
+from app.services.reputation_service import adjust_reputation
+from app.db.enums import ReputationEventReason
+```
+
+After flush:
+```python
+if complaint.target_user_id is not None:
+    await adjust_reputation(
+        session, complaint.target_user_id, -8, ReputationEventReason.COMPLAINT_FILED, source_id=complaint.id
+    )
+```
+
+- [ ] **Step 2: Fraud signal created**
+
+In `fraud_service.py`, after line 313 (`return signal.id`), add reputation adjustment before the return:
+
+Import at top:
+```python
+from app.services.reputation_service import adjust_reputation
+from app.db.enums import ReputationEventReason
+```
+
+Before `return signal.id`:
+```python
+await adjust_reputation(
+    session, user_id, -15, ReputationEventReason.FRAUD_SIGNAL, source_id=signal.id
+)
+```
+
+- [ ] **Step 3: Fraud signal confirmed**
+
+Find `resolve_fraud_signal` in `fraud_service.py` (around line 398-413). When status is set to CONFIRMED, add:
+
+```python
+if new_status == "CONFIRMED":
+    await adjust_reputation(
+        session, signal.user_id, -10, ReputationEventReason.FRAUD_CONFIRMED, source_id=signal.id
+    )
+```
+
+- [ ] **Step 4: Bid removed**
+
+In `moderation_service.py`, in `remove_bid` function (line 370), after the bid is removed and moderation action logged:
+
+```python
+await adjust_reputation(session, bid.user_id, -5, ReputationEventReason.BID_REMOVED, source_id=bid.id)
+```
+
+- [ ] **Step 5: Ban (perm)**
+
+In `moderation_service.py`, in `ban_user` function (line 425), after the blacklist entry is created:
+
+```python
+await adjust_reputation(session, target_user_id, 0, ReputationEventReason.PERM_BAN)
+```
+
+Note: `adjust_reputation` handles PERM_BAN specially — it sets score to 0 regardless of delta.
+
+- [ ] **Step 6: Verify compilation**
+
+Run: `docker compose exec bot python -c "from app.services.complaint_service import create_complaint; from app.services.fraud_service import evaluate_and_store_bid_fraud_signal; from app.services.moderation_service import remove_bid, ban_user; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/complaint_service.py app/services/fraud_service.py app/services/moderation_service.py
+git commit -m "feat: integrate negative reputation events (complaint, fraud, ban, bid removal)"
+```
+
+---
+
+### Task 8: Tier change notifications to users
+
+**Files:**
+- Modify: `app/services/reputation_service.py` (the `adjust_reputation` function)
+
+- [ ] **Step 1: Add notification helper**
+
+Add to `reputation_service.py`:
+
+```python
+from app.services.private_topics_service import PrivateTopicPurpose, send_user_topic_message
+from aiogram import Bot
+import logging
+
+logger = logging.getLogger(__name__)
+
+TIER_LABELS = {
+    ReputationTier.NEW: "NEW 🆕",
+    ReputationTier.BRONZE: "BRONZE 🥉",
+    ReputationTier.SILVER: "SILVER 🥈",
+    ReputationTier.GOLD: "GOLD 🥇",
+    ReputationTier.PLATINUM: "PLATINUM 💎",
+}
+
+
+async def notify_tier_change(bot: Bot, tg_user_id: int, old_tier: str, new_tier: str, score: int) -> None:
+    old_label = TIER_LABELS.get(old_tier, old_tier)
+    new_label = TIER_LABELS.get(new_tier, new_tier)
+    if _score_to_tier_score(old_tier) < _score_to_tier_score(new_tier):
+        text = f"🎉 Ваш уровень повышен: {old_label} → {new_label} (score: {score})"
+    else:
+        text = f"⚠️ Ваш уровень понижен: {old_label} → {new_label} (score: {score})"
+    try:
+        await send_user_topic_message(
+            bot, tg_user_id=tg_user_id, purpose=PrivateTopicPurpose.NOTIFICATIONS, text=text
+        )
+    except Exception:
+        logger.warning("Failed to send tier change notification to tg_user_id=%s", tg_user_id)
+```
+
+Note: The implementer needs `_score_to_tier_score` helper (NEW=0, BRONZE=21, SILVER=41, GOLD=61, PLATINUM=81) or just compare labels directly.
+
+- [ ] **Step 2: Call notification from integration point**
+
+This notification cannot be called from within `adjust_reputation` directly because the `Bot` instance is not available in the session context. Instead, handle it at the call sites (in auction_service, moderation handlers, etc.) by checking `reputation._tier_changed` after `adjust_reputation` returns.
+
+Alternatively, add a simpler post-transaction check: In the moderation handler and auction watcher (where Bot is available), after calling `adjust_reputation`, check if tier changed and send notification.
+
+For this task, just add the `notify_tier_change` function. Integration will happen naturally in the existing handlers.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/services/reputation_service.py
+git commit -m "feat: add tier change notification helper"
+```
+
+---
+
+### Task 9: Moderation commands — `/reputation` and `/modrepadjust`
+
+**Files:**
+- Modify: `app/bot/handlers/moderation.py` (add 2 new command handlers)
+
+- [ ] **Step 1: Add `/reputation` command**
+
+Find the pattern of existing mod commands (e.g., `/risk` at line 2321). Add a new handler following the same pattern:
+
+```python
+@router.message(Command("reputation"), F.chat.type == ChatType.PRIVATE)
+async def command_reputation(message: Message, bot: Bot) -> None:
+    if message.from_user is None:
+        return
+    if not await _ensure_moderation_topic(message, bot, "/reputation"):
+        return
+
+    target_text = (message.text or "").strip().split(maxsplit=1)
+    if len(target_text) < 2:
+        await message.answer("Формат: /reputation <user_id>")
+        return
+
+    try:
+        target_user_id = int(target_text[1].strip())
+    except ValueError:
+        await message.answer("user_id должен быть числом")
+        return
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            reputation = await get_or_create_reputation(session, target_user_id)
+            history = await get_reputation_history(session, target_user_id, limit=10)
+            user = await session.scalar(select(User).where(User.id == target_user_id))
+
+    user_label = f"@{user.username}" if user and user.username else str(target_user_id)
+    tier_labels = {"NEW": "🆕 NEW", "BRONZE": "🥉 BRONZE", "SILVER": "🥈 SILVER", "GOLD": "🥇 GOLD", "PLATINUM": "💎 PLATINUM"}
+    tier_display = tier_labels.get(reputation.tier, reputation.tier)
+
+    lines = [f"Пользователь: {user_label}", f"Уровень: {tier_display} (score: {reputation.score})", "", "Последние события:"]
+    for event in history:
+        sign = "+" if event.delta > 0 else ""
+        lines.append(f"  {sign}{event.delta} — {event.reason}")
+
+    await message.answer("\n".join(lines))
+```
+
+Add imports at top of moderation.py:
+```python
+from app.services.reputation_service import get_or_create_reputation, get_reputation_history, adjust_reputation
+from app.db.enums import ReputationEventReason
+```
+
+Note: `User`, `select`, `SessionFactory` are already imported in this file.
+
+- [ ] **Step 2: Add `/modrepadjust` command**
+
+```python
+@router.message(Command("modrepadjust"), F.chat.type == ChatType.PRIVATE)
+async def command_mod_reputation_adjust(message: Message, bot: Bot) -> None:
+    if message.from_user is None:
+        return
+    if not await _ensure_moderation_topic(message, bot, "/modrepadjust"):
+        return
+
+    parts = (message.text or "").strip().split(maxsplit=3)
+    if len(parts) < 3:
+        await message.answer("Формат: /modrepadjust <user_id> <delta> [reason]")
+        return
+
+    try:
+        target_user_id = int(parts[1])
+        delta = int(parts[2])
+    except ValueError:
+        await message.answer("user_id и delta должны быть числами")
+        return
+
+    reason_text = parts[3] if len(parts) > 3 else "moderator adjustment"
+
+    async with SessionFactory() as session:
+        async with session.begin():
+            reputation = await adjust_reputation(
+                session, target_user_id, delta, ReputationEventReason.MOD_ADJUST
+            )
+
+    if reputation is None:
+        await message.answer("Пользователь не найден")
+        return
+
+    await message.answer(
+        f"Репутация обновлена: score={reputation.score}, tier={reputation.tier}"
+    )
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `docker compose exec bot python -c "from app.bot.handlers.moderation import router; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/bot/handlers/moderation.py
+git commit -m "feat: add /reputation and /modrepadjust mod commands"
+```
+
+---
+
+### Task 10: Backfill script for existing users
+
+**Files:**
+- Create: `scripts/backfill_reputations.py`
+
+- [ ] **Step 1: Write backfill script**
+
+```python
+"""One-time script to calculate reputation for all existing users."""
+import asyncio
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.db.session import SessionFactory
+from app.db.models import User
+from app.services.reputation_service import recalculate_user_reputation
+from sqlalchemy import select
+
+
+async def main() -> None:
+    async with SessionFactory() as session:
+        result = await session.execute(select(User.id))
+        user_ids = list(result.scalars().all())
+
+    print(f"Calculating reputation for {len(user_ids)} users...")
+    updated = 0
+    for user_id in user_ids:
+        async with SessionFactory() as session:
+            async with session.begin():
+                await recalculate_user_reputation(session, user_id)
+        updated += 1
+        if updated % 100 == 0:
+            print(f"  ...{updated}/{len(user_ids)}")
+
+    print(f"Done. {updated} users processed.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+- [ ] **Step 2: Run backfill**
+
+Run: `docker compose exec bot python scripts/backfill_reputations.py`
+Expected: Output showing user count and progress.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/backfill_reputations.py
+git commit -m "feat: add backfill script for user reputations"
+```
+
+---
+
+### Task 11: E2E verification
+
+- [ ] **Step 1: Rebuild and restart**
+
+Run: `docker compose up -d --build bot`
+
+- [ ] **Step 2: Check startup logs**
+
+Run: `docker compose logs bot --tail=20`
+Expected: Clean startup, no import errors.
+
+- [ ] **Step 3: Verify reputation service loads**
+
+Run: `docker compose exec bot python -c "
+from app.services.reputation_service import (
+    get_or_create_reputation,
+    adjust_reputation,
+    recalculate_user_reputation,
+    get_user_tier,
+    get_reputation_history,
+    run_reputation_decay,
+)
+from app.db.enums import ReputationTier, ReputationEventReason
+print('All reputation service functions imported OK')
+print('Tiers:', [t.value for t in ReputationTier])
+print('Reasons:', [r.value for r in ReputationEventReason])
+"`
+
+Expected: All imports OK, tier and reason lists printed.
+
+- [ ] **Step 4: Verify migration applied**
+
+Run: `docker compose exec bot python -m alembic current`
+Expected: `0039_user_reputations (head)`
+
+- [ ] **Step 5: Final commit if any fixes needed**
+
+```bash
+git add -A
+git commit -m "chore: finalize reputation score implementation"
+```

--- a/docs/superpowers/plans/2026-04-11-v1.2-queue-trust-signals-gap-fill.md
+++ b/docs/superpowers/plans/2026-04-11-v1.2-queue-trust-signals-gap-fill.md
@@ -1,0 +1,1155 @@
+# v1.2 Queue Trust Signals — Gap-fill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend SLA health, evidence timeline, and telemetry coverage to complaints and signals dense lists in the admin web panel.
+
+**Architecture:** Gap-fill approach — reuse existing `decide_queue_sla_health`, `_render_inline_timeline_html`, `_build_rationale_artifact`, and the triage detail infrastructure to wire SLA columns, filter chips, and inline evidence timeline into complaints and signals queue pages.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy 2.x async, Jinja-style f-string HTML templates (existing pattern in `app/web/main.py`)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `app/web/main.py` | Modify | Add SLA columns, filter chips, detail sections for complaints and signals |
+| `tests/test_sla_complaints_signals.py` | Create | Unit tests for SLA derivation on complaints/signals contexts |
+| `tests/integration/test_evidence_timeline_and_telemetry.py` | Create | Integration tests for evidence timeline rendering and telemetry aggregation |
+
+---
+
+### Task 1: Add SLA health filter parsing helpers for complaints
+
+**Files:**
+- Modify: `app/web/main.py` (after line 255, near existing `_parse_appeal_sla_health_filter`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_sla_complaints_signals.py`:
+
+```python
+from app.web.main import (
+    _parse_complaint_sla_health_filter,
+    _parse_complaint_aging_bucket_filter,
+    _parse_signal_sla_health_filter,
+    _parse_signal_aging_bucket_filter,
+)
+
+
+def test_parse_complaint_sla_health_filter_valid_values():
+    for value in ("all", "healthy", "warning", "critical", "overdue", "no_sla"):
+        assert _parse_complaint_sla_health_filter(value) == value
+
+
+def test_parse_complaint_sla_health_filter_invalid():
+    import pytest
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException):
+        _parse_complaint_sla_health_filter("invalid")
+
+
+def test_parse_complaint_aging_bucket_filter_valid_values():
+    for value in ("all", "fresh", "aging", "stale", "critical", "overdue", "unknown"):
+        assert _parse_complaint_aging_bucket_filter(value) == value
+
+
+def test_parse_complaint_aging_bucket_filter_invalid():
+    import pytest
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException):
+        _parse_complaint_aging_bucket_filter("bad_value")
+
+
+def test_parse_signal_sla_health_filter_valid_values():
+    for value in ("all", "healthy", "warning", "critical", "overdue", "no_sla"):
+        assert _parse_signal_sla_health_filter(value) == value
+
+
+def test_parse_signal_aging_bucket_filter_valid_values():
+    for value in ("all", "fresh", "aging", "stale", "critical", "overdue", "unknown"):
+        assert _parse_signal_aging_bucket_filter(value) == value
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/n501/VibeCoding/LiteAuction && python -m pytest tests/test_sla_complaints_signals.py -v -x 2>&1 | tail -20`
+Expected: FAIL — `ImportError` for the new functions.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add after `_parse_appeal_aging_bucket_filter` (line 255) in `app/web/main.py`:
+
+```python
+def _parse_complaint_sla_health_filter(raw: str) -> str:
+    value = raw.strip().lower()
+    if value in {"all", "healthy", "warning", "critical", "overdue", "no_sla"}:
+        return value
+    raise HTTPException(status_code=400, detail="Invalid complaints SLA health filter")
+
+
+def _parse_complaint_aging_bucket_filter(raw: str) -> str:
+    value = raw.strip().lower()
+    if value in {"all", "fresh", "aging", "stale", "critical", "overdue", "unknown"}:
+        return value
+    raise HTTPException(status_code=400, detail="Invalid complaints aging filter")
+
+
+def _parse_signal_sla_health_filter(raw: str) -> str:
+    value = raw.strip().lower()
+    if value in {"all", "healthy", "warning", "critical", "overdue", "no_sla"}:
+        return value
+    raise HTTPException(status_code=400, detail="Invalid signals SLA health filter")
+
+
+def _parse_signal_aging_bucket_filter(raw: str) -> str:
+    value = raw.strip().lower()
+    if value in {"all", "fresh", "aging", "stale", "critical", "overdue", "unknown"}:
+        return value
+    raise HTTPException(status_code=400, detail="Invalid signals aging filter")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/n501/VibeCoding/LiteAuction && python -m pytest tests/test_sla_complaints_signals.py -v -x 2>&1 | tail -20`
+Expected: PASS — all filter parsing tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_sla_complaints_signals.py app/web/main.py
+git commit -m "feat: add SLA health and aging filter parsers for complaints and signals"
+```
+
+---
+
+### Task 2: Add SLA columns and filter chips to complaints dense list
+
+**Files:**
+- Modify: `app/web/main.py` (lines 134, 2096-2226)
+
+- [ ] **Step 1: Update allowed columns for complaints**
+
+In `_QUEUE_ALLOWED_COLUMNS` (line 134), change the `"complaints"` tuple to include SLA columns:
+
+```python
+"complaints": ("id", "auction", "reporter", "status", "reason", "created", "sla", "deadline"),
+```
+
+- [ ] **Step 2: Add SLA health and aging query parameters to complaints handler**
+
+In the `complaints` function signature (line 2097), add parameters after `telemetry_preset_id`:
+
+```python
+sla_health: str = "all",
+aging: str = "all",
+```
+
+After line 2107 (`page = max(page, 0)`), add:
+
+```python
+sla_health_value = _parse_complaint_sla_health_filter(sla_health)
+aging_value = _parse_complaint_aging_bucket_filter(aging)
+now = datetime.now(UTC)
+complaint_sla_thresholds = SLA_THRESHOLDS_BY_CONTEXT["moderation"]
+```
+
+- [ ] **Step 3: Add SLA data computation to each complaint row**
+
+After line 2155 (`complaint_priority = "high" if ...`), add SLA computation:
+
+```python
+complaint_deadline = item.created_at + complaint_sla_thresholds.warning_window if item.created_at else None
+sla_decision = decide_queue_sla_health(
+    queue_context="moderation",
+    status=item.status,
+    created_at=item.created_at,
+    deadline_at=complaint_deadline,
+    now=now,
+)
+if sla_decision.health_state in ("critical", "overdue"):
+    complaint_priority = "urgent"
+sla_hint = f"SLA:{sla_decision.health_state} | age:{sla_decision.aging_bucket}"
+```
+
+- [ ] **Step 4: Add SLA cells to complaint table rows**
+
+In the complaint table row HTML (around line 2166, after the `created` cell), add two new cells before `</tr>`:
+
+```python
+f"<td data-col='sla' data-sla-health='{escape(sla_decision.health_state)}' data-aging-bucket='{escape(sla_decision.aging_bucket)}'><small>{escape(sla_hint)}</small></td>"
+f"<td data-col='deadline'>{escape(_fmt_ts(complaint_deadline))}</td>"
+```
+
+Update the `_triage_detail_row` call to use `col_count=9` (was 7, now +2 for SLA/deadline).
+
+Update the empty state colspan from 7 to 9.
+
+- [ ] **Step 5: Update table header**
+
+In the table `<thead>` (line 2220), add two new `<th>` cells after `Created`:
+
+```html
+<th data-col='sla'>SLA</th><th data-col='deadline'>Deadline</th>
+```
+
+- [ ] **Step 6: Add SLA health and aging filter chips to toolbar**
+
+After the existing status filter toolbar (line 2218), add SLA health and aging filter chips following the appeals pattern:
+
+```python
+sla_health_chips = "".join(
+    f"<a class='chip' href='{escape(_path_with_auth(request, _complaints_path(page_value=0, status_value=status, sla_health_value=sv)))}'>{label}</a>"
+    for sv, label in [("all", "Все"), ("healthy", "В норме"), ("warning", "Внимание"), ("critical", "Критично"), ("overdue", "Просрочена"), ("no_sla", "Без SLA")]
+)
+aging_chips = "".join(
+    f"<a class='chip' href='{escape(_path_with_auth(request, _complaints_path(page_value=0, status_value=status, aging_value=av)))}'>{label}</a>"
+    for av, label in [("all", "Все"), ("fresh", "Свежие"), ("aging", "Aging"), ("stale", "Stale"), ("critical", "Critical")]
+)
+```
+
+Update `_complaints_path` to accept `sla_health_value` and `aging_value` parameters.
+
+- [ ] **Step 7: Run linter and existing tests**
+
+Run: `cd /home/n501/VibeCoding/LiteAuction && python -m ruff check app/web/main.py && python -m pytest tests/ -q --timeout=30 2>&1 | tail -20`
+Expected: No lint errors. All tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/web/main.py
+git commit -m "feat: add SLA health columns and filter chips to complaints dense list"
+```
+
+---
+
+### Task 3: Add SLA columns and filter chips to signals dense list
+
+**Files:**
+- Modify: `app/web/main.py` (lines 134, 2229-2379)
+
+- [ ] **Step 1: Update allowed columns for signals**
+
+In `_QUEUE_ALLOWED_COLUMNS` (line 134), change the `"signals"` tuple to include SLA:
+
+```python
+"signals": ("id", "auction", "user", "risk", "score", "status", "created", "sla"),
+```
+
+- [ ] **Step 2: Add SLA parameters to signals handler**
+
+In the `signals` function signature (line 2230), add after `telemetry_preset_id`:
+
+```python
+sla_health: str = "all",
+aging: str = "all",
+```
+
+After line 2240 (`page = max(page, 0)`), add:
+
+```python
+sla_health_value = _parse_signal_sla_health_filter(sla_health)
+aging_value = _parse_signal_aging_bucket_filter(aging)
+now = datetime.now(UTC)
+signal_sla_thresholds = SLA_THRESHOLDS_BY_CONTEXT["risk"]
+```
+
+- [ ] **Step 3: Add SLA computation to each signal row**
+
+After line 2304 (`signal_priority = "high"`), add:
+
+```python
+signal_deadline = item.created_at + signal_sla_thresholds.warning_window if item.created_at else None
+sla_decision = decide_queue_sla_health(
+    queue_context="risk",
+    status=item.status,
+    created_at=item.created_at,
+    deadline_at=signal_deadline,
+    now=now,
+)
+if sla_decision.health_state in ("critical", "overdue"):
+    signal_priority = "urgent"
+sla_hint = f"SLA:{sla_decision.health_state} | age:{sla_decision.aging_bucket}"
+```
+
+- [ ] **Step 4: Add SLA cell to signal table rows**
+
+After the `created` cell (line 2319), add:
+
+```python
+f"<td data-col='sla' data-sla-health='{escape(sla_decision.health_state)}' data-aging-bucket='{escape(sla_decision.aging_bucket)}'><small>{escape(sla_hint)}</small></td>"
+```
+
+Update `_triage_detail_row` to `col_count=9` (was 8, now +1 for SLA).
+
+Update empty state colspan from 8 to 9.
+
+- [ ] **Step 5: Update table header**
+
+In the `<thead>`, add `<th data-col='sla'>SLA</th>` after `Created`.
+
+- [ ] **Step 6: Add SLA health and aging filter chips**
+
+Same pattern as complaints — add SLA health and aging chip toolbars after the status toolbar.
+
+Update `_signals_path` to accept `sla_health_value` and `aging_value` parameters.
+
+- [ ] **Step 7: Run linter and existing tests**
+
+Run: `cd /home/n501/VibeCoding/LiteAuction && python -m ruff check app/web/main.py && python -m pytest tests/ -q --timeout=30 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/web/main.py
+git commit -m "feat: add SLA health column and filter chips to signals dense list"
+```
+
+---
+
+### Task 4: Add evidence timeline detail section for complaints
+
+**Files:**
+- Modify: `app/web/main.py` (after `_render_appeal_detail_section`, around line 629)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_sla_complaints_signals.py`:
+
+```python
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from datetime import UTC, datetime
+
+from app.web.main import _render_complaint_detail_section
+
+
+@pytest.mark.asyncio
+async def test_complaint_detail_primary_section():
+    complaint = MagicMock()
+    complaint.id = 42
+    complaint.auction_id = "auction-uuid"
+    complaint.reporter_user_id = 1
+    complaint.target_user_id = 2
+    complaint.reason = "test reason"
+    complaint.status = "OPEN"
+    complaint.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    complaint.resolved_at = None
+    complaint.resolution_note = None
+    complaint.resolved_by_user_id = None
+
+    reporter = MagicMock()
+    reporter.id = 1
+    reporter.username = "reporter_user"
+    reporter.tg_user_id = 100
+
+    target = MagicMock()
+    target.id = 2
+    target.username = "target_user"
+    target.tg_user_id = 200
+
+    mod_log = MagicMock()
+    mod_log.id = 10
+    mod_log.action = "RESOLVE_COMPLAINT"
+    mod_log.actor_user_id = 3
+    mod_log.target_user_id = 2
+    mod_log.reason = "resolved reason"
+    mod_log.payload = {"rationale_artifact": {"summary": "test rationale", "actor_user_id": 3, "actor_tg_user_id": 300, "source": "web", "recorded_at": "2026-01-01T12:00:00+00:00", "immutable": True}}
+    mod_log.created_at = datetime(2026, 1, 2, tzinfo=UTC)
+
+    mock_session = AsyncMock()
+    mock_session.scalar = AsyncMock(side_effect=[complaint, reporter, target])
+    mock_session.execute = AsyncMock(return_value=MagicMock(scalars=MagicMock(return_value=MagicMock(all=MagicMock(return_value=[mod_log])))))
+
+    request = MagicMock()
+    result = await _render_complaint_detail_section(
+        mock_session,
+        row_id=42,
+        section="primary",
+        request=request,
+    )
+    assert result["ok"] is True
+    assert "timeline" in result["html"].lower() or "evidence" in result["html"].lower() or "complaint" in result["html"].lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/n501/VibeCoding/LiteAuction && python -m pytest tests/test_sla_complaints_signals.py::test_complaint_detail_primary_section -v -x 2>&1 | tail -20`
+Expected: FAIL — `ImportError` for `_render_complaint_detail_section`.
+
+- [ ] **Step 3: Write implementation**
+
+Add `_render_complaint_detail_section` after `_render_appeal_detail_section` (after line 629) in `app/web/main.py`:
+
+```python
+async def _render_complaint_detail_section(
+    session: AsyncSession,
+    *,
+    row_id: int,
+    section: str,
+    request: Request,
+) -> dict[str, object]:
+    complaint = await session.scalar(select(Complaint).where(Complaint.id == row_id))
+    if complaint is None:
+        return {"ok": False, "message": "Complaint not found"}
+
+    reporter = await session.scalar(select(User).where(User.id == complaint.reporter_user_id))
+    target = None
+    if complaint.target_user_id is not None:
+        target = await session.scalar(select(User).where(User.id == complaint.target_user_id))
+    resolver = None
+    if complaint.resolved_by_user_id is not None:
+        resolver = await session.scalar(select(User).where(User.id == complaint.resolved_by_user_id))
+
+    mod_logs = (
+        await session.execute(
+            select(ModerationLog)
+            .where(
+                ModerationLog.auction_id == complaint.auction_id,
+                ModerationLog.created_at >= complaint.created_at,
+            )
+            .order_by(ModerationLog.created_at.asc(), ModerationLog.id.asc())
+        )
+    ).scalars().all()
+
+    actor_ids = {log_row.actor_user_id for log_row in mod_logs}
+    actors_by_id: dict[int, User] = {}
+    if actor_ids:
+        actors = (await session.execute(select(User).where(User.id.in_(actor_ids)))).scalars().all()
+        actors_by_id = {item.id: item for item in actors}
+
+    if section == "primary":
+        timeline_events: list[tuple[datetime, str, str]] = []
+        _append_timeline_event(
+            timeline_events,
+            happened_at=complaint.created_at,
+            title="Complaint created",
+            details=f"reporter={_user_label(reporter, complaint.reporter_user_id)}, target={_user_label(target, complaint.target_user_id)}, reason={complaint.reason[:120]}",
+        )
+        _append_timeline_event(
+            timeline_events,
+            happened_at=complaint.resolved_at,
+            title=f"Complaint finalized: {complaint.status}",
+            details=f"resolver={_user_label(resolver, complaint.resolved_by_user_id)}, note={complaint.resolution_note or '-'}",
+        )
+        for log_row in mod_logs:
+            _append_timeline_event(
+                timeline_events,
+                happened_at=log_row.created_at,
+                title=f"Moderation action: {str(log_row.action)}",
+                details=f"actor={_user_label(actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id)}",
+            )
+
+        timeline_events.sort(key=lambda item: item[0])
+        timeline_html = _render_inline_timeline_html(timeline_events)
+        source_line = f"<p><b>Evidence timeline:</b> complaint #{complaint.id}</p>"
+        auction_link = f"<p class='section-note'><a href='{escape(_path_with_auth(request, f'/timeline/auction/{complaint.auction_id}'))}'>Open full auction timeline</a></p>"
+        return {
+            "ok": True,
+            "html": f"<div data-detail-state='loaded'>{source_line}{timeline_html}{auction_link}</div>",
+        }
+
+    if section == "secondary":
+        source_bits: list[str] = [
+            f"<p><b>Source evidence:</b> complaint #{complaint.id}, status={escape(str(complaint.status))}</p>",
+            f"<p class='section-note'>auction={escape(str(complaint.auction_id))}, reporter={escape(_user_label(reporter, complaint.reporter_user_id))}, target={escape(_user_label(target, complaint.target_user_id))}</p>",
+        ]
+        if complaint.resolution_note:
+            source_bits.append(f"<p class='section-note'>resolution={escape(complaint.resolution_note[:200])}</p>")
+
+        artifact_items: list[str] = []
+        for log_row in mod_logs:
+            payload = log_row.payload or {}
+            artifact = payload.get("rationale_artifact") if isinstance(payload, dict) else None
+            if not isinstance(artifact, dict):
+                continue
+            actor_label = _user_label(actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id)
+            summary = str(artifact.get("summary") or "-")
+            recorded_at = str(artifact.get("recorded_at") or _fmt_ts(log_row.created_at))
+            source_value = str(artifact.get("source") or "web")
+            artifact_items.append(
+                f"<li><b>{escape(str(log_row.action))}</b> - {escape(summary)}"
+                f"<div class='section-note'>actor={escape(actor_label)}, recorded_at={escape(recorded_at)}, source={escape(source_value)}</div></li>"
+            )
+        if artifact_items:
+            source_bits.append(f"<p><b>Rationale artifacts:</b></p><ul>{''.join(artifact_items)}</ul>")
+        else:
+            source_bits.append("<p class='section-note'>No rationale artifacts yet.</p>")
+
+        return {
+            "ok": True,
+            "html": f"<div data-detail-state='loaded'>{''.join(source_bits)}</div>",
+        }
+
+    audit_items = [
+        f"<li>complaint_id={complaint.id}</li>",
+        f"<li>created_at={escape(_fmt_ts(complaint.created_at))}</li>",
+        f"<li>status={escape(str(complaint.status))}</li>",
+        f"<li>resolver={escape(_user_label(resolver, complaint.resolved_by_user_id))}</li>",
+        "<li>record_policy=append_only</li>",
+    ]
+    for log_row in mod_logs:
+        audit_items.append(
+            f"<li>log#{log_row.id} {escape(str(log_row.action))} at {escape(_fmt_ts(log_row.created_at))} by {escape(_user_label(actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id))}</li>"
+        )
+    html = f"<div data-detail-state='loaded'><p><b>Audit trail (immutable)</b></p><ul>{''.join(audit_items)}</ul></div>"
+    return {"ok": True, "html": html}
+```
+
+- [ ] **Step 4: Wire into triage detail endpoint**
+
+In `action_triage_detail_section` (around line 4665), replace the placeholder content for `complaints` queue. Before the existing `if queue_value == "appeals":` block, add:
+
+```python
+if queue_value == "complaints":
+    async with SessionFactory() as session:
+        detail_payload = await _render_complaint_detail_section(
+            session,
+            row_id=row_id,
+            section=section_value,
+            request=request,
+        )
+    return {**detail_payload, **metadata}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /home/n501/VibeCoding/LiteAuction && python -m pytest tests/test_sla_complaints_signals.py -v -x 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/web/main.py tests/test_sla_complaints_signals.py
+git commit -m "feat: add evidence timeline detail section for complaints"
+```
+
+---
+
+### Task 5: Add evidence timeline detail section for signals
+
+**Files:**
+- Modify: `app/web/main.py` (after `_render_complaint_detail_section`)
+- Modify: `tests/test_sla_complaints_signals.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_sla_complaints_signals.py`:
+
+```python
+from app.web.main import _render_signal_detail_section
+
+
+@pytest.mark.asyncio
+async def test_signal_detail_primary_section():
+    signal = MagicMock()
+    signal.id = 55
+    signal.auction_id = "auction-uuid"
+    signal.user_id = 1
+    signal.score = 75
+    signal.status = "OPEN"
+    signal.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    signal.resolved_at = None
+    signal.resolution_note = None
+    signal.resolved_by_user_id = None
+
+    signal_user = MagicMock()
+    signal_user.id = 1
+    signal_user.username = "risky_user"
+    signal_user.tg_user_id = 100
+
+    mock_session = AsyncMock()
+    mock_session.scalar = AsyncMock(side_effect=[signal, signal_user])
+    mock_session.execute = AsyncMock(return_value=MagicMock(scalars=MagicMock(return_value=MagicMock(all=MagicMock(return_value=[])))))
+
+    request = MagicMock()
+    result = await _render_signal_detail_section(
+        mock_session,
+        row_id=55,
+        section="primary",
+        request=request,
+    )
+    assert result["ok"] is True
+    assert "signal" in result["html"].lower() or "evidence" in result["html"].lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/n501/VibeCoding/LiteAuction && python -m pytest tests/test_sla_complaints_signals.py::test_signal_detail_primary_section -v -x 2>&1 | tail -20`
+Expected: FAIL — `ImportError`.
+
+- [ ] **Step 3: Write implementation**
+
+Add `_render_signal_detail_section` after `_render_complaint_detail_section` in `app/web/main.py`:
+
+```python
+async def _render_signal_detail_section(
+    session: AsyncSession,
+    *,
+    row_id: int,
+    section: str,
+    request: Request,
+) -> dict[str, object]:
+    signal = await session.scalar(select(FraudSignal).where(FraudSignal.id == row_id))
+    if signal is None:
+        return {"ok": False, "message": "Signal not found"}
+
+    signal_user = await session.scalar(select(User).where(User.id == signal.user_id))
+    resolver = None
+    if signal.resolved_by_user_id is not None:
+        resolver = await session.scalar(select(User).where(User.id == signal.resolved_by_user_id))
+
+    mod_logs = (
+        await session.execute(
+            select(ModerationLog)
+            .where(
+                ModerationLog.auction_id == signal.auction_id,
+                ModerationLog.created_at >= signal.created_at,
+            )
+            .order_by(ModerationLog.created_at.asc(), ModerationLog.id.asc())
+        )
+    ).scalars().all()
+
+    actor_ids = {log_row.actor_user_id for log_row in mod_logs}
+    actors_by_id: dict[int, User] = {}
+    if actor_ids:
+        actors = (await session.execute(select(User).where(User.id.in_(actor_ids)))).scalars().all()
+        actors_by_id = {item.id: item for item in actors}
+
+    if section == "primary":
+        timeline_events: list[tuple[datetime, str, str]] = []
+        _append_timeline_event(
+            timeline_events,
+            happened_at=signal.created_at,
+            title="Fraud signal created",
+            details=f"user={_user_label(signal_user, signal.user_id)}, score={signal.score}, status={signal.status}",
+        )
+        _append_timeline_event(
+            timeline_events,
+            happened_at=signal.resolved_at,
+            title=f"Signal finalized: {signal.status}",
+            details=f"resolver={_user_label(resolver, signal.resolved_by_user_id)}, note={signal.resolution_note or '-'}",
+        )
+        for log_row in mod_logs:
+            _append_timeline_event(
+                timeline_events,
+                happened_at=log_row.created_at,
+                title=f"Moderation action: {str(log_row.action)}",
+                details=f"actor={_user_label(actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id)}",
+            )
+
+        timeline_events.sort(key=lambda item: item[0])
+        timeline_html = _render_inline_timeline_html(timeline_events)
+        source_line = f"<p><b>Evidence timeline:</b> fraud signal #{signal.id}</p>"
+        auction_link = f"<p class='section-note'><a href='{escape(_path_with_auth(request, f'/timeline/auction/{signal.auction_id}'))}'>Open full auction timeline</a></p>"
+        return {
+            "ok": True,
+            "html": f"<div data-detail-state='loaded'>{source_line}{timeline_html}{auction_link}</div>",
+        }
+
+    if section == "secondary":
+        source_bits: list[str] = [
+            f"<p><b>Source evidence:</b> signal #{signal.id}, score={signal.score}, status={escape(str(signal.status))}</p>",
+            f"<p class='section-note'>auction={escape(str(signal.auction_id))}, user={escape(_user_label(signal_user, signal.user_id))}</p>",
+        ]
+        if signal.resolution_note:
+            source_bits.append(f"<p class='section-note'>resolution={escape(signal.resolution_note[:200])}</p>")
+
+        artifact_items: list[str] = []
+        for log_row in mod_logs:
+            payload = log_row.payload or {}
+            artifact = payload.get("rationale_artifact") if isinstance(payload, dict) else None
+            if not isinstance(artifact, dict):
+                continue
+            actor_label = _user_label(actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id)
+            summary = str(artifact.get("summary") or "-")
+            recorded_at = str(artifact.get("recorded_at") or _fmt_ts(log_row.created_at))
+            source_value = str(artifact.get("source") or "web")
+            artifact_items.append(
+                f"<li><b>{escape(str(log_row.action))}</b> - {escape(summary)}"
+                f"<div class='section-note'>actor={escape(actor_label)}, recorded_at={escape(recorded_at)}, source={escape(source_value)}</div></li>"
+            )
+        if artifact_items:
+            source_bits.append(f"<p><b>Rationale artifacts:</b></p><ul>{''.join(artifact_items)}</ul>")
+        else:
+            source_bits.append("<p class='section-note'>No rationale artifacts yet.</p>")
+
+        return {
+            "ok": True,
+            "html": f"<div data-detail-state='loaded'>{''.join(source_bits)}</div>",
+        }
+
+    audit_items = [
+        f"<li>signal_id={signal.id}</li>",
+        f"<li>created_at={escape(_fmt_ts(signal.created_at))}</li>",
+        f"<li>score={signal.score}</li>",
+        f"<li>status={escape(str(signal.status))}</li>",
+        f"<li>resolver={escape(_user_label(resolver, signal.resolved_by_user_id))}</li>",
+        "<li>record_policy=append_only</li>",
+    ]
+    for log_row in mod_logs:
+        audit_items.append(
+            f"<li>log#{log_row.id} {escape(str(log_row.action))} at {escape(_fmt_ts(log_row.created_at))} by {escape(_user_label(actors_by_id.get(log_row.actor_user_id), log_row.actor_user_id))}</li>"
+        )
+    html = f"<div data-detail-state='loaded'><p><b>Audit trail (immutable)</b></p><ul>{''.join(audit_items)}</ul></div>"
+    return {"ok": True, "html": html}
+```
+
+- [ ] **Step 4: Wire into triage detail endpoint**
+
+Add before the existing appeals block in `action_triage_detail_section`:
+
+```python
+if queue_value == "signals":
+    async with SessionFactory() as session:
+        detail_payload = await _render_signal_detail_section(
+            session,
+            row_id=row_id,
+            section=section_value,
+            request=request,
+        )
+    return {**detail_payload, **metadata}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /home/n501/VibeCoding/LiteAuction && python -m pytest tests/test_sla_complaints_signals.py -v -x 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/web/main.py tests/test_sla_complaints_signals.py
+git commit -m "feat: add evidence timeline detail section for fraud signals"
+```
+
+---
+
+### Task 6: Unit tests for SLA derivation on complaints and signals (TEST-21)
+
+**Files:**
+- Modify: `tests/test_sla_complaints_signals.py`
+
+- [ ] **Step 1: Write SLA derivation tests**
+
+Add to `tests/test_sla_complaints_signals.py`:
+
+```python
+from datetime import timedelta
+from app.services.queue_sla_health_service import (
+    SLA_THRESHOLDS_BY_CONTEXT,
+    decide_queue_sla_health,
+)
+
+
+def test_complaint_sla_healthy():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    created = now - timedelta(minutes=30)
+    thresholds = SLA_THRESHOLDS_BY_CONTEXT["moderation"]
+    deadline = created + thresholds.warning_window + timedelta(hours=1)
+    result = decide_queue_sla_health(
+        queue_context="moderation", status="OPEN", created_at=created, deadline_at=deadline, now=now,
+    )
+    assert result.health_state == "healthy"
+    assert result.aging_bucket == "fresh"
+    assert result.queue_context == "moderation"
+
+
+def test_complaint_sla_warning():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    thresholds = SLA_THRESHOLDS_BY_CONTEXT["moderation"]
+    created = now - timedelta(hours=3)
+    deadline = now + thresholds.critical_window + timedelta(minutes=10)
+    result = decide_queue_sla_health(
+        queue_context="moderation", status="OPEN", created_at=created, deadline_at=deadline, now=now,
+    )
+    assert result.health_state == "warning"
+    assert result.aging_bucket == "aging"
+
+
+def test_complaint_sla_critical():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    thresholds = SLA_THRESHOLDS_BY_CONTEXT["moderation"]
+    created = now - timedelta(hours=5)
+    deadline = now + timedelta(minutes=15)
+    result = decide_queue_sla_health(
+        queue_context="moderation", status="OPEN", created_at=created, deadline_at=deadline, now=now,
+    )
+    assert result.health_state == "critical"
+    assert result.aging_bucket == "aging"
+
+
+def test_complaint_sla_overdue():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    created = now - timedelta(hours=10)
+    deadline = now - timedelta(hours=1)
+    result = decide_queue_sla_health(
+        queue_context="moderation", status="OPEN", created_at=created, deadline_at=deadline, now=now,
+    )
+    assert result.health_state == "overdue"
+    assert result.aging_bucket == "aging"
+    assert result.countdown_seconds == 0
+
+
+def test_complaint_sla_closed():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    created = now - timedelta(hours=10)
+    result = decide_queue_sla_health(
+        queue_context="moderation", status="RESOLVED", created_at=created, deadline_at=None, now=now,
+    )
+    assert result.health_state == "closed"
+    assert result.aging_bucket == "closed"
+
+
+def test_complaint_sla_no_deadline():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    created = now - timedelta(hours=2)
+    result = decide_queue_sla_health(
+        queue_context="moderation", status="OPEN", created_at=created, deadline_at=None, now=now,
+    )
+    assert result.health_state == "no_sla"
+    assert result.aging_bucket == "fresh"
+
+
+def test_signal_sla_healthy():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    created = now - timedelta(minutes=15)
+    thresholds = SLA_THRESHOLDS_BY_CONTEXT["risk"]
+    deadline = created + thresholds.warning_window + timedelta(hours=1)
+    result = decide_queue_sla_health(
+        queue_context="risk", status="OPEN", created_at=created, deadline_at=deadline, now=now,
+    )
+    assert result.health_state == "healthy"
+    assert result.aging_bucket == "fresh"
+    assert result.queue_context == "risk"
+
+
+def test_signal_aging_bucket_stale():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    thresholds = SLA_THRESHOLDS_BY_CONTEXT["risk"]
+    created = now - thresholds.aging_aging_max - timedelta(minutes=1)
+    result = decide_queue_sla_health(
+        queue_context="risk", status="OPEN", created_at=created, deadline_at=None, now=now,
+    )
+    assert result.aging_bucket == "stale"
+
+
+def test_signal_aging_bucket_critical():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    thresholds = SLA_THRESHOLDS_BY_CONTEXT["risk"]
+    created = now - thresholds.aging_stale_max - timedelta(hours=1)
+    result = decide_queue_sla_health(
+        queue_context="risk", status="OPEN", created_at=created, deadline_at=None, now=now,
+    )
+    assert result.aging_bucket == "critical"
+
+
+def test_unknown_queue_context_fallback():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    created = now - timedelta(hours=1)
+    result = decide_queue_sla_health(
+        queue_context="nonexistent", status="OPEN", created_at=created, deadline_at=None, now=now,
+    )
+    assert result.queue_context == "moderation"
+    assert result.fallback_applied is True
+    assert "unknown_queue_context" in result.fallback_notes
+
+
+def test_queue_filter_continuity_preserves_existing_filters():
+    from app.web.main import _parse_complaint_sla_health_filter, _parse_complaint_aging_bucket_filter
+    sla = _parse_complaint_sla_health_filter("critical")
+    aging = _parse_complaint_aging_bucket_filter("fresh")
+    assert sla == "critical"
+    assert aging == "fresh"
+```
+
+- [ ] **Step 2: Run all unit tests**
+
+Run: `cd /home/n501/VibeCoding/LiteAuction && python -m pytest tests/test_sla_complaints_signals.py -v 2>&1 | tail -30`
+Expected: All tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_sla_complaints_signals.py
+git commit -m "test: add SLA derivation and filter continuity tests for complaints and signals"
+```
+
+---
+
+### Task 7: Integration tests for evidence timeline and telemetry (TEST-22)
+
+**Files:**
+- Create: `tests/integration/test_evidence_timeline_and_telemetry.py`
+
+- [ ] **Step 1: Write integration tests**
+
+Create `tests/integration/test_evidence_timeline_and_telemetry.py`:
+
+```python
+import pytest
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+
+from app.db.models import Complaint, FraudSignal, ModerationLog, User, AdminQueuePresetTelemetryEvent
+from app.services.admin_queue_preset_telemetry_service import (
+    load_workflow_preset_telemetry_segments,
+    record_workflow_preset_telemetry_event,
+)
+from app.web.auth import AdminAuthContext
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _ensure_user(session, *, tg_user_id: int, username: str = "test_user") -> User:
+    user = await session.scalar(select(User).where(User.tg_user_id == tg_user_id))
+    if user is not None:
+        return user
+    user = User(tg_user_id=tg_user_id, username=username)
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def test_complaint_evidence_timeline_rendering(db_session):
+    reporter = await _ensure_user(db_session, tg_user_id=90001, username="reporter_tl")
+    target = await _ensure_user(db_session, tg_user_id=90002, username="target_tl")
+    actor = await _ensure_user(db_session, tg_user_id=90003, username="actor_tl")
+
+    complaint = Complaint(
+        auction_id=None,
+        reporter_user_id=reporter.id,
+        target_user_id=target.id,
+        reason="Integration test complaint",
+        status="OPEN",
+    )
+    db_session.add(complaint)
+    await db_session.flush()
+
+    mod_log = ModerationLog(
+        actor_user_id=actor.id,
+        target_user_id=target.id,
+        auction_id=None,
+        action="RESOLVE_COMPLAINT",
+        reason="resolved in test",
+        payload={"rationale_artifact": {"summary": "test rationale artifact", "actor_user_id": actor.id, "actor_tg_user_id": 90003, "source": "web", "recorded_at": datetime.now(UTC).isoformat(), "immutable": True}},
+    )
+    db_session.add(mod_log)
+    await db_session.flush()
+
+    from app.web.main import _render_complaint_detail_section
+    from unittest.mock import MagicMock
+
+    request = MagicMock()
+    result = await _render_complaint_detail_section(
+        db_session,
+        row_id=complaint.id,
+        section="primary",
+        request=request,
+    )
+    assert result["ok"] is True
+    html = result["html"]
+    assert "Complaint created" in html
+    assert "Moderation action" in html
+
+    result_secondary = await _render_complaint_detail_section(
+        db_session,
+        row_id=complaint.id,
+        section="secondary",
+        request=request,
+    )
+    assert result_secondary["ok"] is True
+    assert "test rationale artifact" in result_secondary["html"]
+
+    result_audit = await _render_complaint_detail_section(
+        db_session,
+        row_id=complaint.id,
+        section="audit",
+        request=request,
+    )
+    assert result_audit["ok"] is True
+    assert "append_only" in result_audit["html"]
+
+
+async def test_signal_evidence_timeline_rendering(db_session):
+    signal_user = await _ensure_user(db_session, tg_user_id=90011, username="signal_user_tl")
+    resolver = await _ensure_user(db_session, tg_user_id=90012, username="resolver_tl")
+
+    signal = FraudSignal(
+        auction_id=None,
+        user_id=signal_user.id,
+        score=85,
+        status="OPEN",
+        reason="integration test signal",
+    )
+    db_session.add(signal)
+    await db_session.flush()
+
+    from app.web.main import _render_signal_detail_section
+    from unittest.mock import MagicMock
+
+    request = MagicMock()
+    result = await _render_signal_detail_section(
+        db_session,
+        row_id=signal.id,
+        section="primary",
+        request=request,
+    )
+    assert result["ok"] is True
+    assert "Fraud signal created" in result["html"]
+    assert "score=85" in result["html"]
+
+
+async def test_telemetry_trend_aggregation(db_session):
+    auth = AdminAuthContext(authorized=True, via="token", role="admin", can_manage=True, scopes=frozenset({"user_ban"}), tg_user_id=90050)
+
+    now = datetime.now(UTC)
+    recent_time = now - timedelta(hours=12)
+    old_time = now - timedelta(hours=10 * 24)
+
+    for i in range(6):
+        event = AdminQueuePresetTelemetryEvent(
+            queue_context="moderation",
+            queue_key="complaints",
+            preset_id=1,
+            action="select",
+            actor_subject_key="test_actor",
+            time_to_action_ms=500 + i * 100,
+            reopen_signal=False,
+            filter_churn_count=i,
+            created_at=recent_time + timedelta(minutes=i),
+        )
+        db_session.add(event)
+
+    for i in range(6):
+        event = AdminQueuePresetTelemetryEvent(
+            queue_context="moderation",
+            queue_key="complaints",
+            preset_id=1,
+            action="select",
+            actor_subject_key="test_actor",
+            time_to_action_ms=200 + i * 50,
+            reopen_signal=False,
+            filter_churn_count=i,
+            created_at=old_time + timedelta(minutes=i),
+        )
+        db_session.add(event)
+
+    await db_session.flush()
+
+    segments = await load_workflow_preset_telemetry_segments(
+        db_session,
+        queue_context="moderation",
+        lookback_hours=24 * 7,
+    )
+    assert len(segments) > 0
+    matching = [s for s in segments if s.get("preset_id") == 1 and s.get("queue_context") == "moderation"]
+    assert len(matching) > 0
+    segment = matching[0]
+    assert int(segment["events_total"]) == 6
+    assert segment["time_to_action_delta_ms"] is not None
+
+
+async def test_telemetry_low_sample_guardrail(db_session):
+    auth = AdminAuthContext(authorized=True, via="token", role="admin", can_manage=True, scopes=frozenset({"user_ban"}), tg_user_id=90051)
+
+    now = datetime.now(UTC)
+    recent_time = now - timedelta(hours=12)
+
+    for i in range(2):
+        event = AdminQueuePresetTelemetryEvent(
+            queue_context="risk",
+            queue_key="signals",
+            preset_id=None,
+            action="save",
+            actor_subject_key="guardrail_actor",
+            time_to_action_ms=100,
+            reopen_signal=False,
+            filter_churn_count=0,
+            created_at=recent_time + timedelta(minutes=i),
+        )
+        db_session.add(event)
+
+    await db_session.flush()
+
+    segments = await load_workflow_preset_telemetry_segments(
+        db_session,
+        queue_context="risk",
+        lookback_hours=24 * 7,
+    )
+    if segments:
+        assert segments[0].get("trend_low_sample_guardrail") is True
+
+
+async def test_rationale_artifact_immutability(db_session):
+    actor = await _ensure_user(db_session, tg_user_id=90061, username="immut_actor")
+
+    log = ModerationLog(
+        actor_user_id=actor.id,
+        target_user_id=None,
+        auction_id=None,
+        action="FREEZE_AUCTION",
+        reason="test immutability",
+        payload={"rationale_artifact": {"summary": "original summary", "actor_user_id": actor.id, "actor_tg_user_id": 90061, "source": "web", "recorded_at": datetime.now(UTC).isoformat(), "immutable": True}},
+    )
+    db_session.add(log)
+    await db_session.flush()
+
+    loaded = await db_session.scalar(select(ModerationLog).where(ModerationLog.id == log.id))
+    artifact = loaded.payload["rationale_artifact"]
+    assert artifact["immutable"] is True
+    assert artifact["summary"] == "original summary"
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `cd /home/n501/VibeCoding/LiteAuction && RUN_INTEGRATION_TESTS=1 TEST_DATABASE_URL=postgresql+asyncpg://auction:auction@localhost:5432/auction_test python -m pytest tests/integration/test_evidence_timeline_and_telemetry.py -v -x 2>&1 | tail -30`
+Expected: All integration tests PASS (requires test DB).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_evidence_timeline_and_telemetry.py
+git commit -m "test: add integration tests for evidence timeline and telemetry trend aggregation"
+```
+
+---
+
+### Task 8: Final validation and cleanup
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run full lint check**
+
+Run: `cd /home/n501/VibeCoding/LiteAuction && python -m ruff check app tests`
+Expected: No errors.
+
+- [ ] **Step 2: Run full unit test suite**
+
+Run: `cd /home/n501/VibeCoding/LiteAuction && python -m pytest tests/ -q --timeout=30`
+Expected: All tests pass.
+
+- [ ] **Step 3: Run ruff format check**
+
+Run: `cd /home/n501/VibeCoding/LiteAuction && python -m ruff format --check app tests`
+Expected: No formatting issues.
+
+- [ ] **Step 4: Update planning status**
+
+Update `planning/STATUS.md` with v1.2 completion status.
+Update `.planning/STATE.md` progress to reflect v1.2 implementation.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add planning/STATUS.md .planning/STATE.md
+git commit -m "docs: update planning status for v1.2 queue trust signals implementation"
+```

--- a/docs/superpowers/specs/2026-04-11-command-reorganization-design.md
+++ b/docs/superpowers/specs/2026-04-11-command-reorganization-design.md
@@ -1,0 +1,128 @@
+# Command Reorganization: Hub-and-Spoke Design
+
+**Date:** 2026-04-11
+**Status:** Approved
+**Scope:** Slash commands in private chat + Telegram menu
+
+## Problem
+
+~30+ slash commands in private chat create chaos. Users see a long command list in Telegram menu with irrelevant options (emoji tools, feedback, trade feedback, points). Moderators have 20+ commands that clutter the interface. The bot is pivoting to focus on PC hardware auctions published via `/publish` in a single trading chat.
+
+## Decision: Hub-and-Spoke
+
+Approach A (Hub-and-Spoke): `/start` is the single navigation hub. All user actions accessible via inline buttons. Minimal commands registered in Telegram menu.
+
+## Section 1: Command Map
+
+### Public commands in Telegram menu (4 commands)
+
+| Command | Where | Purpose |
+|---|---|---|
+| `/start` | Private chat | Main hub: inline buttons for all actions |
+| `/newauction` | Private, supergroup | Shortcut to create auction |
+| `/guarant` | Private chat | Shortcut to guarantor request |
+| `/publish` | Group, supergroup | Publish lot to trading chat |
+| `/cancel` | Private, supergroup | Cancel current FSM action |
+
+### Hidden commands (handlers stay, removed from menu)
+
+All existing command handlers remain functional. Users who know the commands can type them manually.
+
+**User commands hidden from menu:**
+- `/points` — points system accessible but not promoted
+- `/bug`, `/suggest`, `/boostfeedback` — feedback accessible but not promoted
+- `/boostappeal` — appeal boost accessible but not promoted
+- `/tradefeedback` — trade feedback accessible but not promoted
+- `/emojiid`, `/effectid` — emoji tools accessible but not promoted
+- `/topics`, `/settings` — replaced by buttons in `/start` hub
+
+**Moderator commands (already restricted to mod-chat topics):**
+- All 20+ mod commands (`/freeze`, `/ban`, `/end`, `/modpanel`, `/modstats`, etc.) remain as hidden shortcuts for experienced moderators
+- `/modpanel` also accessible via button in `/start` for moderators
+
+### Commands NOT removed
+
+No handlers are deleted. No service files are touched. All existing functionality remains operational.
+
+## Section 2: `/start` Hub Structure
+
+### Main menu keyboard
+
+```
++---------------------+
+|  📦 Создать лот       |  -> callback: create:new
++---------------------+
+|  📋 Мои лоты          |  -> callback: dash:my_auctions
++---------------------+
+|  🛡 Гарант            |  -> callback: dash:guarant
+|  🔔 Уведомления       |  -> callback: dash:notifications
+|  ⚙️ Настройки          |  -> callback: dash:settings
++---------------------+
+|  🛠 Модерация          |  -> callback: mod:panel  (moderators only)
++---------------------+
+```
+
+### Button behaviors
+
+- **Создать лот** (`create:new`) — existing handler, starts auction creation FSM
+- **Мои лоты** (`dash:my_auctions`) — existing handler, shows seller's auction list with statuses
+- **Гарант** (`dash:guarant`) — NEW callback, triggers guarantor request flow (same as `/guarant`)
+- **Уведомления** (`dash:notifications`) — NEW callback, shows notification settings (quiet hours, snooze, event toggles)
+- **Настройки** (`dash:settings`) — existing callback, shows topic management and settings
+- **Модерация** (`mod:panel`) — existing callback, only shown when `show_moderation_button=True`
+
+### Removed button
+
+- **Баланс** (`dash:balance`) — removed from main menu keyboard. Points system not promoted.
+
+### Sub-menu navigation
+
+All sub-menus use callback buttons with "← Назад" to return to the previous level.
+
+- **Уведомления** sub-menu: current notification settings, quiet hours toggle, snooze, per-event toggles. Reuses logic from existing `/settings` and notification callback handlers.
+- **Гарант** sub-menu: submit request, view current request status. Reuses logic from `handlers/guarantor.py`.
+- **Настройки** sub-menu: private topics (on/off), topic management. Reuses logic from existing `/topics` and `/settings` handlers.
+
+## Section 3: Implementation Scope
+
+### What changes
+
+1. **`app/bot/keyboards/auction.py`** — `start_private_keyboard()`:
+   - Remove "Баланс" button
+   - Add "Гарант" button (`dash:guarant`)
+   - Add "Уведомления" button (`dash:notifications`)
+   - Rename "Создать аукцион" → "Создать лот"
+   - Rename "Мои аукционы" → "Мои лоты"
+
+2. **`app/bot/handlers/start.py`** — add 2 new callback handlers:
+   - `dash:guarant` — invokes guarantor intake flow (reuse logic from `handlers/guarantor.py` service layer)
+   - `dash:notifications` — renders notification settings view (reuse logic from `start_notification_views.py`)
+
+3. **Telegram menu commands** — update via `BotFather` or `bot.set_my_commands()`:
+   - Register only: `/start`, `/newauction`, `/guarant`, `/publish`, `/cancel`
+   - All other commands become unlisted but functional
+
+### What does NOT change
+
+- All existing command handlers remain registered and functional
+- No service files are modified
+- No handler files are deleted
+- All moderator commands stay as-is
+- Inline query publication stays as-is
+- Channel DM intake stays as-is
+- Suggested posts stays as-is
+
+## Section 4: Risk Assessment
+
+- **Low risk:** Adding buttons to keyboard — purely additive
+- **Low risk:** Adding callback handlers — new code, doesn't touch existing
+- **Low risk:** Hiding commands from menu — handlers still work
+- **No risk:** No deletions, no service layer changes
+
+## Success Criteria
+
+1. `/start` shows new hub keyboard with 5-6 buttons
+2. All new buttons navigate correctly to their targets
+3. Existing commands (`/points`, `/bug`, etc.) still work when typed manually
+4. Only 5 commands appear in Telegram menu
+5. Moderator button only visible to moderators

--- a/docs/superpowers/specs/2026-04-11-post-auction-ux-design.md
+++ b/docs/superpowers/specs/2026-04-11-post-auction-ux-design.md
@@ -1,0 +1,282 @@
+# Post-Auction UX Redesign
+
+**Date:** 2026-04-11
+**Status:** Approved
+**Scope:** Improve notifications, communication, and post-auction flow after deal completion.
+
+## Problem
+
+When an auction completes, users receive minimal messages with almost no actionable information:
+
+- Seller gets: `"Лот #{id} завершен."`
+- Winner gets: `"Вы выиграли лот #{id}."`
+- Only button: "Открыть пост лота" (links back to ended auction post)
+
+No way for seller and winner to contact each other. No guarantor reminder. No feedback prompt. No deal details (price, counterparty).
+
+## Solution Overview
+
+Redesign all post-auction notifications using "Approach A: Everything in one message" — show full deal info, next-step instructions, guarantor memo, and action buttons in a single rich notification. Introduce a new **Deal Topic** system for mediated communication between seller and winner through the bot.
+
+## Scenarios
+
+### Scenario 1: Seller — Auction Ended with Winner
+
+**Recipient:** Seller (via private topic in bot)
+**Trigger:** Timer expiration, buyout, or moderator `/end`
+
+**Message structure:**
+
+```
+🏆 Аукцион завершён!
+
+Лот: #a1b2c3d4
+Описание: <truncated to ~80 chars>
+Финальная цена: 15 000 ₽
+Победитель: @winner_username
+
+📋 Следующие шаги:
+1. Нажмите «Написать победителю» — откроется топик сделки
+2. Договоритесь о способе передачи товара и оплаты
+3. После завершения — оставьте отзыв
+
+🛡 Гарант — ваша безопасность
+Если сумма сделки значительная или вы впервые работаете с покупателем —
+запросите гаранта. Гарант выступит посредником и обеспечит защиту обеих сторон.
+Стоимость: бесплатно для участников с репутацией 50+
+
+[💬 Написать победителю]
+[🛡 Запросить гаранта] [⭐ Оставить отзыв]
+[📄 Открыть пост лота]
+```
+
+**Keyboard:**
+- Row 1: `💬 Написать победителю` — creates deal topic, opens it for seller
+- Row 2: `🛡 Запросить гаранта` — starts guarantor FSM with pre-filled auction_id
+- Row 2: `⭐ Оставить отзыв` — starts feedback FSM
+- Row 3: `📄 Открыть пост лота` — URL button (existing)
+
+### Scenario 2: Winner — You Won
+
+**Recipient:** Winner (via private topic in bot)
+**Trigger:** Same as Scenario 1
+
+Identical structure to Scenario 1, with differences:
+- Title: `🎉 Вы выиграли аукцион!`
+- Price label: `Ваша цена:` instead of `Финальная цена:`
+- Counterparty: `Продавец: @seller_username` instead of `Победитель`
+- Button: `💬 Написать продавцу`
+
+### Scenario 3: Seller — No Bids
+
+**Recipient:** Seller
+**Trigger:** Auction expires with 0 bids
+
+```
+⏰ Аукцион завершён без ставок
+
+Лот: #a1b2c3d4
+Описание: <truncated>
+Стартовая цена: 10 000 ₽
+Ставок: 0
+
+💡 Совет: Попробуйте изменить стартовую цену или описание
+и опубликуйте лот заново.
+
+[🔄 Опубликовать заново] [📄 Открыть пост лота]
+```
+
+**Keyboard:**
+- `🔄 Опубликовать заново` — re-creates auction with same data, resets status to DRAFT
+- `📄 Открыть пост лота` — existing URL button
+
+### Scenario 4: Deal Topic
+
+**What:** A new forum topic created in each participant's private chat with the bot, enabling mediated communication.
+
+**Creation trigger:** Either participant clicks `💬 Написать ...` button from Scenario 1 or 2.
+
+**Mechanics:**
+1. Bot creates a forum topic in the seller's private chat: `🤝 Сделка #a1b2c3d4`
+2. Bot creates a forum topic in the winner's private chat: `🤝 Сделка #a1b2c3d4`
+3. Both topics get an intro message with deal details and a safety reminder
+4. When seller writes in their deal topic → message is forwarded to winner's deal topic (prefixed with sender identity)
+5. When winner writes → forwarded to seller's deal topic
+
+**Intro message in each topic:**
+```
+🤝 Топик сделки создан
+
+Лот: #a1b2c3d4 — iPhone 15 Pro Max 256GB
+Цена: 15 000 ₽
+Участники: @seller (продавец) и @winner (победитель)
+
+Все сообщения здесь будут пересылаться вашему контрагенту.
+Будьте вежливы и обсуждайте только сделку.
+
+🛡 Совет по безопасности
+Для защиты обеих сторон вы можете запросить гаранта — нажав кнопку ниже.
+```
+
+**Buttons on intro message:**
+- `🛡 Запросить гаранта`
+- `⭐ Оставить отзыв`
+- `⚠ Жалоба`
+
+**Message forwarding format:**
+- From seller → winner: `@seller_username (продавец):\n<text>`
+- From winner → seller: `@winner_username (победитель):\n<text>`
+- Photos/files forwarded as-is with caption prefix
+
+### Scenario 5: Moderation Channel
+
+**Recipient:** Moderation topic section
+
+Enhanced version of current moderation notification:
+
+```
+🏁 Лот #a1b2c3d4 завершён по таймеру
+
+Описание: iPhone 15 Pro Max 256GB
+Финальная цена: 15 000 ₽
+Ставок: 7
+
+Продавец: @seller_username (tg: 123456789)
+Победитель: @winner_username (tg: 987654321)
+Репутация продавца: 42
+Репутация победителя: 15
+
+🤝 Топик сделки: создан автоматически
+🛡 Гарант: не запрошен
+
+[📄 Открыть пост лота] [⚠ Заморозить]
+```
+
+## Data Model Changes
+
+### New model: `DealTopic`
+
+```python
+class DealTopic(Base):
+    __tablename__ = "deal_topics"
+
+    id: Mapped[uuid.UUID]          # PK
+    auction_id: Mapped[uuid.UUID]  # FK -> auctions.id
+    seller_topic_id: Mapped[int]   # forum topic ID in seller's private chat
+    winner_topic_id: Mapped[int | None]  # forum topic ID in winner's chat (None until winner opens)
+    status: Mapped[DealTopicStatus]  # ACTIVE, CLOSED
+    created_at: Mapped[datetime]
+    closed_at: Mapped[datetime | None]
+```
+
+### New enum: `DealTopicStatus`
+
+```python
+class DealTopicStatus(str, Enum):
+    ACTIVE = "ACTIVE"
+    CLOSED = "CLOSED"
+```
+
+### Modified model: `GuarantorRequest`
+
+Add optional `auction_id` field:
+
+```python
+auction_id: Mapped[uuid.UUID | None]  # FK -> auctions.id, nullable
+```
+
+Alembic migration required. Backward-safe: existing rows get NULL.
+
+## Notification Copy Changes
+
+All templates in `app/services/notification_copy_service.py` are replaced with rich versions. The copy service gains new parameters:
+
+- `auction_id: str` — full short ID
+- `description: str` — truncated to ~80 chars
+- `final_price: int` — winning bid amount
+- `counterparty_mention: str` — formatted mention of the other party
+- `counterparty_role: str` — "продавец" or "победитель"
+- `auction_title: str | None` — for deal topic header
+
+New functions:
+- `seller_completion_message(...)` — Scenario 1
+- `winner_completion_message(...)` — Scenario 2
+- `seller_no_bids_message(...)` — Scenario 3
+- `deal_topic_intro(...)` — Scenario 4 intro
+- `moderation_completion_message(...)` — Scenario 5
+
+## Keyboard Changes
+
+New keyboards in `app/bot/keyboards/auction.py`:
+
+- `deal_completion_keyboard(auction_id: str, post_url: str | None, is_seller: bool)` — Scenarios 1, 2
+- `no_bids_keyboard(auction_id: str, post_url: str | None)` — Scenario 3
+- `deal_topic_keyboard(auction_id: str)` — Scenario 4 buttons on intro message
+- `moderation_completion_keyboard(auction_id: str, post_url: str | None)` — Scenario 5
+
+Callback data prefixes:
+- `deal:write:<auction_id>` — open/create deal topic
+- `deal:guarant:<auction_id>` — start guarantor request
+- `deal:feedback:<auction_id>` — start feedback FSM
+- `deal:republish:<auction_id>` — republish auction without bids
+
+## Handler Changes
+
+### New handler: `deal_topic.py`
+
+- `handle_deal_write` — callback `deal:write:*`, creates DealTopic + forum topics, sends intro, opens topic for user
+- `handle_deal_message` — listens for messages in deal topics, forwards to counterparty
+- `handle_deal_guarant` — callback `deal:guarant:*`, starts guarantor FSM with pre-filled auction_id
+- `handle_deal_feedback` — callback `deal:feedback:*`, starts feedback FSM
+- `handle_deal_republish` — callback `deal:republish:*`, clones auction to DRAFT
+
+### Modified handlers
+
+- `bid_actions.py:_notify_auction_finish` — use new rich templates + keyboards
+- `auction_service.py:finalize_expired_auctions` — pass AuctionView data to notifications
+- `auction_service.py:_finalize_auction_locked` — return rich FinalizeResult with price + description
+- `moderation.py:mod_end` — use `_finalize_auction_locked` (fixes missing reputation award)
+
+## FSM Flows
+
+### Feedback FSM (existing mechanism, triggered by inline button)
+
+1. User clicks `⭐ Оставить отзыв`
+2. Bot asks: "Оцените сделку" with inline buttons: ⭐⭐⭐⭐⭐ (1-5)
+3. User selects rating
+4. Bot asks: "Комментарий (необязательно)" — text input or skip button
+5. Bot saves via `trade_feedback_service.submit_trade_feedback`
+6. Confirmation message
+
+### Guarantor FSM (modified to accept auction_id)
+
+1. User clicks `🛡 Запросить гаранта`
+2. If triggered from deal completion — auction_id is pre-filled, bot asks "Опишите запрос" (or uses default text)
+3. If triggered from deal topic — same, with auction_id pre-filled
+4. Creates `GuarantorRequest` with `auction_id` set
+
+## Edge Cases
+
+- **Winner has no username:** Use `tg://user?id=<tg_id>` mention format (existing `_format_user_mention`)
+- **Auction ended by moderator:** Same rich notification, with `Модерация:` prefix in title
+- **Buyout vs timer:** Same notification template, buyout adds `(выкуп)` to title
+- **Deal topic already exists:** `deal:write:*` opens existing topic instead of creating new one
+- **User blocks bot:** Private topic delivery fails silently (existing behavior)
+- **One party closes topic:** DealTopic status → CLOSED, both parties notified
+
+## Files Affected
+
+| File | Change |
+|------|--------|
+| `app/services/notification_copy_service.py` | New rich message templates |
+| `app/bot/keyboards/auction.py` | New keyboard builders |
+| `app/bot/handlers/deal_topic.py` | **New** — deal topic handler |
+| `app/bot/handlers/bid_actions.py` | Updated `_notify_auction_finish` |
+| `app/services/auction_service.py` | Rich FinalizeResult, updated notifications |
+| `app/services/deal_topic_service.py` | **New** — deal topic CRUD + forwarding |
+| `app/db/models.py` | New `DealTopic` model, `GuarantorRequest.auction_id` |
+| `app/db/enums.py` | New `DealTopicStatus` enum |
+| `app/bot/handlers/guarantor.py` | Accept pre-filled auction_id |
+| `app/bot/handlers/trade_feedback.py` | FSM trigger from inline button |
+| `app/bot/handlers/moderation.py` | Use `_finalize_auction_locked` for `/end` |
+| `alembic/versions/xxx_add_deal_topics.py` | **New** migration |

--- a/docs/superpowers/specs/2026-04-11-reputation-score-design.md
+++ b/docs/superpowers/specs/2026-04-11-reputation-score-design.md
@@ -1,0 +1,265 @@
+# Reputation Score + Progressive Trust — Design Spec (Sub-project 1 of 3)
+
+**Date:** 2026-04-11
+**Status:** Approved
+**Scope:** Sub-project 1 — Reputation Score Foundation
+**Parent:** Anti-fraud system improvement for LiteAuction Telegram bot
+
+## Problem
+
+Current anti-fraud system has 14 identified vulnerabilities. Three are critical: (H) fraud detection doesn't block bids, (C) no seller shill detection, (A) no cross-auction collusion tracking. The system uses binary heuristics with no user-level trust model — a brand new account has the same privileges as a verified seller with 50 completed deals.
+
+## Decision: Reputation Score + Progressive Trust (Approach C)
+
+Build a reputation system where every user has a score (0-100) and trust tier. Trust level determines what actions are available. This sub-project establishes the foundation — model, calculator, publish gate integration, and event log.
+
+**Sub-project decomposition:**
+1. **This spec:** Reputation Score Foundation — model, calculator, publish gate, UI
+2. **Next spec:** Progressive Trust + Pre-bid Block — tier-based restrictions, bid blocking, auto-freeze
+3. **Future spec:** Advanced Heuristics — seller shill, cross-auction collusion, reputation decay
+
+---
+
+## Section 1: Data Model
+
+### New table: `user_reputations`
+
+```sql
+CREATE TABLE user_reputations (
+    id              BIGSERIAL PRIMARY KEY,
+    user_id         BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    score           INTEGER NOT NULL DEFAULT 0 CHECK (score >= 0 AND score <= 100),
+    tier            VARCHAR(16) NOT NULL DEFAULT 'NEW',
+    last_event_at   TIMESTAMP WITH TIME ZONE,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_user_reputations_user_id UNIQUE (user_id)
+);
+```
+
+### New table: `user_reputation_events`
+
+```sql
+CREATE TABLE user_reputation_events (
+    id              BIGSERIAL PRIMARY KEY,
+    user_id         BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    delta           INTEGER NOT NULL,
+    reason          VARCHAR(32) NOT NULL,
+    source_id       BIGINT,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX ix_reputation_events_user_created
+    ON user_reputation_events (user_id, created_at DESC);
+```
+
+### Trust tiers
+
+| Tier | Score range | Meaning |
+|---|---|---|
+| NEW | 0-20 | New/untrusted user |
+| BRONZE | 21-40 | Limited access |
+| SILVER | 41-60 | Standard user |
+| GOLD | 61-80 | Reliable seller |
+| PLATINUM | 81-100 | Verified participant |
+
+Tier is derived from score — not stored independently. Updated on every score change.
+
+---
+
+## Section 2: Initial Score Calculation
+
+Calculated once when `UserReputation` record is first created (lazy — on first interaction requiring reputation).
+
+**Base score: 10** (new account < 24h) or **25** (account > 24h)
+
+**Adjustments (applied once at creation):**
+
+| Factor | Delta | Max | Source |
+|---|---|---|---|
+| Completed auctions as seller | +5 each | +30 | `auctions` where seller_user_id and status=CLOSED |
+| Won auctions as buyer | +3 each | +30 | `bids` where user is winner |
+| Complaints against user | -10 each | -30 | `complaints` count targeting user |
+| Confirmed fraud signals | -20 each | -40 | `fraud_signals` where status=CONFIRMED |
+| Verified user | +15 | +15 | `verified_users` table |
+| Has assigned guarantor | +10 | +10 | `guarantor_requests` where status=ASSIGNED |
+
+Final score clamped to [0, 100].
+
+---
+
+## Section 3: Reputation Events
+
+### Positive events
+
+| Event | Delta | Trigger |
+|---|---|---|
+| `auction_completed` | +3 | Auction closes with seller's status=ACTIVE, no fraud signals |
+| `bid_won` | +2 | Auction finalizes with user as winner |
+| `guarantor_assigned` | +10 | Moderator assigns guarantor request |
+| `user_verified` | +15 | User passes verification |
+| `mod_adjust` | +N | Manual moderator correction |
+
+### Negative events
+
+| Event | Delta | Trigger |
+|---|---|---|
+| `complaint_filed` | -8 | New complaint targeting user |
+| `fraud_signal` | -15 | New fraud signal (OPEN) created |
+| `fraud_confirmed` | -10 | Fraud signal status → CONFIRMED by moderator |
+| `bid_removed` | -5 | Moderator removes user's bid |
+| `temp_ban` | -20 | User receives temporary ban |
+| `perm_ban` | score = 0 | User receives permanent ban (full reset) |
+| `mod_adjust` | -N | Manual moderator correction |
+| `decay` | -2 | 30+ days of inactivity (per 30-day period) |
+
+### Protections
+
+- Max negative delta per 24h: **-40** (except `perm_ban`)
+- Max positive delta per 24h: **+15**
+- Score clamped to **[0, 100]**
+- Decay floor: **10** (previously active users don't decay below 10)
+
+### Decay
+
+- Triggered by auction_watcher once per day (batch process)
+- Users with `last_event_at` older than 30 days: score -= 2 per 30-day gap
+- Decay stops at score=10
+- Each decay creates a `user_reputation_events` record with reason=`decay`
+
+---
+
+## Section 4: Publish Gate Integration
+
+### New logic (replaces `evaluate_seller_publish_gate`)
+
+```
+PLATINUM / GOLD / SILVER  → publish allowed
+BRONZE                    → publish allowed only with assigned guarantor
+NEW                       → publish blocked (need guarantor + 1 completed deal)
+```
+
+**Blocking message:**
+```
+Публикация ограничена. Ваш уровень: {tier} (score: {score}).
+{reason_specific_advice}
+Повысить уровень: завершите сделки без жалоб.
+```
+
+Where `reason_specific_advice`:
+- BRONZE without guarantor: "Для публикации нужен назначенный гарант → /guarant"
+- NEW: "Для публикации нужен гарант и хотя бы 1 завершённая сделка (проданный или выигранный аукцион)."
+
+### Implementation
+
+Modify `publish_gate_service.py`:
+1. Load `UserReputation` for seller
+2. If reputation doesn't exist yet, call `recalculate_user_reputation()` to create it
+3. Apply tier-based rules above
+4. Keep existing guarantor check as BRONZE requirement
+
+**Fallback:** If `UserReputation` record doesn't exist and recalculation fails, use existing `evaluate_user_risk_snapshot` as safety net.
+
+---
+
+## Section 5: API — `reputation_service.py`
+
+### Functions
+
+```python
+async def get_or_create_reputation(session, user_id: int) -> UserReputation
+    # Lazy creation with initial score calculation
+
+async def recalculate_user_reputation(session, user_id: int) -> UserReputation
+    # Full recalculation from historical data
+
+async def adjust_reputation(session, user_id: int, delta: int, reason: str, source_id: int | None = None) -> UserReputation
+    # Apply delta with 24h cap enforcement, update tier
+
+async def get_user_tier(session, user_id: int) -> str
+    # Returns tier string
+
+async def get_reputation_history(session, user_id: int, limit: int = 20) -> list[UserReputationEvent]
+    # Recent events for mod display
+
+async def run_reputation_decay(session) -> int
+    # Batch decay process, returns count of affected users
+```
+
+### Integration points (add calls in existing services)
+
+| File | Location | Call |
+|---|---|---|
+| `complaint_service.py` | After complaint creation | `adjust_reputation(session, target_user_id, -8, "complaint_filed", complaint.id)` |
+| `fraud_service.py` | After signal creation (score >= threshold) | `adjust_reputation(session, user_id, -15, "fraud_signal", signal.id)` |
+| `moderation_service.py` | On signal CONFIRMED | `adjust_reputation(session, user_id, -10, "fraud_confirmed", signal.id)` |
+| `moderation_service.py` | On bid removal | `adjust_reputation(session, user_id, -5, "bid_removed", bid.id)` |
+| `moderation_service.py` | On temp ban | `adjust_reputation(session, user_id, -20, "temp_ban")` |
+| `moderation_service.py` | On perm ban | `adjust_reputation(session, user_id, -score, "perm_ban")` |
+| `auction_service.py` | On auction close (seller) | `adjust_reputation(session, seller_user_id, +3, "auction_completed", auction.id)` |
+| `auction_service.py` | On auction close (winner) | `adjust_reputation(session, winner_user_id, +2, "bid_won", auction.id)` |
+| `guarantor_service.py` | On guarantor assigned | `adjust_reputation(session, submitter_user_id, +10, "guarantor_assigned", request.id)` |
+| `verification_service.py` | On user verified | `adjust_reputation(session, user_id, +15, "user_verified")` |
+
+---
+
+## Section 6: Moderation UI
+
+### New command: `/reputation <user_id_or_username>`
+
+Shows:
+- Current tier and score
+- Score history (last 10 events)
+- Active restrictions
+- Recommendations
+
+### New mod action: `/modrepadjust <user_id> <delta> <reason>`
+
+Manual reputation adjustment by moderator. Requires `trust:manage` scope.
+
+### Modpanel addition
+
+New "Репутация" section listing NEW and BRONZE tier users (paginated).
+
+---
+
+## Section 7: User Notifications
+
+On tier change (upgrade or downgrade), send message to user's private topic:
+
+**Upgrade:**
+```
+🎉 Ваш уровень повышен: {old_tier} → {new_tier} (score: {score})
+```
+
+**Downgrade:**
+```
+⚠️ Ваш уровень понижен: {old_tier} → {new_tier} (score: {score})
+Причина: {reason_label}
+```
+
+Sent via existing `send_user_topic_message` with `purpose=NOTIFICATIONS`.
+
+---
+
+## Section 8: Scope — What This Sub-project Does NOT Include
+
+- Bid blocking based on reputation (Sub-project 2)
+- Auto-freeze auctions on high fraud score (Sub-project 2)
+- Tier-based bid/lot limits (Sub-project 2)
+- Seller shill detection heuristic (Sub-project 3)
+- Cross-auction collusion detection (Sub-project 3)
+- IP/device fingerprinting (out of scope for Telegram)
+- Existing fraud heuristics remain unchanged
+
+---
+
+## Success Criteria
+
+1. `user_reputations` and `user_reputation_events` tables created via Alembic migration
+2. Existing users have reputation calculated (backfill script)
+3. New events (complaint, fraud, ban, auction complete, etc.) automatically adjust reputation
+4. Publish gate uses tier-based rules instead of old risk_eval
+5. Moderators can view and adjust reputation
+6. Users receive notifications on tier changes
+7. Daily decay process runs via auction_watcher

--- a/docs/superpowers/specs/2026-04-11-v1.2-queue-trust-signals-gap-fill-design.md
+++ b/docs/superpowers/specs/2026-04-11-v1.2-queue-trust-signals-gap-fill-design.md
@@ -1,0 +1,156 @@
+# v1.2 Queue Trust Signals — Gap-fill Design
+
+**Date:** 2026-04-11
+**Milestone:** v1.2 Queue Trust Signals
+**Approach:** Gap-fill — extend existing infrastructure to complete v1.2 requirements
+
+## Context
+
+Significant v1.2 infrastructure already ships:
+
+| Component | Location | Status |
+|---|---|---|
+| `decide_queue_sla_health()` | `app/services/queue_sla_health_service.py` | Complete — 4 contexts, thresholds, aging buckets |
+| `build_auction_timeline_page()` | `app/services/timeline_service.py` | Complete — paginated timeline |
+| `_build_rationale_artifact()` | `app/web/main.py:362` | Complete — immutable rationale |
+| `_render_appeal_detail_section()` | `app/web/main.py:420` | Complete — evidence timeline for appeals |
+| Telemetry recording + trend deltas | `app/services/admin_queue_preset_telemetry_service.py` | Complete — week-over-week with sample guardrails |
+| `_render_workflow_preset_telemetry_panel()` | `app/web/main.py:1201` | Complete — UI panel |
+| SLA/aging filter chips for appeals | `app/web/main.py:244-255` | Complete |
+| CSRF + RBAC infrastructure | `app/web/main.py:754-828` | Complete |
+
+The gap: these features are wired into the **appeals** queue page but not into **complaints** or **signals** dense lists. Additionally, tests for SLA derivation on non-appeal queues and evidence timeline rendering are incomplete.
+
+## Design
+
+### Section 1: SLA Health for Complaints and Signals
+
+**Requirement coverage:** SLA-01, SLA-02
+
+**Changes:**
+
+1. **Complaints dense list (`/complaints`)**:
+   - Add `sla` and `deadline` columns to `_QUEUE_ALLOWED_COLUMNS["complaints"]`
+   - For each complaint row, compute `decide_queue_sla_health(queue_context="moderation", status=..., created_at=..., deadline_at=...)`
+   - Deadline derivation: `created_at + SLA_THRESHOLDS_BY_CONTEXT["moderation"].warning_window` (soft SLA deadline since complaints lack an explicit `sla_deadline_at` column)
+   - Add SLA health filter chips: `all`, `healthy`, `warning`, `critical`, `overdue`, `no_sla`
+   - Add aging bucket filter chips: `all`, `fresh`, `aging`, `stale`, `critical`, `unknown`
+   - Filters must preserve current sort, filter, and focus context (per SLA-02)
+
+2. **Signals dense list (`/signals`)**:
+   - Add `sla` column to `_QUEUE_ALLOWED_COLUMNS["signals"]`
+   - Compute `decide_queue_sla_health(queue_context="risk", status=..., created_at=..., deadline_at=...)`
+   - Deadline derivation: `created_at + SLA_THRESHOLDS_BY_CONTEXT["risk"].warning_window`
+   - Same SLA health and aging bucket filter chips as complaints
+   - Same filter context preservation guarantee
+
+3. **Visual rendering**:
+   - Reuse existing `_appeal_sla_state_label` pattern (adapt for generic SLA state)
+   - Color-coded KPI styling: healthy=ok, warning=warn, critical/overdue=critical
+
+### Section 2: Evidence Timeline for Complaints and Signals
+
+**Requirement coverage:** EVID-01, EVID-02, SAFE-12
+
+**Changes:**
+
+1. **Complaints inline detail section**:
+   - Add `data-triage-detail` attribute support to complaints dense list rows
+   - Render inline detail with three sub-sections (matching appeals pattern):
+     - **primary:** Evidence timeline showing complaint creation, moderation actions, resolution events
+     - **secondary:** Source evidence (auction context, bidder info, rationale artifacts from moderation logs)
+     - **audit:** Immutable audit trail with actor, timestamp, action
+   - Timeline events sourced from: `Complaint` fields + `ModerationLog` entries for the complaint's auction
+   - Rationale artifacts extracted from `ModerationLog.payload["rationale_artifact"]` (existing format)
+
+2. **Signals inline detail section**:
+   - Same `data-triage-detail` pattern as complaints
+   - Timeline events: signal creation, risk score, resolution
+   - Source evidence: linked auction, complaint context if applicable
+   - Rationale artifacts from moderation logs
+
+3. **Immutability (SAFE-12)**:
+   - Rationale artifacts already marked `immutable: True` via `_build_rationale_artifact`
+   - Evidence timeline records derived from append-only `ModerationLog` entries
+   - No new write paths — only read-side rendering
+
+### Section 3: Telemetry Coverage and Tests
+
+**Requirement coverage:** TRND-01, TRND-02, SAFE-11, TEST-21, TEST-22
+
+**Changes:**
+
+1. **Telemetry recording coverage**:
+   - Verify `record_workflow_preset_telemetry_event` is called on preset actions for complaints and signals queue pages
+   - If gaps exist, add telemetry recording calls matching the appeals pattern
+
+2. **Telemetry panel visibility**:
+   - Verify `_render_workflow_preset_telemetry_panel` is rendered on all 4 queue context pages
+   - If gaps exist, add panel rendering to complaints and signals pages
+
+3. **Unit tests (TEST-21)** — `tests/test_sla_complaints_signals.py`:
+   - `test_sla_healthy_complaint`: fresh complaint within SLA budget → `healthy`
+   - `test_sla_warning_complaint`: complaint approaching deadline → `warning`
+   - `test_sla_critical_complaint`: complaint in critical window → `critical`
+   - `test_sla_overdue_complaint`: complaint past deadline → `overdue`
+   - `test_sla_closed_complaint`: resolved complaint → `closed`
+   - `test_sla_no_deadline_complaint`: complaint without deadline → `no_sla`
+   - `test_aging_bucket_fresh_signal`: signal under fresh threshold → `fresh`
+   - `test_aging_bucket_stale_signal`: signal in stale range → `stale`
+   - `test_aging_bucket_critical_signal`: signal past stale max → `critical`
+   - `test_queue_filter_continuity`: SLA filter applied while sort and other filters remain unchanged
+   - `test_unknown_queue_context_fallback`: unknown context falls back to moderation defaults
+
+4. **Integration tests (TEST-22)** — `tests/integration/test_evidence_timeline_and_telemetry.py`:
+   - `test_complaint_evidence_timeline_rendering`: create complaint + moderation logs, verify timeline HTML contains expected events
+   - `test_signal_evidence_timeline_rendering`: create fraud signal + resolution, verify timeline events
+   - `test_telemetry_trend_aggregation`: record telemetry events across two windows, verify trend deltas computed correctly
+   - `test_telemetry_low_sample_guardrail`: verify guardrail applied when sample below threshold
+   - `test_rationale_artifact_immutability`: verify rationale artifacts in moderation log payload are not mutable after write
+
+5. **RBAC/CSRF (SAFE-11)**:
+   - All new endpoints reuse existing `_require_or_redirect`, `_csrf_hidden_input`, `_validate_csrf_token`
+   - No new auth surfaces — all rendering happens behind existing auth middleware
+   - Test: verify unauthenticated access to new detail sections returns redirect
+
+## Requirements Traceability
+
+| Requirement | Design Section | Status |
+|---|---|---|
+| SLA-01 | Section 1 (SLA columns for complaints/signals) | Designed |
+| SLA-02 | Section 1 (filter chips + context preservation) | Designed |
+| EVID-01 | Section 2 (inline evidence timeline) | Designed |
+| EVID-02 | Section 2 (rationale artifacts from mod logs) | Designed |
+| TRND-01 | Section 3 (telemetry panel coverage) | Designed |
+| TRND-02 | Section 3 (sample guardrails already in service) | Designed |
+| SAFE-11 | Section 3 (RBAC/CSRF reuse) | Designed |
+| SAFE-12 | Section 2 (immutable artifacts) | Designed |
+| TEST-21 | Section 3 (unit tests for SLA + aging + filters) | Designed |
+| TEST-22 | Section 3 (integration tests for timeline + telemetry) | Designed |
+
+## Scope Boundaries
+
+| In scope | Out of scope |
+|---|---|
+| SLA columns for complaints and signals dense lists | New database tables or Alembic migrations |
+| Inline evidence timeline for complaints and signals | Autonomous moderation from SLA signals |
+| Telemetry panel coverage verification | Cross-product analytics warehouse |
+| Unit + integration tests | Non-Telegram operator channels |
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `app/web/main.py` | Add SLA columns, filter chips, inline detail sections for complaints and signals dense lists |
+| `app/services/timeline_service.py` | Extend timeline builder for complaint and signal entity types |
+| `app/services/queue_sla_health_service.py` | No changes (already complete) |
+| `app/services/admin_queue_preset_telemetry_service.py` | No changes (already complete) |
+| `tests/test_sla_complaints_signals.py` | New file — unit tests for SLA derivation on complaints/signals |
+| `tests/integration/test_evidence_timeline_and_telemetry.py` | New file — integration tests |
+
+## Rollout Notes
+
+- No schema changes required — all data sourced from existing tables
+- No bot behavior changes — admin panel only
+- Safe to deploy without bot restart (admin service is independent)
+- Rollback: remove the new columns from allowed lists and revert template changes

--- a/scripts/backfill_reputations.py
+++ b/scripts/backfill_reputations.py
@@ -1,0 +1,36 @@
+"""One-time script to calculate reputation for all existing users."""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from sqlalchemy import select
+
+from app.db.models import User
+from app.db.session import SessionFactory
+from app.services.reputation_service import recalculate_user_reputation
+
+
+async def main() -> None:
+    async with SessionFactory() as session:
+        result = await session.execute(select(User.id))
+        user_ids = list(result.scalars().all())
+
+    print(f"Calculating reputation for {len(user_ids)} users...")
+    updated = 0
+    for user_id in user_ids:
+        async with SessionFactory() as session:
+            async with session.begin():
+                await recalculate_user_reputation(session, user_id)
+        updated += 1
+        if updated % 100 == 0:
+            print(f"  ...{updated}/{len(user_ids)}")
+
+    print(f"Done. {updated} users processed.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/integration/test_evidence_timeline_and_telemetry.py
+++ b/tests/integration/test_evidence_timeline_and_telemetry.py
@@ -6,8 +6,16 @@ from unittest.mock import MagicMock
 
 from sqlalchemy import select
 
-from app.db.models import AdminQueuePresetTelemetryEvent, Complaint, FraudSignal, ModerationLog, User
-from app.services.admin_queue_preset_telemetry_service import load_workflow_preset_telemetry_segments
+from app.db.models import (
+    AdminQueuePresetTelemetryEvent,
+    Complaint,
+    FraudSignal,
+    ModerationLog,
+    User,
+)
+from app.services.admin_queue_preset_telemetry_service import (
+    load_workflow_preset_telemetry_segments,
+)
 from app.web.main import _render_complaint_detail_section, _render_signal_detail_section
 
 
@@ -45,7 +53,16 @@ async def test_complaint_evidence_timeline_rendering(db_session):
         auction_id=None,
         action="RESOLVE_COMPLAINT",
         reason="resolved in test",
-        payload={"rationale_artifact": {"summary": "test rationale artifact", "actor_user_id": actor.id, "actor_tg_user_id": 90003, "source": "web", "recorded_at": datetime.now(UTC).isoformat(), "immutable": True}},
+        payload={
+            "rationale_artifact": {
+                "summary": "test rationale artifact",
+                "actor_user_id": actor.id,
+                "actor_tg_user_id": 90003,
+                "source": "web",
+                "recorded_at": datetime.now(UTC).isoformat(),
+                "immutable": True,
+            }
+        },
     )
     db_session.add(mod_log)
     await db_session.flush()
@@ -145,7 +162,9 @@ async def test_telemetry_trend_aggregation(db_session):
         lookback_hours=24 * 7,
     )
     assert len(segments) > 0
-    matching = [s for s in segments if s.get("preset_id") == 1 and s.get("queue_context") == "moderation"]
+    matching = [
+        s for s in segments if s.get("preset_id") == 1 and s.get("queue_context") == "moderation"
+    ]
     assert len(matching) > 0
     segment = matching[0]
     assert int(segment["events_total"]) == 6
@@ -190,7 +209,16 @@ async def test_rationale_artifact_immutability(db_session):
         auction_id=None,
         action="FREEZE_AUCTION",
         reason="test immutability",
-        payload={"rationale_artifact": {"summary": "original summary", "actor_user_id": actor.id, "actor_tg_user_id": 90061, "source": "web", "recorded_at": datetime.now(UTC).isoformat(), "immutable": True}},
+        payload={
+            "rationale_artifact": {
+                "summary": "original summary",
+                "actor_user_id": actor.id,
+                "actor_tg_user_id": 90061,
+                "source": "web",
+                "recorded_at": datetime.now(UTC).isoformat(),
+                "immutable": True,
+            }
+        },
     )
     db_session.add(log)
     await db_session.flush()

--- a/tests/integration/test_evidence_timeline_and_telemetry.py
+++ b/tests/integration/test_evidence_timeline_and_telemetry.py
@@ -8,7 +8,6 @@ from sqlalchemy import select
 
 from app.db.models import AdminQueuePresetTelemetryEvent, Complaint, FraudSignal, ModerationLog, User
 from app.services.admin_queue_preset_telemetry_service import load_workflow_preset_telemetry_segments
-from app.web.auth import AdminAuthContext
 from app.web.main import _render_complaint_detail_section, _render_signal_detail_section
 
 

--- a/tests/integration/test_evidence_timeline_and_telemetry.py
+++ b/tests/integration/test_evidence_timeline_and_telemetry.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import pytest
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+from sqlalchemy import select
+
+from app.db.models import AdminQueuePresetTelemetryEvent, Complaint, FraudSignal, ModerationLog, User
+from app.services.admin_queue_preset_telemetry_service import load_workflow_preset_telemetry_segments
+from app.web.auth import AdminAuthContext
+from app.web.main import _render_complaint_detail_section, _render_signal_detail_section
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _ensure_user(session, *, tg_user_id: int, username: str = "test_user") -> User:
+    user = await session.scalar(select(User).where(User.tg_user_id == tg_user_id))
+    if user is not None:
+        return user
+    user = User(tg_user_id=tg_user_id, username=username)
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def test_complaint_evidence_timeline_rendering(db_session):
+    reporter = await _ensure_user(db_session, tg_user_id=90001, username="reporter_tl")
+    target = await _ensure_user(db_session, tg_user_id=90002, username="target_tl")
+    actor = await _ensure_user(db_session, tg_user_id=90003, username="actor_tl")
+
+    complaint = Complaint(
+        auction_id=None,
+        reporter_user_id=reporter.id,
+        target_user_id=target.id,
+        reason="Integration test complaint",
+        status="OPEN",
+    )
+    db_session.add(complaint)
+    await db_session.flush()
+
+    mod_log = ModerationLog(
+        actor_user_id=actor.id,
+        target_user_id=target.id,
+        auction_id=None,
+        action="RESOLVE_COMPLAINT",
+        reason="resolved in test",
+        payload={"rationale_artifact": {"summary": "test rationale artifact", "actor_user_id": actor.id, "actor_tg_user_id": 90003, "source": "web", "recorded_at": datetime.now(UTC).isoformat(), "immutable": True}},
+    )
+    db_session.add(mod_log)
+    await db_session.flush()
+
+    request = MagicMock()
+    result = await _render_complaint_detail_section(
+        db_session,
+        row_id=complaint.id,
+        section="primary",
+        request=request,
+    )
+    assert result["ok"] is True
+    assert "Complaint created" in result["html"]
+
+    result_secondary = await _render_complaint_detail_section(
+        db_session,
+        row_id=complaint.id,
+        section="secondary",
+        request=request,
+    )
+    assert result_secondary["ok"] is True
+    assert "test rationale artifact" in result_secondary["html"]
+
+    result_audit = await _render_complaint_detail_section(
+        db_session,
+        row_id=complaint.id,
+        section="audit",
+        request=request,
+    )
+    assert result_audit["ok"] is True
+    assert "append_only" in result_audit["html"]
+
+
+async def test_signal_evidence_timeline_rendering(db_session):
+    signal_user = await _ensure_user(db_session, tg_user_id=90011, username="signal_user_tl")
+
+    signal = FraudSignal(
+        auction_id=None,
+        user_id=signal_user.id,
+        score=85,
+        status="OPEN",
+        reason="integration test signal",
+    )
+    db_session.add(signal)
+    await db_session.flush()
+
+    request = MagicMock()
+    result = await _render_signal_detail_section(
+        db_session,
+        row_id=signal.id,
+        section="primary",
+        request=request,
+    )
+    assert result["ok"] is True
+    assert "Fraud signal created" in result["html"]
+    assert "score=85" in result["html"]
+
+
+async def test_telemetry_trend_aggregation(db_session):
+    now = datetime.now(UTC)
+    recent_time = now - timedelta(hours=12)
+    old_time = now - timedelta(hours=10 * 24)
+
+    for i in range(6):
+        event = AdminQueuePresetTelemetryEvent(
+            queue_context="moderation",
+            queue_key="complaints",
+            preset_id=1,
+            action="select",
+            actor_subject_key="test_actor",
+            time_to_action_ms=500 + i * 100,
+            reopen_signal=False,
+            filter_churn_count=i,
+            created_at=recent_time + timedelta(minutes=i),
+        )
+        db_session.add(event)
+
+    for i in range(6):
+        event = AdminQueuePresetTelemetryEvent(
+            queue_context="moderation",
+            queue_key="complaints",
+            preset_id=1,
+            action="select",
+            actor_subject_key="test_actor",
+            time_to_action_ms=200 + i * 50,
+            reopen_signal=False,
+            filter_churn_count=i,
+            created_at=old_time + timedelta(minutes=i),
+        )
+        db_session.add(event)
+
+    await db_session.flush()
+
+    segments = await load_workflow_preset_telemetry_segments(
+        db_session,
+        queue_context="moderation",
+        lookback_hours=24 * 7,
+    )
+    assert len(segments) > 0
+    matching = [s for s in segments if s.get("preset_id") == 1 and s.get("queue_context") == "moderation"]
+    assert len(matching) > 0
+    segment = matching[0]
+    assert int(segment["events_total"]) == 6
+    assert segment["time_to_action_delta_ms"] is not None
+
+
+async def test_telemetry_low_sample_guardrail(db_session):
+    now = datetime.now(UTC)
+    recent_time = now - timedelta(hours=12)
+
+    for i in range(2):
+        event = AdminQueuePresetTelemetryEvent(
+            queue_context="risk",
+            queue_key="signals",
+            preset_id=None,
+            action="save",
+            actor_subject_key="guardrail_actor",
+            time_to_action_ms=100,
+            reopen_signal=False,
+            filter_churn_count=0,
+            created_at=recent_time + timedelta(minutes=i),
+        )
+        db_session.add(event)
+
+    await db_session.flush()
+
+    segments = await load_workflow_preset_telemetry_segments(
+        db_session,
+        queue_context="risk",
+        lookback_hours=24 * 7,
+    )
+    if segments:
+        assert segments[0].get("trend_low_sample_guardrail") is True
+
+
+async def test_rationale_artifact_immutability(db_session):
+    actor = await _ensure_user(db_session, tg_user_id=90061, username="immut_actor")
+
+    log = ModerationLog(
+        actor_user_id=actor.id,
+        target_user_id=None,
+        auction_id=None,
+        action="FREEZE_AUCTION",
+        reason="test immutability",
+        payload={"rationale_artifact": {"summary": "original summary", "actor_user_id": actor.id, "actor_tg_user_id": 90061, "source": "web", "recorded_at": datetime.now(UTC).isoformat(), "immutable": True}},
+    )
+    db_session.add(log)
+    await db_session.flush()
+
+    loaded = await db_session.scalar(select(ModerationLog).where(ModerationLog.id == log.id))
+    artifact = loaded.payload["rationale_artifact"]
+    assert artifact["immutable"] is True
+    assert artifact["summary"] == "original summary"

--- a/tests/test_bid_actions_outbid_notifications.py
+++ b/tests/test_bid_actions_outbid_notifications.py
@@ -211,4 +211,4 @@ async def test_notify_auction_finish_reports_closed_lot_to_moderation_topic(monk
     assert len(private_notifications) == 2
     assert len(moderation_notifications) == 1
     assert moderation_notifications[0]["section"] == bid_actions.ModerationTopicSection.AUCTIONS_CLOSED
-    assert "завершен выкупом" in str(moderation_notifications[0]["text"])
+    assert "завершён выкупом" in str(moderation_notifications[0]["text"]).lower() or "завершен выкупом" in str(moderation_notifications[0]["text"]).lower()

--- a/tests/test_deal_topic_service.py
+++ b/tests/test_deal_topic_service.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.deal_topic_service import (
+    find_active_deal_topic,
+    close_deal_topic,
+)
+from app.db.enums import DealTopicStatus
+
+
+@pytest.fixture
+def auction_id() -> uuid.UUID:
+    return uuid.UUID("a1b2c3d4-5678-9012-abcd-ef1234567890")
+
+
+@pytest.mark.asyncio
+async def test_find_active_deal_topic_returns_none_when_not_exists(auction_id: uuid.UUID) -> None:
+    mock_session = AsyncMock()
+    mock_session.scalar.return_value = None
+    result = await find_active_deal_topic(mock_session, auction_id=auction_id)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_find_active_deal_topic_returns_existing(auction_id: uuid.UUID) -> None:
+    mock_session = AsyncMock()
+    existing = MagicMock()
+    existing.auction_id = auction_id
+    existing.status = DealTopicStatus.ACTIVE
+    mock_session.scalar.return_value = existing
+    result = await find_active_deal_topic(mock_session, auction_id=auction_id)
+    assert result is existing
+
+
+@pytest.mark.asyncio
+async def test_close_deal_topic_updates_status(auction_id: uuid.UUID) -> None:
+    mock_session = AsyncMock()
+    deal = MagicMock()
+    deal.status = DealTopicStatus.ACTIVE
+    deal.closed_at = None
+    await close_deal_topic(mock_session, deal=deal)
+    assert deal.status == DealTopicStatus.CLOSED
+    assert deal.closed_at is not None
+    mock_session.flush.assert_called_once()

--- a/tests/test_notification_copy_rich.py
+++ b/tests/test_notification_copy_rich.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.services.notification_copy_service import (
+    seller_completion_text,
+    winner_completion_text,
+    seller_no_bids_text,
+    deal_topic_intro_text,
+    moderation_completion_text,
+    format_user_mention,
+)
+
+
+@pytest.fixture
+def auction_id() -> uuid.UUID:
+    return uuid.UUID("a1b2c3d4-5678-9012-abcd-ef1234567890")
+
+
+def test_seller_completion_text_basic(auction_id: uuid.UUID) -> None:
+    text = seller_completion_text(
+        auction_id=auction_id,
+        description="iPhone 15 Pro Max",
+        final_price=15000,
+        counterparty_mention="@winner",
+        counterparty_role="победитель",
+    )
+    assert "#a1b2c3d4" in text
+    assert "15 000" in text
+    assert "@winner" in text
+
+
+def test_seller_completion_text_buyout(auction_id: uuid.UUID) -> None:
+    text = seller_completion_text(
+        auction_id=auction_id,
+        description="iPhone",
+        final_price=20000,
+        counterparty_mention="@w",
+        counterparty_role="победитель",
+        is_buyout=True,
+    )
+    assert "выкупом" in text
+
+
+def test_winner_completion_text_basic(auction_id: uuid.UUID) -> None:
+    text = winner_completion_text(
+        auction_id=auction_id,
+        description="iPhone 15 Pro Max",
+        final_price=15000,
+        counterparty_mention="@seller",
+        counterparty_role="продавец",
+    )
+    assert "#a1b2c3d4" in text
+    assert "15 000" in text
+    assert "@seller" in text
+    assert "выиграл" in text.lower() or "выиграли" in text.lower()
+
+
+def test_seller_no_bids_text_basic(auction_id: uuid.UUID) -> None:
+    text = seller_no_bids_text(
+        auction_id=auction_id,
+        description="iPhone 15 Pro Max",
+        start_price=10000,
+    )
+    assert "#a1b2c3d4" in text
+    assert "10 000" in text
+    assert "0" in text
+
+
+def test_deal_topic_intro_text_basic(auction_id: uuid.UUID) -> None:
+    text = deal_topic_intro_text(
+        auction_id=auction_id,
+        description="iPhone 15 Pro Max",
+        final_price=15000,
+        seller_mention="@seller",
+        winner_mention="@winner",
+    )
+    assert "#a1b2c3d4" in text
+    assert "@seller" in text
+    assert "@winner" in text
+
+
+def test_moderation_completion_text_basic(auction_id: uuid.UUID) -> None:
+    text = moderation_completion_text(
+        auction_id=auction_id,
+        description="iPhone 15 Pro Max",
+        final_price=15000,
+        bid_count=7,
+        seller_mention="@seller (tg: 123)",
+        winner_mention="@winner (tg: 456)",
+        seller_reputation=42,
+        winner_reputation=15,
+        has_deal_topic=True,
+        has_guarantor=False,
+        reason="по таймеру",
+    )
+    assert "#a1b2c3d4" in text
+    assert "15 000" in text
+    assert "7" in text
+    assert "создан" in text.lower()
+    assert "не запрошен" in text.lower()
+
+
+def test_format_user_mention_with_username() -> None:
+    assert format_user_mention(username="john", first_name="John", tg_user_id=123) == "@john"
+
+
+def test_format_user_mention_without_username() -> None:
+    result = format_user_mention(username=None, first_name="John", tg_user_id=123)
+    assert "tg://user?id=123" in result
+    assert "John" in result

--- a/tests/test_post_auction_callbacks.py
+++ b/tests/test_post_auction_callbacks.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import uuid
+
+from app.bot.handlers.post_auction import parse_deal_callback
+
+
+def test_parse_deal_callback_write() -> None:
+    action, auction_id = parse_deal_callback("deal:write:a1b2c3d4-5678-9012-abcd-ef1234567890")
+    assert action == "write"
+    assert auction_id == uuid.UUID("a1b2c3d4-5678-9012-abcd-ef1234567890")
+
+
+def test_parse_deal_callback_guarant() -> None:
+    action, auction_id = parse_deal_callback("deal:guarant:a1b2c3d4-5678-9012-abcd-ef1234567890")
+    assert action == "guarant"
+    assert auction_id == uuid.UUID("a1b2c3d4-5678-9012-abcd-ef1234567890")
+
+
+def test_parse_deal_callback_feedback() -> None:
+    action, auction_id = parse_deal_callback("deal:feedback:a1b2c3d4-5678-9012-abcd-ef1234567890")
+    assert action == "feedback"
+    assert auction_id == uuid.UUID("a1b2c3d4-5678-9012-abcd-ef1234567890")
+
+
+def test_parse_deal_callback_republish() -> None:
+    action, auction_id = parse_deal_callback("deal:republish:a1b2c3d4-5678-9012-abcd-ef1234567890")
+    assert action == "republish"
+    assert auction_id == uuid.UUID("a1b2c3d4-5678-9012-abcd-ef1234567890")

--- a/tests/test_post_auction_keyboards.py
+++ b/tests/test_post_auction_keyboards.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from app.bot.keyboards.auction import (
+    deal_completion_keyboard,
+    deal_topic_keyboard,
+    moderation_completion_keyboard,
+    no_bids_keyboard,
+)
+
+
+def test_deal_completion_keyboard_seller() -> None:
+    kb = deal_completion_keyboard(
+        auction_id="a1b2c3d4",
+        post_url="https://t.me/channel/123",
+        is_seller=True,
+    )
+    buttons = kb.inline_keyboard
+    assert len(buttons) == 3
+    assert "deal:write:a1b2c3d4" == buttons[0][0].callback_data
+    assert "победителю" in buttons[0][0].text.lower()
+
+
+def test_deal_completion_keyboard_winner() -> None:
+    kb = deal_completion_keyboard(
+        auction_id="a1b2c3d4",
+        post_url="https://t.me/channel/123",
+        is_seller=False,
+    )
+    buttons = kb.inline_keyboard
+    assert len(buttons) == 3
+    assert "продавцу" in buttons[0][0].text.lower()
+
+
+def test_deal_completion_keyboard_no_post_url() -> None:
+    kb = deal_completion_keyboard(
+        auction_id="a1b2c3d4",
+        post_url=None,
+        is_seller=True,
+    )
+    buttons = kb.inline_keyboard
+    assert len(buttons) == 2
+
+
+def test_no_bids_keyboard() -> None:
+    kb = no_bids_keyboard(
+        auction_id="a1b2c3d4",
+        post_url="https://t.me/channel/123",
+    )
+    buttons = kb.inline_keyboard
+    assert len(buttons) == 2
+    assert "deal:republish:a1b2c3d4" == buttons[0][0].callback_data
+
+
+def test_no_bids_keyboard_no_post_url() -> None:
+    kb = no_bids_keyboard(
+        auction_id="a1b2c3d4",
+        post_url=None,
+    )
+    buttons = kb.inline_keyboard
+    assert len(buttons) == 1
+
+
+def test_deal_topic_keyboard() -> None:
+    kb = deal_topic_keyboard(auction_id="a1b2c3d4")
+    buttons = kb.inline_keyboard
+    assert len(buttons) == 2
+    all_callbacks = [b.callback_data for row in buttons for b in row]
+    assert "deal:guarant:a1b2c3d4" in all_callbacks
+    assert "deal:feedback:a1b2c3d4" in all_callbacks
+    assert "deal:complaint:a1b2c3d4" in all_callbacks
+
+
+def test_moderation_completion_keyboard() -> None:
+    kb = moderation_completion_keyboard(
+        auction_id="a1b2c3d4",
+        post_url="https://t.me/channel/123",
+    )
+    buttons = kb.inline_keyboard
+    assert len(buttons) == 2

--- a/tests/test_sla_complaints_signals.py
+++ b/tests/test_sla_complaints_signals.py
@@ -1,0 +1,42 @@
+from app.web.main import (
+    _parse_complaint_sla_health_filter,
+    _parse_complaint_aging_bucket_filter,
+    _parse_signal_sla_health_filter,
+    _parse_signal_aging_bucket_filter,
+)
+
+
+def test_parse_complaint_sla_health_filter_valid_values():
+    for value in ("all", "healthy", "warning", "critical", "overdue", "no_sla"):
+        assert _parse_complaint_sla_health_filter(value) == value
+
+
+def test_parse_complaint_sla_health_filter_invalid():
+    import pytest
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException):
+        _parse_complaint_sla_health_filter("invalid")
+
+
+def test_parse_complaint_aging_bucket_filter_valid_values():
+    for value in ("all", "fresh", "aging", "stale", "critical", "overdue", "unknown"):
+        assert _parse_complaint_aging_bucket_filter(value) == value
+
+
+def test_parse_complaint_aging_bucket_filter_invalid():
+    import pytest
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException):
+        _parse_complaint_aging_bucket_filter("bad_value")
+
+
+def test_parse_signal_sla_health_filter_valid_values():
+    for value in ("all", "healthy", "warning", "critical", "overdue", "no_sla"):
+        assert _parse_signal_sla_health_filter(value) == value
+
+
+def test_parse_signal_aging_bucket_filter_valid_values():
+    for value in ("all", "fresh", "aging", "stale", "critical", "overdue", "unknown"):
+        assert _parse_signal_aging_bucket_filter(value) == value

--- a/tests/test_sla_complaints_signals.py
+++ b/tests/test_sla_complaints_signals.py
@@ -54,7 +54,11 @@ def test_complaint_sla_healthy():
     thresholds = SLA_THRESHOLDS_BY_CONTEXT["moderation"]
     deadline = created + thresholds.warning_window + timedelta(hours=1)
     result = decide_queue_sla_health(
-        queue_context="moderation", status="OPEN", created_at=created, deadline_at=deadline, now=now,
+        queue_context="moderation",
+        status="OPEN",
+        created_at=created,
+        deadline_at=deadline,
+        now=now,
     )
     assert result.health_state == "healthy"
     assert result.aging_bucket == "fresh"
@@ -67,7 +71,11 @@ def test_complaint_sla_warning():
     created = now - timedelta(hours=3)
     deadline = now + thresholds.critical_window + timedelta(minutes=10)
     result = decide_queue_sla_health(
-        queue_context="moderation", status="OPEN", created_at=created, deadline_at=deadline, now=now,
+        queue_context="moderation",
+        status="OPEN",
+        created_at=created,
+        deadline_at=deadline,
+        now=now,
     )
     assert result.health_state == "warning"
     assert result.aging_bucket == "aging"
@@ -78,7 +86,11 @@ def test_complaint_sla_critical():
     created = now - timedelta(hours=5)
     deadline = now + timedelta(minutes=15)
     result = decide_queue_sla_health(
-        queue_context="moderation", status="OPEN", created_at=created, deadline_at=deadline, now=now,
+        queue_context="moderation",
+        status="OPEN",
+        created_at=created,
+        deadline_at=deadline,
+        now=now,
     )
     assert result.health_state == "critical"
     assert result.aging_bucket == "aging"
@@ -89,7 +101,11 @@ def test_complaint_sla_overdue():
     created = now - timedelta(hours=10)
     deadline = now - timedelta(hours=1)
     result = decide_queue_sla_health(
-        queue_context="moderation", status="OPEN", created_at=created, deadline_at=deadline, now=now,
+        queue_context="moderation",
+        status="OPEN",
+        created_at=created,
+        deadline_at=deadline,
+        now=now,
     )
     assert result.health_state == "overdue"
     assert result.aging_bucket == "overdue"
@@ -100,7 +116,11 @@ def test_complaint_sla_closed():
     now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
     created = now - timedelta(hours=10)
     result = decide_queue_sla_health(
-        queue_context="moderation", status="RESOLVED", created_at=created, deadline_at=None, now=now,
+        queue_context="moderation",
+        status="RESOLVED",
+        created_at=created,
+        deadline_at=None,
+        now=now,
     )
     assert result.health_state == "closed"
     assert result.aging_bucket == "closed"
@@ -110,7 +130,11 @@ def test_complaint_sla_no_deadline():
     now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
     created = now - timedelta(hours=2)
     result = decide_queue_sla_health(
-        queue_context="moderation", status="OPEN", created_at=created, deadline_at=None, now=now,
+        queue_context="moderation",
+        status="OPEN",
+        created_at=created,
+        deadline_at=None,
+        now=now,
     )
     assert result.health_state == "no_sla"
     assert result.aging_bucket == "fresh"
@@ -122,7 +146,11 @@ def test_signal_sla_healthy():
     thresholds = SLA_THRESHOLDS_BY_CONTEXT["risk"]
     deadline = created + thresholds.warning_window + timedelta(hours=1)
     result = decide_queue_sla_health(
-        queue_context="risk", status="OPEN", created_at=created, deadline_at=deadline, now=now,
+        queue_context="risk",
+        status="OPEN",
+        created_at=created,
+        deadline_at=deadline,
+        now=now,
     )
     assert result.health_state == "healthy"
     assert result.aging_bucket == "fresh"
@@ -134,7 +162,11 @@ def test_signal_aging_bucket_stale():
     thresholds = SLA_THRESHOLDS_BY_CONTEXT["risk"]
     created = now - thresholds.aging_aging_max - timedelta(minutes=1)
     result = decide_queue_sla_health(
-        queue_context="risk", status="OPEN", created_at=created, deadline_at=None, now=now,
+        queue_context="risk",
+        status="OPEN",
+        created_at=created,
+        deadline_at=None,
+        now=now,
     )
     assert result.aging_bucket == "stale"
 
@@ -144,7 +176,11 @@ def test_signal_aging_bucket_critical():
     thresholds = SLA_THRESHOLDS_BY_CONTEXT["risk"]
     created = now - thresholds.aging_stale_max - timedelta(hours=1)
     result = decide_queue_sla_health(
-        queue_context="risk", status="OPEN", created_at=created, deadline_at=None, now=now,
+        queue_context="risk",
+        status="OPEN",
+        created_at=created,
+        deadline_at=None,
+        now=now,
     )
     assert result.aging_bucket == "critical"
 
@@ -153,7 +189,11 @@ def test_unknown_queue_context_fallback():
     now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
     created = now - timedelta(hours=1)
     result = decide_queue_sla_health(
-        queue_context="nonexistent", status="OPEN", created_at=created, deadline_at=None, now=now,
+        queue_context="nonexistent",
+        status="OPEN",
+        created_at=created,
+        deadline_at=None,
+        now=now,
     )
     assert result.queue_context == "moderation"
     assert result.fallback_applied is True

--- a/tests/test_sla_complaints_signals.py
+++ b/tests/test_sla_complaints_signals.py
@@ -1,8 +1,14 @@
+from datetime import UTC, datetime, timedelta
+
+from app.services.queue_sla_health_service import (
+    SLA_THRESHOLDS_BY_CONTEXT,
+    decide_queue_sla_health,
+)
 from app.web.main import (
-    _parse_complaint_sla_health_filter,
     _parse_complaint_aging_bucket_filter,
-    _parse_signal_sla_health_filter,
+    _parse_complaint_sla_health_filter,
     _parse_signal_aging_bucket_filter,
+    _parse_signal_sla_health_filter,
 )
 
 
@@ -42,13 +48,6 @@ def test_parse_signal_aging_bucket_filter_valid_values():
         assert _parse_signal_aging_bucket_filter(value) == value
 
 
-from datetime import timedelta, UTC, datetime
-from app.services.queue_sla_health_service import (
-    SLA_THRESHOLDS_BY_CONTEXT,
-    decide_queue_sla_health,
-)
-
-
 def test_complaint_sla_healthy():
     now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
     created = now - timedelta(minutes=30)
@@ -76,7 +75,6 @@ def test_complaint_sla_warning():
 
 def test_complaint_sla_critical():
     now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
-    thresholds = SLA_THRESHOLDS_BY_CONTEXT["moderation"]
     created = now - timedelta(hours=5)
     deadline = now + timedelta(minutes=15)
     result = decide_queue_sla_health(

--- a/tests/test_sla_complaints_signals.py
+++ b/tests/test_sla_complaints_signals.py
@@ -40,3 +40,123 @@ def test_parse_signal_sla_health_filter_valid_values():
 def test_parse_signal_aging_bucket_filter_valid_values():
     for value in ("all", "fresh", "aging", "stale", "critical", "overdue", "unknown"):
         assert _parse_signal_aging_bucket_filter(value) == value
+
+
+from datetime import timedelta, UTC, datetime
+from app.services.queue_sla_health_service import (
+    SLA_THRESHOLDS_BY_CONTEXT,
+    decide_queue_sla_health,
+)
+
+
+def test_complaint_sla_healthy():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    created = now - timedelta(minutes=30)
+    thresholds = SLA_THRESHOLDS_BY_CONTEXT["moderation"]
+    deadline = created + thresholds.warning_window + timedelta(hours=1)
+    result = decide_queue_sla_health(
+        queue_context="moderation", status="OPEN", created_at=created, deadline_at=deadline, now=now,
+    )
+    assert result.health_state == "healthy"
+    assert result.aging_bucket == "fresh"
+    assert result.queue_context == "moderation"
+
+
+def test_complaint_sla_warning():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    thresholds = SLA_THRESHOLDS_BY_CONTEXT["moderation"]
+    created = now - timedelta(hours=3)
+    deadline = now + thresholds.critical_window + timedelta(minutes=10)
+    result = decide_queue_sla_health(
+        queue_context="moderation", status="OPEN", created_at=created, deadline_at=deadline, now=now,
+    )
+    assert result.health_state == "warning"
+    assert result.aging_bucket == "aging"
+
+
+def test_complaint_sla_critical():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    thresholds = SLA_THRESHOLDS_BY_CONTEXT["moderation"]
+    created = now - timedelta(hours=5)
+    deadline = now + timedelta(minutes=15)
+    result = decide_queue_sla_health(
+        queue_context="moderation", status="OPEN", created_at=created, deadline_at=deadline, now=now,
+    )
+    assert result.health_state == "critical"
+    assert result.aging_bucket == "aging"
+
+
+def test_complaint_sla_overdue():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    created = now - timedelta(hours=10)
+    deadline = now - timedelta(hours=1)
+    result = decide_queue_sla_health(
+        queue_context="moderation", status="OPEN", created_at=created, deadline_at=deadline, now=now,
+    )
+    assert result.health_state == "overdue"
+    assert result.aging_bucket == "overdue"
+    assert result.countdown_seconds == 0
+
+
+def test_complaint_sla_closed():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    created = now - timedelta(hours=10)
+    result = decide_queue_sla_health(
+        queue_context="moderation", status="RESOLVED", created_at=created, deadline_at=None, now=now,
+    )
+    assert result.health_state == "closed"
+    assert result.aging_bucket == "closed"
+
+
+def test_complaint_sla_no_deadline():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    created = now - timedelta(hours=2)
+    result = decide_queue_sla_health(
+        queue_context="moderation", status="OPEN", created_at=created, deadline_at=None, now=now,
+    )
+    assert result.health_state == "no_sla"
+    assert result.aging_bucket == "fresh"
+
+
+def test_signal_sla_healthy():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    created = now - timedelta(minutes=15)
+    thresholds = SLA_THRESHOLDS_BY_CONTEXT["risk"]
+    deadline = created + thresholds.warning_window + timedelta(hours=1)
+    result = decide_queue_sla_health(
+        queue_context="risk", status="OPEN", created_at=created, deadline_at=deadline, now=now,
+    )
+    assert result.health_state == "healthy"
+    assert result.aging_bucket == "fresh"
+    assert result.queue_context == "risk"
+
+
+def test_signal_aging_bucket_stale():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    thresholds = SLA_THRESHOLDS_BY_CONTEXT["risk"]
+    created = now - thresholds.aging_aging_max - timedelta(minutes=1)
+    result = decide_queue_sla_health(
+        queue_context="risk", status="OPEN", created_at=created, deadline_at=None, now=now,
+    )
+    assert result.aging_bucket == "stale"
+
+
+def test_signal_aging_bucket_critical():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    thresholds = SLA_THRESHOLDS_BY_CONTEXT["risk"]
+    created = now - thresholds.aging_stale_max - timedelta(hours=1)
+    result = decide_queue_sla_health(
+        queue_context="risk", status="OPEN", created_at=created, deadline_at=None, now=now,
+    )
+    assert result.aging_bucket == "critical"
+
+
+def test_unknown_queue_context_fallback():
+    now = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+    created = now - timedelta(hours=1)
+    result = decide_queue_sla_health(
+        queue_context="nonexistent", status="OPEN", created_at=created, deadline_at=None, now=now,
+    )
+    assert result.queue_context == "moderation"
+    assert result.fallback_applied is True
+    assert "unknown_queue_context" in result.fallback_notes


### PR DESCRIPTION
## Summary

- **Rich post-auction notifications**: seller/winner now receive full deal info (price, description, counterparty mention, next steps, guarantor memo) instead of terse `"Лот #xxx завершен."`
- **Deal Topic system**: new `DealTopic` model + service for mediated seller-winner communication through bot forum topics
- **Inline action buttons**: "Написать победителю/продавцу", "Запросить гаранта", "Оставить отзыв", "Опубликовать заново" (no bids case)
- **Feedback FSM**: inline rating + comment flow triggered from completion message (no more forgotten `/tradefeedback`)
- **Guarantor integration**: `GuarantorRequest` now links to `auction_id`, requestable directly from deal completion/topic
- **Bug fix**: `mod_end` now delegates to `_finalize_auction_locked`, fixing missing reputation awards (+3 seller, +2 winner)

## Scenarios covered

| # | Scenario | Recipient | Buttons |
|---|----------|-----------|---------|
| 1 | Auction completed with winner | Seller | Write, Guarantor, Feedback, Post |
| 2 | Won auction | Winner | Write, Guarantor, Feedback, Post |
| 3 | No bids | Seller | Republish, Post |
| 4 | Deal topic | Both parties | Guarantor, Feedback, Complaint |
| 5 | Moderation channel | Moderators | Post, Freeze |

## Files changed

- `app/db/enums.py` — `DealTopicStatus` enum
- `app/db/models.py` — `DealTopic` model, `GuarantorRequest.auction_id`
- `alembic/versions/d6ae79c2bdc0_...py` — migration (applied)
- `app/services/notification_copy_service.py` — 6 rich template functions
- `app/bot/keyboards/auction.py` — 4 new keyboard builders
- `app/services/deal_topic_service.py` — deal topic CRUD + message forwarding
- `app/services/auction_service.py` — rich `FinalizeResult`, `BidActionResult`
- `app/bot/handlers/post_auction.py` — callback handlers (write, feedback, guarantor, republish)
- `app/bot/handlers/bid_actions.py` — rich `_notify_auction_finish`
- `app/bot/handlers/moderation.py` — rich notifications in `mod_end`
- `app/services/moderation_service.py` — delegate to `_finalize_auction_locked`
- `app/services/guarantor_service.py` — accept `auction_id`

## Test plan

- [x] 22 new unit tests (copy, keyboards, callbacks, deal topic service)
- [x] 350 total tests pass (0 new failures)
- [x] Lint clean (only pre-existing unused import)
- [x] Alembic migration applied to running DB
- [ ] Smoke test: complete an auction in bot, verify rich notification appears
- [ ] Smoke test: click "Написать победителю", verify deal topic created
- [ ] Smoke test: click "Запросить гаранта", verify FSM + request created
- [ ] Smoke test: click "Оставить отзыв", verify FSM + feedback saved

## Spec

Design doc: `docs/superpowers/specs/2026-04-11-post-auction-ux-design.md`
